### PR TITLE
🚧 Fix type-extensions missing in files

### DIFF
--- a/packages/utils-evm-hardhat/package.json
+++ b/packages/utils-evm-hardhat/package.json
@@ -25,7 +25,8 @@
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
   "files": [
-    "./dist/index.*"
+    "./dist/index.*",
+    "./dist/type-extensions.*"
   ],
   "scripts": {
     "prebuild": "npx tsc --noEmit -p tsconfig.build.json",


### PR DESCRIPTION
### In this PR

- `type-extensions.*` were missing in `files` field in `package.json` in `utils-evm-hardhat`