### PR TITLE
🪚 OmniGraph™ Add flattenTransactions utility

### DIFF
--- a/packages/utils/src/transactions/index.ts
+++ b/packages/utils/src/transactions/index.ts
@@ -1,1 +1,2 @@
 export * from './types'
+export * from './utils'

--- a/packages/utils/src/transactions/utils.ts
+++ b/packages/utils/src/transactions/utils.ts
@@ -1,0 +1,7 @@
+import { OmniTransaction } from './types'
+
+const isNonNullable = <T>(value: T | null | undefined): value is T => value != null
+
+export const flattenTransactions = (
+    transations: (OmniTransaction | OmniTransaction[] | null | undefined)[]
+): OmniTransaction[] => transations.filter(isNonNullable).flat()

--- a/packages/utils/test/transactions/utils.test.ts
+++ b/packages/utils/test/transactions/utils.test.ts
@@ -1,0 +1,53 @@
+import fc from 'fast-check'
+import { pointArbitrary } from '@layerzerolabs/test-utils'
+import { OmniTransaction, flattenTransactions } from '@/transactions'
+
+describe('transactions/utils', () => {
+    const nullableArbitrary = fc.constantFrom(null, undefined)
+    const transactionArbitrary: fc.Arbitrary<OmniTransaction> = fc.record({
+        point: pointArbitrary,
+        data: fc.hexaString(),
+    })
+
+    describe('flattenTransactions', () => {
+        it('should return an empty array when called with an empty array', () => {
+            expect(flattenTransactions([])).toEqual([])
+        })
+
+        it('should return an empty array when called with an array of nulls and undefineds', () => {
+            fc.assert(
+                fc.property(fc.array(nullableArbitrary), (transactions) => {
+                    expect(flattenTransactions(transactions)).toEqual([])
+                })
+            )
+        })
+
+        it('should remove any nulls or undefineds', () => {
+            fc.assert(
+                fc.property(fc.array(fc.oneof(transactionArbitrary, nullableArbitrary)), (transactions) => {
+                    const flattened = flattenTransactions(transactions)
+
+                    for (const transaction of flattened) {
+                        expect(transaction).not.toBeNull()
+                        expect(transaction).not.toBeUndefined()
+                    }
+                })
+            )
+        })
+
+        it('should flatten any arrays', () => {
+            fc.assert(
+                fc.property(
+                    fc.array(fc.oneof(transactionArbitrary, nullableArbitrary, fc.array(transactionArbitrary))),
+                    (transactions) => {
+                        const flattened = flattenTransactions(transactions)
+
+                        for (const transaction of flattened) {
+                            expect(transaction).not.toBeInstanceOf(Array)
+                        }
+                    }
+                )
+            )
+        })
+    })
+})


### PR DESCRIPTION
### In this PR

- `flattenTransactions` utility for working with incomplete or nested lists of `OmniTransaction`s. This is useful for when SDKs need to return transactions conditionally or when they return nested lists of transactions, less repeated code in the SDK logic