### PR TITLE
🪚 Add type-extensions export to utils-evm-hardhat

### DIFF
--- a/packages/utils-evm-hardhat/package.json
+++ b/packages/utils-evm-hardhat/package.json
@@ -10,9 +10,16 @@
   },
   "license": "MIT",
   "exports": {
-    "types": "./dist/index.d.ts",
-    "require": "./dist/index.js",
-    "import": "./dist/index.mjs"
+    ".": {
+      "types": "./dist/index.d.ts",
+      "require": "./dist/index.js",
+      "import": "./dist/index.mjs"
+    },
+    "./*": {
+      "types": "./dist/*.d.ts",
+      "require": "./dist/*.js",
+      "import": "./dist/*.mjs"
+    }
   },
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/utils-evm-hardhat/src/type-extensions.ts
+++ b/packages/utils-evm-hardhat/src/type-extensions.ts
@@ -1,3 +1,4 @@
+import 'hardhat/types/config'
 import { EndpointId } from '@layerzerolabs/lz-definitions'
 
 declare module 'hardhat/types/config' {

--- a/packages/utils-evm-hardhat/tsup.config.ts
+++ b/packages/utils-evm-hardhat/tsup.config.ts
@@ -1,12 +1,24 @@
 import { defineConfig } from 'tsup'
 
-export default defineConfig({
-    entry: ['src/index.ts'],
-    outDir: './dist',
-    clean: true,
-    dts: true,
-    sourcemap: true,
-    splitting: false,
-    treeshake: true,
-    format: ['esm', 'cjs'],
-})
+export default defineConfig([
+    {
+        entry: ['src/index.ts'],
+        outDir: './dist',
+        clean: true,
+        dts: true,
+        sourcemap: true,
+        splitting: false,
+        treeshake: true,
+        format: ['esm', 'cjs'],
+    },
+    {
+        entry: ['src/type-extensions.ts'],
+        outDir: './dist',
+        clean: true,
+        dts: true,
+        sourcemap: true,
+        splitting: false,
+        treeshake: true,
+        format: ['esm', 'cjs'],
+    },
+])


### PR DESCRIPTION
### In this PR

- In order to be able to import the type definitions independently of the logic, we add another build target to utils-evm-hardhat