### PR TITLE
🪚 OmniGraph™ OmniPoint transformation utility

### DIFF
--- a/packages/utils-evm-hardhat/src/omnigraph/builder.ts
+++ b/packages/utils-evm-hardhat/src/omnigraph/builder.ts
@@ -1,7 +1,7 @@
-import type { OmniGraphHardhat } from './types'
+import type { OmniGraphHardhat, OmniGraphHardhatTransformer } from './types'
 import { OmniGraphBuilder } from '@layerzerolabs/utils'
 import assert from 'assert'
-import { OmniGraphHardhatTransformer, createOmniGraphHardhatTransformer } from './transformations'
+import { createOmniGraphHardhatTransformer } from './transformations'
 
 /**
  * OmniGraphBuilderHardhat houses all hardhat-specific utilities for building OmniGraphs

--- a/packages/utils-evm-hardhat/src/omnigraph/types.ts
+++ b/packages/utils-evm-hardhat/src/omnigraph/types.ts
@@ -1,4 +1,4 @@
-import type { OmniPoint, WithEid, WithOptionals } from '@layerzerolabs/utils'
+import type { OmniGraph, OmniPoint, WithEid, WithOptionals } from '@layerzerolabs/utils'
 import type { OmniContract } from '@layerzerolabs/utils-evm'
 import type { Deployment } from 'hardhat-deploy/dist/types'
 
@@ -50,3 +50,9 @@ export interface OmniGraphHardhat<TNodeConfig = unknown, TEdgeConfig = unknown> 
 }
 
 export type OmniContractFactoryHardhat = (point: OmniPointHardhat) => OmniContract | Promise<OmniContract>
+
+export type OmniPointHardhatTransformer = (point: OmniPointHardhat | OmniPoint) => Promise<OmniPoint>
+
+export type OmniGraphHardhatTransformer<TNodeConfig = unknown, TEdgeConfig = unknown> = (
+    graph: OmniGraphHardhat<TNodeConfig, TEdgeConfig>
+) => Promise<OmniGraph<TNodeConfig, TEdgeConfig>>


### PR DESCRIPTION
### In this PR

Sorry for this purely abstract piece of work in advance. This is something I originally thought was required for the next bit of work, the suddenly it wasn't but it's still a good change.

In general we have transformation utilities for:
- `OmniNodeHardhat` → `OmniNode`
- `OmniEdgeHardhat` → `OmniEdge`

These were both doing the same kind of ternary operation on the `OmniPointHardhat`. In this PR this ternary operation is isolated into a function. This simplifies tests and adds a utility for when we need it (like e.g. in the `getSendConfig` / `getReceiveConfig`)

So now we also have:
- `OmniPointHardhat` → `OmniPoint`