### PR TITLE
🪚 OmniGraph™ renaming endpointId to eid

### DIFF
--- a/packages/ua-utils-evm-hardhat-test/deploy/001_bootstrap.ts
+++ b/packages/ua-utils-evm-hardhat-test/deploy/001_bootstrap.ts
@@ -8,14 +8,14 @@ import assert from 'assert'
  * @param env `HardhatRuntimeEnvironment`
  */
 const deploy: DeployFunction = async ({ getUnnamedAccounts, deployments, network }) => {
-    assert(network.config.endpointId != null, `Missing endpoint ID for network ${network.name}`)
+    assert(network.config.eid != null, `Missing endpoint ID for network ${network.name}`)
 
     const [deployer] = await getUnnamedAccounts()
     assert(deployer, 'Missing deployer')
 
     const endpointV2Deployment = await deployments.deploy('EndpointV2', {
         from: deployer,
-        args: [network.config.endpointId, AddressZero],
+        args: [network.config.eid, AddressZero],
     })
 
     const uln302Deployment = await deployments.deploy('UltraLightNode302', {

--- a/packages/ua-utils-evm-hardhat-test/hardhat.config.ts
+++ b/packages/ua-utils-evm-hardhat-test/hardhat.config.ts
@@ -21,14 +21,14 @@ const config: HardhatUserConfig = {
             },
         },
         vengaboys: {
-            endpointId: EndpointId.ETHEREUM_MAINNET,
+            eid: EndpointId.ETHEREUM_MAINNET,
             url: 'http://network-vengaboys:8545',
             accounts: {
                 mnemonic: MNEMONIC,
             },
         },
         britney: {
-            endpointId: EndpointId.AVALANCHE_MAINNET,
+            eid: EndpointId.AVALANCHE_MAINNET,
             url: 'http://network-britney:8545',
             accounts: {
                 mnemonic: MNEMONIC,

--- a/packages/ua-utils-evm-hardhat-test/test/config.test.ts
+++ b/packages/ua-utils-evm-hardhat-test/test/config.test.ts
@@ -16,10 +16,10 @@ describe('config', () => {
 
             it('should have an endpoint deployed', async () => {
                 const endpoint = await environment.ethers.getContract('EndpointV2')
-                const endpointId = await endpoint.eid()
+                const eid = await endpoint.eid()
 
-                expect(environment.network.config.endpointId).to.be.a('number')
-                expect(endpointId).to.eql(environment.network.config.endpointId)
+                expect(environment.network.config.eid).to.be.a('number')
+                expect(eid).to.eql(environment.network.config.eid)
             })
         })
     })

--- a/packages/ua-utils-evm-hardhat/hardhat.config.ts
+++ b/packages/ua-utils-evm-hardhat/hardhat.config.ts
@@ -9,7 +9,7 @@ import { HardhatUserConfig } from 'hardhat/types'
 const config: HardhatUserConfig = {
     networks: {
         withEndpointId: {
-            endpointId: EndpointId.ETHEREUM_MAINNET,
+            eid: EndpointId.ETHEREUM_MAINNET,
             url: 'no:///way',
             saveDeployments: false,
         },

--- a/packages/utils-evm-hardhat/hardhat.config.ts
+++ b/packages/utils-evm-hardhat/hardhat.config.ts
@@ -11,11 +11,11 @@ const config: HardhatUserConfig = {
         'ethereum-mainnet': {
             url: 'https://eth.llamarpc.com',
             saveDeployments: true,
-            endpointId: EndpointId.ETHEREUM_MAINNET,
+            eid: EndpointId.ETHEREUM_MAINNET,
         },
         'ethereum-testnet': {
             url: 'https://eth-goerli.public.blastapi.io',
-            endpointId: EndpointId.ETHEREUM_TESTNET,
+            eid: EndpointId.ETHEREUM_TESTNET,
         },
         'bsc-testnet': {
             url: 'https://bsc-testnet.publicnode.com',

--- a/packages/utils-evm-hardhat/src/config.ts
+++ b/packages/utils-evm-hardhat/src/config.ts
@@ -29,10 +29,10 @@ const resolvePackageDirectory = (packageName: string): string => {
  * const config: HardhatUserConfig = {
  *   networks: {
  *     arbitrum: {
- *       endpointId: EndpointId.ARBITRUM_MAINNET
+ *       eid: EndpointId.ARBITRUM_MAINNET
  *     },
  *     fuji: {
- *       endpointId: EndpointId.AVALANCHE_TESTNET
+ *       eid: EndpointId.AVALANCHE_TESTNET
  *     }
  *   }
  * }
@@ -61,11 +61,11 @@ export const withLayerZeroDeployments = (...packageNames: string[]) => {
             // Now for the meat of the operation, we'll enrich the external.deployments object
             deployments: Object.fromEntries(
                 Object.entries(config.networks ?? {}).flatMap(([networkName, networkConfig]) => {
-                    const endpointId = networkConfig?.endpointId
+                    const eid = networkConfig?.eid
                     const networkLogger = createNetworkLogger(networkName)
 
-                    // Let's first check whether endpointId is defined on the network config
-                    if (endpointId == null) {
+                    // Let's first check whether eid is defined on the network config
+                    if (eid == null) {
                         networkLogger.debug(
                             'Endpoint ID not specified in hardhat config, skipping external deployment configuration'
                         )
@@ -75,7 +75,7 @@ export const withLayerZeroDeployments = (...packageNames: string[]) => {
 
                     try {
                         // This operation is unsafe and can throw - let's make sure we don't explode with some unreadable error
-                        const layerZeroNetworkName = endpointIdToNetwork(endpointId)
+                        const layerZeroNetworkName = endpointIdToNetwork(eid)
                         const layerZeroNetworkDeploymentsDirectories = resolvedDeploymentsDirectories.map(
                             (deploymentsDirectory) => join(deploymentsDirectory, layerZeroNetworkName)
                         )
@@ -99,7 +99,7 @@ export const withLayerZeroDeployments = (...packageNames: string[]) => {
                         ]
                     } catch (error) {
                         networkLogger.error(
-                            `Invalid endpoint ID specified in hardhat config (${endpointId}), skipping external deployment configuration`
+                            `Invalid endpoint ID specified in hardhat config (${eid}), skipping external deployment configuration`
                         )
 
                         return []
@@ -121,10 +121,10 @@ export const withLayerZeroDeployments = (...packageNames: string[]) => {
  * const config: HardhatUserConfig = {
  *   networks: {
  *     arbitrum: {
- *       endpointId: EndpointId.ARBITRUM_MAINNET
+ *       eid: EndpointId.ARBITRUM_MAINNET
  *     },
  *     fuji: {
- *       endpointId: EndpointId.AVALANCHE_TESTNET
+ *       eid: EndpointId.AVALANCHE_TESTNET
  *     }
  *   }
  * }

--- a/packages/utils-evm-hardhat/src/runtime.ts
+++ b/packages/utils-evm-hardhat/src/runtime.ts
@@ -119,7 +119,7 @@ export const createNetworkEnvironmentFactory = (
  * Creates a mapping between EndpointId and network name
  * based on the hardhat project configuration.
  *
- * It will silently ignore networks that don't have `endpointId`
+ * It will silently ignore networks that don't have `eid`
  * specified in their network configuration.
  *
  * @param hre `HardhatRuntimeEnvironment`
@@ -132,9 +132,9 @@ export const getNetworkNamesByEid = (
 
     return new Map(
         networks.flatMap(([networkName, networkConfig]) => {
-            if (networkConfig.endpointId == null) return []
+            if (networkConfig.eid == null) return []
 
-            return [[networkConfig.endpointId, networkName]]
+            return [[networkConfig.eid, networkName]]
         })
     )
 }

--- a/packages/utils-evm-hardhat/src/type-extensions.ts
+++ b/packages/utils-evm-hardhat/src/type-extensions.ts
@@ -3,18 +3,18 @@ import { EndpointId } from '@layerzerolabs/lz-definitions'
 
 declare module 'hardhat/types/config' {
     interface HardhatNetworkUserConfig {
-        endpointId?: never
+        eid?: never
     }
 
     interface HardhatNetworkConfig {
-        endpointId?: never
+        eid?: never
     }
 
     interface HttpNetworkUserConfig {
-        endpointId?: EndpointId
+        eid?: EndpointId
     }
 
     interface HttpNetworkConfig {
-        endpointId?: EndpointId
+        eid?: EndpointId
     }
 }

--- a/packages/utils-evm-hardhat/test/config.test.ts
+++ b/packages/utils-evm-hardhat/test/config.test.ts
@@ -20,7 +20,7 @@ describe('config', () => {
             })
         })
 
-        it('should not add external deployments for networks without endpointId', () => {
+        it('should not add external deployments for networks without eid', () => {
             const config = {
                 networks: {
                     'vengaboys-testnet': {},
@@ -37,11 +37,11 @@ describe('config', () => {
             })
         })
 
-        it('should not add external deployments for networks with invalid endpointId', () => {
+        it('should not add external deployments for networks with invalid eid', () => {
             const config = {
                 networks: {
                     'vengaboys-testnet': {
-                        endpointId: 0,
+                        eid: 0,
                     },
                 },
             }
@@ -49,7 +49,7 @@ describe('config', () => {
             expect(withLayerZeroDeployments('@layerzerolabs/lz-evm-sdk-v1')(config)).to.eql({
                 networks: {
                     'vengaboys-testnet': {
-                        endpointId: 0,
+                        eid: 0,
                     },
                 },
                 external: {
@@ -62,7 +62,7 @@ describe('config', () => {
             const config = {
                 networks: {
                     'vengaboys-testnet': {
-                        endpointId: EndpointId.ARBITRUM_MAINNET,
+                        eid: EndpointId.ARBITRUM_MAINNET,
                     },
                 },
             }
@@ -70,7 +70,7 @@ describe('config', () => {
             expect(withLayerZeroDeployments('@layerzerolabs/lz-evm-sdk-v1')(config)).to.eql({
                 networks: {
                     'vengaboys-testnet': {
-                        endpointId: EndpointId.ARBITRUM_MAINNET,
+                        eid: EndpointId.ARBITRUM_MAINNET,
                     },
                 },
                 external: {
@@ -85,7 +85,7 @@ describe('config', () => {
             const config = {
                 networks: {
                     'vengaboys-testnet': {
-                        endpointId: EndpointId.BSC_TESTNET,
+                        eid: EndpointId.BSC_TESTNET,
                     },
                 },
             }
@@ -99,7 +99,7 @@ describe('config', () => {
             expect(configWithSomePathAgain).to.eql({
                 networks: {
                     'vengaboys-testnet': {
-                        endpointId: EndpointId.BSC_TESTNET,
+                        eid: EndpointId.BSC_TESTNET,
                     },
                 },
                 external: {


### PR DESCRIPTION
### In this PR

- We use `eid` all over so let's use it everywhere, including the user-facing config