### PR TITLE
🪚 Add DefaultOApp, an OApp placeholder to ua-utils-evm-hardhat-test

### DIFF
--- a/packages/ua-utils-evm-hardhat-test/.gitignore
+++ b/packages/ua-utils-evm-hardhat-test/.gitignore
@@ -1,2 +1,3 @@
+artifacts
 cache
 deployments

--- a/packages/ua-utils-evm-hardhat-test/README.md
+++ b/packages/ua-utils-evm-hardhat-test/README.md
@@ -29,3 +29,12 @@ and run the command from there. For that usecase the `$DOCKER_COMPOSE_RUN_TESTS_
 # To rebuild the containers before running tests from the project root
 DOCKER_COMPOSE_RUN_TESTS_ARGS=--build yarn test --filter=utils-evm-hardhat-test
 ```
+
+To monitor the container logs, you'll need to `cd` into the package directory and run:
+
+```bash
+docker compose logs -f
+```
+
+This allows you to see any logs coming from the containers, including detailed logs from the `hardhat` nodes
+.

--- a/packages/ua-utils-evm-hardhat-test/contracts/DefaultOApp.sol
+++ b/packages/ua-utils-evm-hardhat-test/contracts/DefaultOApp.sol
@@ -1,0 +1,4 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.19;
+
+contract DefaultOApp {}

--- a/packages/ua-utils-evm-hardhat-test/deploy/001_bootstrap.ts
+++ b/packages/ua-utils-evm-hardhat-test/deploy/001_bootstrap.ts
@@ -11,6 +11,7 @@ const deploy: DeployFunction = async ({ getUnnamedAccounts, deployments, network
     assert(network.config.endpointId != null, `Missing endpoint ID for network ${network.name}`)
 
     const [deployer] = await getUnnamedAccounts()
+    assert(deployer, 'Missing deployer')
 
     const endpointV2Deployment = await deployments.deploy('EndpointV2', {
         from: deployer,
@@ -23,6 +24,7 @@ const deploy: DeployFunction = async ({ getUnnamedAccounts, deployments, network
     })
 
     console.table({
+        Network: network.name,
         EndpointV2: endpointV2Deployment.address,
         UltraLightNode302: uln302Deployment.address,
     })

--- a/packages/ua-utils-evm-hardhat-test/deploy/002_oapp.ts
+++ b/packages/ua-utils-evm-hardhat-test/deploy/002_oapp.ts
@@ -1,0 +1,26 @@
+import { type DeployFunction } from 'hardhat-deploy/types'
+import assert from 'assert'
+
+/**
+ * This deploy function will deploy and configure LayerZero endpoint
+ *
+ * @param env `HardhatRuntimeEnvironment`
+ */
+const deploy: DeployFunction = async ({ getUnnamedAccounts, deployments, network }) => {
+    const [deployer] = await getUnnamedAccounts()
+    assert(deployer, 'Missing deployer')
+
+    const defaultOAppDeployment = await deployments.deploy('DefaultOApp', {
+        from: deployer,
+    })
+
+    console.table({
+        Network: network.name,
+        DefaultOApp: defaultOAppDeployment.address,
+    })
+}
+
+deploy.tags = ['OApp', 'DefaultOApp']
+deploy.dependencies = ['Bootstrap']
+
+export default deploy

--- a/packages/ua-utils-evm-hardhat-test/hardhat.config.ts
+++ b/packages/ua-utils-evm-hardhat-test/hardhat.config.ts
@@ -11,6 +11,9 @@ const MNEMONIC = 'test test test test test test test test test test test test'
  * hardhat functionality without mocking too much
  */
 const config: HardhatUserConfig = {
+    solidity: {
+        version: '0.8.19',
+    },
     networks: {
         hardhat: {
             accounts: {

--- a/packages/ua-utils-evm-hardhat-test/package.json
+++ b/packages/ua-utils-evm-hardhat-test/package.json
@@ -25,6 +25,7 @@
     "@layerzerolabs/lz-definitions": "~1.5.62",
     "@layerzerolabs/lz-evm-sdk-v1": "~1.5.62",
     "@layerzerolabs/lz-evm-sdk-v2": "~1.5.62",
+    "@layerzerolabs/ua-utils-evm-hardhat": "~0.0.1",
     "@layerzerolabs/utils-evm-hardhat": "~0.0.1",
     "@nomiclabs/hardhat-ethers": "^2.2.3",
     "@types/chai-as-promised": "^7.1.7",


### PR DESCRIPTION
### In this PR

- Add empty `DefaultOApp` contract to `@layerzerolabs/ua-utils-evm-hardhat`
- Add solidity version configuration
- Add a small docs piece about monitoring `docker compose` logs
- Add network name to deploy script logs