### PR TITLE
🚧 Fix imports in ua-utils-evm-hardhat-test

### DIFF
--- a/packages/ua-utils-evm-hardhat-test/hardhat.config.ts
+++ b/packages/ua-utils-evm-hardhat-test/hardhat.config.ts
@@ -1,6 +1,6 @@
 import 'hardhat-deploy'
 import 'hardhat-deploy-ethers'
-import { withLayerZeroArtifacts } from '../utils-evm-hardhat/dist'
+import { withLayerZeroArtifacts } from '@layerzerolabs/utils-evm-hardhat'
 import { EndpointId } from '@layerzerolabs/lz-definitions'
 import { HardhatUserConfig } from 'hardhat/types'
 

--- a/packages/ua-utils-evm-hardhat-test/test/config.test.ts
+++ b/packages/ua-utils-evm-hardhat-test/test/config.test.ts
@@ -1,6 +1,6 @@
 import { expect } from 'chai'
 import { describe } from 'mocha'
-import { getNetworkRuntimeEnvironment } from '../../utils-evm-hardhat/dist'
+import { getNetworkRuntimeEnvironment } from '@layerzerolabs/utils-evm-hardhat'
 import { HardhatRuntimeEnvironment } from 'hardhat/types'
 
 const NETWORK_NAMES = ['vengaboys', 'britney']


### PR DESCRIPTION
### In this PR

- Fix typos in imports in `ua-utils-evm-hardhat-test` - the imports should not use paths but package names