### PR TITLE
🪚 OmniGraph™ Delete deployments before deploying

### DIFF
--- a/packages/ua-utils-evm-hardhat-test/deploy/001_bootstrap.ts
+++ b/packages/ua-utils-evm-hardhat-test/deploy/001_bootstrap.ts
@@ -1,6 +1,6 @@
 import { type DeployFunction } from 'hardhat-deploy/types'
-import { AddressZero } from '@ethersproject/constants'
 import assert from 'assert'
+import { formatEid } from '@layerzerolabs/utils'
 
 /**
  * This deploy function will deploy and configure LayerZero endpoint
@@ -13,23 +13,26 @@ const deploy: DeployFunction = async ({ getUnnamedAccounts, deployments, network
     const [deployer] = await getUnnamedAccounts()
     assert(deployer, 'Missing deployer')
 
+    await deployments.delete('EndpointV2')
     const endpointV2Deployment = await deployments.deploy('EndpointV2', {
         from: deployer,
         args: [network.config.eid],
     })
 
+    await deployments.delete('SendUln302')
     const sendUln302 = await deployments.deploy('SendUln302', {
         from: deployer,
         args: [endpointV2Deployment.address, 0, 0],
     })
 
+    await deployments.delete('ReceiveUln302')
     const receiveUln302 = await deployments.deploy('ReceiveUln302', {
         from: deployer,
         args: [endpointV2Deployment.address],
     })
 
     console.table({
-        Network: network.name,
+        Network: `${network.name} (endpoint ${formatEid(network.config.eid)})`,
         EndpointV2: endpointV2Deployment.address,
         SendUln302: sendUln302.address,
         ReceiveUln302: receiveUln302.address,

--- a/packages/ua-utils-evm-hardhat-test/deploy/002_oapp.ts
+++ b/packages/ua-utils-evm-hardhat-test/deploy/002_oapp.ts
@@ -1,3 +1,4 @@
+import { formatEid } from '@layerzerolabs/utils'
 import { type DeployFunction } from 'hardhat-deploy/types'
 import assert from 'assert'
 
@@ -7,15 +8,18 @@ import assert from 'assert'
  * @param env `HardhatRuntimeEnvironment`
  */
 const deploy: DeployFunction = async ({ getUnnamedAccounts, deployments, network }) => {
+    assert(network.config.eid != null, `Missing endpoint ID for network ${network.name}`)
+
     const [deployer] = await getUnnamedAccounts()
     assert(deployer, 'Missing deployer')
 
+    await deployments.delete('DefaultOApp')
     const defaultOAppDeployment = await deployments.deploy('DefaultOApp', {
         from: deployer,
     })
 
     console.table({
-        Network: network.name,
+        Network: `${network.name} (endpoint ${formatEid(network.config.eid)})`,
         DefaultOApp: defaultOAppDeployment.address,
     })
 }


### PR DESCRIPTION
### In this PR

- Splitting more small stuff from the `OApp` preconfguration - in order to be deploy the testing setup we need to wipe the previous one first