### PR TITLE
🚧 Memoize runtime calls in order not to recreate environments

### DIFF
--- a/.changeset/modern-pandas-accept.md
+++ b/.changeset/modern-pandas-accept.md
@@ -1,0 +1,5 @@
+---
+"@layerzerolabs/hardhat-utils": patch
+---
+
+Memoize create\* calls

--- a/packages/hardhat-utils/hardhat.config.ts
+++ b/packages/hardhat-utils/hardhat.config.ts
@@ -8,6 +8,7 @@ const config: HardhatUserConfig = {
     networks: {
         "ethereum-mainnet": {
             url: "https://eth.llamarpc.com",
+            saveDeployments: true,
         },
         "bsc-testnet": {
             url: "https://bsc-testnet.publicnode.com",

--- a/packages/hardhat-utils/package.json
+++ b/packages/hardhat-utils/package.json
@@ -53,6 +53,7 @@
         "hardhat-deploy": "^0.9.19"
     },
     "dependencies": {
+        "micro-memoize": "~4.1.2",
         "p-memoize": "~4.0.1",
         "zod": "^3.22.4"
     }

--- a/packages/hardhat-utils/test/runtime.test.ts
+++ b/packages/hardhat-utils/test/runtime.test.ts
@@ -20,6 +20,14 @@ describe("runtime", () => {
 
     beforeEach(() => {
         createProviderStub = sinon.stub(providersConstruction, "createProvider")
+
+        // We want to clear the memoization cache before running the test suite
+        createGetEthereumProvider.cache.keys.length = 0
+        createGetEthereumProvider.cache.values.length = 0
+        createGetNetwork.cache.keys.length = 0
+        createGetNetwork.cache.values.length = 0
+        createGetNetworkEnvironment.cache.keys.length = 0
+        createGetNetworkEnvironment.cache.values.length = 0
     })
 
     afterEach(() => {
@@ -63,6 +71,10 @@ describe("runtime", () => {
             expect(provider1).to.equal(provider2)
             expect(provider3).to.equal(provider4)
             expect(provider1).not.to.equal(provider4)
+        })
+
+        it("should cache the factory", () => {
+            expect(createGetEthereumProvider(hre)).to.eql(createGetEthereumProvider(hre))
         })
 
         describe("getSigner()", () => {
@@ -119,6 +131,7 @@ describe("runtime", () => {
                 name: "ethereum-mainnet",
                 config: hre.config.networks["ethereum-mainnet"],
                 provider,
+                saveDeployments: true,
             })
         })
 
@@ -134,6 +147,10 @@ describe("runtime", () => {
             expect(network1).to.equal(network2)
             expect(network3).to.equal(network4)
             expect(network1).not.to.equal(network4)
+        })
+
+        it("should cache the factory", () => {
+            expect(createGetNetwork(hre)).to.eql(createGetNetwork(hre))
         })
     })
 
@@ -160,6 +177,10 @@ describe("runtime", () => {
             expect(deployments).to.have.property("get")
             expect(deployments).to.have.property("getOrNull")
             expect(deployments).to.have.property("save")
+        })
+
+        it("should cache the factory", () => {
+            expect(createGetDeployments(hre)).to.eql(createGetDeployments(hre))
         })
     })
 
@@ -208,6 +229,10 @@ describe("runtime", () => {
             expect(env).to.have.property("network")
             expect(env).to.have.property("deployments")
             expect(env).to.have.property("provider")
+        })
+
+        it("should cache the factory", () => {
+            expect(createGetNetworkEnvironment(hre)).to.eql(createGetNetworkEnvironment(hre))
         })
     })
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -5144,6 +5144,11 @@ micro-ftch@^0.3.1:
   resolved "https://registry.npmjs.org/micro-ftch/-/micro-ftch-0.3.1.tgz"
   integrity sha512-/0LLxhzP0tfiR5hcQebtudP56gUurs2CLkGarnCiB/OqEyUFQ6U3paQi/tgLv0hBJYt2rnr9MNpxz4fiiugstg==
 
+micro-memoize@~4.1.2:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/micro-memoize/-/micro-memoize-4.1.2.tgz#ce719c1ba1e41592f1cd91c64c5f41dcbf135f36"
+  integrity sha512-+HzcV2H+rbSJzApgkj0NdTakkC+bnyeiUxgT6/m7mjcz1CmM22KYFKp+EVj1sWe4UYcnriJr5uqHQD/gMHLD+g==
+
 micromatch@4.0.5, micromatch@^4.0.2, micromatch@^4.0.4:
   version "4.0.5"
   resolved "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz"


### PR DESCRIPTION
### In this PR

- Memoize the return values of `create*` utilities from `hardhat-utils` so that if called with the same environment, they will reuse the existing values