### PR TITLE
🪚 OmniGraph™ More flexible (a.k.a. flexibler) factory types

### DIFF
--- a/packages/protocol-utils-evm/src/endpoint/factory.ts
+++ b/packages/protocol-utils-evm/src/endpoint/factory.ts
@@ -1,5 +1,6 @@
 import pMemoize from 'p-memoize'
 import type { EndpointFactory, Uln302Factory } from '@layerzerolabs/protocol-utils'
+import type { OmniPoint } from '@layerzerolabs/utils'
 import type { OmniContractFactory } from '@layerzerolabs/utils-evm'
 import { Endpoint } from './sdk'
 import { createUln302Factory } from '@/uln302/factory'
@@ -11,7 +12,8 @@ import { createUln302Factory } from '@/uln302/factory'
  * @param {OmniContractFactory} contractFactory
  * @returns {EndpointFactory<Endpoint>}
  */
-export const createEndpointFactory = (
-    contractFactory: OmniContractFactory,
+export const createEndpointFactory = <TOmniPoint = never>(
+    contractFactory: OmniContractFactory<TOmniPoint | OmniPoint>,
     uln302Factory: Uln302Factory = createUln302Factory(contractFactory)
-): EndpointFactory<Endpoint> => pMemoize(async (point) => new Endpoint(await contractFactory(point), uln302Factory))
+): EndpointFactory<Endpoint, TOmniPoint | OmniPoint> =>
+    pMemoize(async (point) => new Endpoint(await contractFactory(point), uln302Factory))

--- a/packages/protocol-utils-evm/src/uln302/factory.ts
+++ b/packages/protocol-utils-evm/src/uln302/factory.ts
@@ -10,5 +10,6 @@ import { Uln302 } from './sdk'
  * @param {OmniContractFactory} contractFactory
  * @returns {Uln302Factory<Uln302>}
  */
-export const createUln302Factory = (contractFactory: OmniContractFactory): Uln302Factory<Uln302> =>
-    pMemoize(async (point) => new Uln302(await contractFactory(point)))
+export const createUln302Factory = <TOmniPoint = never>(
+    contractFactory: OmniContractFactory<TOmniPoint>
+): Uln302Factory<Uln302, TOmniPoint> => pMemoize(async (point) => new Uln302(await contractFactory(point)))

--- a/packages/protocol-utils/src/endpoint/types.ts
+++ b/packages/protocol-utils/src/endpoint/types.ts
@@ -1,11 +1,4 @@
-import type {
-    Address,
-    OmniGraph,
-    OmniPointBasedFactory,
-    OmniTransaction,
-    IOmniSDK,
-    Bytes32,
-} from '@layerzerolabs/utils'
+import type { Address, Factory, OmniGraph, OmniPoint, OmniTransaction, IOmniSDK, Bytes32 } from '@layerzerolabs/utils'
 import type { EndpointId } from '@layerzerolabs/lz-definitions'
 import type { IUln302 } from '@/uln302/types'
 
@@ -40,4 +33,7 @@ export interface EndpointEdgeConfig {
 
 export type EndpointOmniGraph = OmniGraph<unknown, EndpointEdgeConfig>
 
-export type EndpointFactory<TEndpoint extends IEndpoint = IEndpoint> = OmniPointBasedFactory<TEndpoint>
+export type EndpointFactory<TEndpoint extends IEndpoint = IEndpoint, TOmniPoint = OmniPoint> = Factory<
+    [TOmniPoint],
+    TEndpoint
+>

--- a/packages/protocol-utils/src/uln302/types.ts
+++ b/packages/protocol-utils/src/uln302/types.ts
@@ -1,4 +1,4 @@
-import type { Address, OmniGraph, OmniPointBasedFactory, OmniTransaction, IOmniSDK } from '@layerzerolabs/utils'
+import type { Address, OmniGraph, Factory, OmniTransaction, IOmniSDK, OmniPoint } from '@layerzerolabs/utils'
 import type { EndpointId } from '@layerzerolabs/lz-definitions'
 
 export interface IUln302 extends IOmniSDK {
@@ -27,4 +27,4 @@ export interface Uln302NodeConfig {
 
 export type Uln302OmniGraph = OmniGraph<Uln302NodeConfig, unknown>
 
-export type Uln302Factory<TUln302 extends IUln302 = IUln302> = OmniPointBasedFactory<TUln302>
+export type Uln302Factory<TUln302 extends IUln302 = IUln302, TOmniPoint = OmniPoint> = Factory<[TOmniPoint], TUln302>

--- a/packages/ua-utils/src/oapp/types.ts
+++ b/packages/ua-utils/src/oapp/types.ts
@@ -1,8 +1,6 @@
 import type { EndpointId } from '@layerzerolabs/lz-definitions'
 import type { IEndpoint } from '@layerzerolabs/protocol-utils'
-import type { Address, OmniGraph, OmniTransaction, IOmniSDK } from '@layerzerolabs/utils'
-import type { Bytes32 } from '@layerzerolabs/utils'
-import type { OmniPointBasedFactory } from '@layerzerolabs/utils'
+import type { Address, Bytes32, Factory, OmniGraph, OmniTransaction, IOmniSDK, OmniPoint } from '@layerzerolabs/utils'
 
 export interface IOApp extends IOmniSDK {
     getEndpointSDK(): Promise<IEndpoint>
@@ -13,4 +11,4 @@ export interface IOApp extends IOmniSDK {
 
 export type OAppOmniGraph = OmniGraph<unknown, unknown>
 
-export type OAppFactory<TOApp extends IOApp = IOApp> = OmniPointBasedFactory<TOApp>
+export type OAppFactory<TOApp extends IOApp = IOApp, TOmniPoint = OmniPoint> = Factory<[TOmniPoint], TOApp>

--- a/packages/utils-evm/src/omnigraph/types.ts
+++ b/packages/utils-evm/src/omnigraph/types.ts
@@ -1,11 +1,11 @@
 import type { Contract } from '@ethersproject/contracts'
-import type { IOmniSDK as IOmniSDKAbstract, OmniPoint, WithEid } from '@layerzerolabs/utils'
+import type { Factory, IOmniSDK as IOmniSDKAbstract, OmniPoint, WithEid } from '@layerzerolabs/utils'
 
 export type OmniContract<TContract extends Contract = Contract> = WithEid<{
     contract: TContract
 }>
 
-export type OmniContractFactory = (point: OmniPoint) => OmniContract | Promise<OmniContract>
+export type OmniContractFactory<TOmniPoint = OmniPoint> = Factory<[TOmniPoint], OmniContract>
 
 /**
  * Base interface for all EVM SDKs, adding the EVM specific attributes

--- a/packages/utils/src/omnigraph/types.ts
+++ b/packages/utils/src/omnigraph/types.ts
@@ -59,12 +59,6 @@ export interface OmniGraph<TNodeConfig = unknown, TEdgeConfig = unknown> {
 }
 
 /**
- * OmniPointBasedFactory is a basis for all factories that can create objects
- * based on OmniPoints - by their character these are typically contract or deployment factories
- */
-export type OmniPointBasedFactory<TValue> = (point: OmniPoint) => TValue | Promise<TValue>
-
-/**
  * Helper type that adds eid property to an underlying type
  */
 export type WithEid<TValue> = TValue & { eid: EndpointId }

--- a/packages/utils/src/types.ts
+++ b/packages/utils/src/types.ts
@@ -4,6 +4,23 @@ export type Address = string
 
 export type Bytes32 = string
 
+/**
+ * Generic type for a hybrid (sync / async) factory
+ * that generates an instance of `TOutput` based on arguments of type `TInput`
+ *
+ * `TInput` represents the list of all function arguments that need to be passed to the factory:
+ *
+ * ```typescript
+ * const mySyncFactory: Factory<[number, boolean], string> = (num: number, bool: boolean): string => "hello"
+ *
+ * const mySyncFactory: Factory<[], string> = async () => "hello"
+ * ```
+ *
+ * The hybrid aspect just makes it easier for implementers - if the logic is synchronous,
+ * this type will not force any extra `async`.
+ */
+export type Factory<TInput extends unknown[], TOutput> = (...input: TInput) => TOutput | Promise<TOutput>
+
 export type EndpointBasedFactory<TValue> = (eid: EndpointId) => TValue | Promise<TValue>
 
 /**

--- a/packages/utils/test/omnigraph/types.test.ts
+++ b/packages/utils/test/omnigraph/types.test.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { OmniEdge, OmniNode, OmniPoint, OmniVector } from '@/omnigraph'
+import { Factory } from '@/types'
 import { EndpointId } from '@layerzerolabs/lz-definitions'
 
 describe('schema/types', () => {
@@ -118,6 +119,36 @@ describe('schema/types', () => {
         it('should work with destructuring', () => {
             const edge: OmniEdge<number> = { vector, config: 6 }
             const anotherNode: OmniEdge<number> = { vector: edge.vector, config: edge.config }
+        })
+    })
+
+    describe('Factory', () => {
+        it('should not allow a factory that changes input types', () => {
+            // @ts-expect-error The input of the factory is a string, not a boolean
+            const factory: Factory<[boolean], boolean> = (a: string): boolean => !!a
+        })
+
+        it('should not allow a factory that changes output types', () => {
+            // @ts-expect-error The output of the factory is a string, not a boolean
+            const factory: Factory<[boolean], boolean> = (a: string): string => a
+        })
+
+        it('should not allow a factory that changes input types', () => {
+            // @ts-expect-error The input of the factory is a string, not a boolean
+            const factory: Factory<[boolean], boolean> = async (a: string): boolean => !!a
+        })
+
+        it('should not allow a factory that changes output types', () => {
+            // @ts-expect-error The output of the factory is a string, not a boolean
+            const factory: Factory<[boolean], boolean> = async (a: string): string => a
+        })
+
+        it('should allow a sync factory', () => {
+            const factory: Factory<[boolean], boolean> = (a: boolean) => a
+        })
+
+        it('should allow an sync factory', () => {
+            const factory: Factory<[boolean], boolean> = async (a: boolean) => a
         })
     })
 })


### PR DESCRIPTION
### In this PR

The goal of this PR is to preserve factory input types when using SDK factories. The changes are almost 100% TypeScript, with the only code changes being the changes that this improvement results in.

#### The problem

Considering:

```typescript
import { createConnectedContractFactory } from '@layerzerolabs/utils-evm-hardhat'

const contractFactory = createConnectedContractFactory();
const endpointFactory = createEndpointFactory(contractFactory);
```

We can do:

```typescript
const contract = await contractFactory({ eid: EndpointId.AVALANCHE_V2_MAINNET, contractName: "DefaultOApp" })
```

But we cannot do:

```typescript
const sdk = await endpointFactory({ eid: EndpointId.AVALANCHE_V2_MAINNET, contractName: "DefaultOApp" })
```

Because `endpointFactory` only accepts `OmniPoint`, not `OmniPointHardhat`

#### The solution

`createEndpointFactory` (and `createUln302Factory`) now allow the input type to be widened, depending on the `contractFactory` passed in. The only requirement is that the `contractFactory` will still accept `OmniPoint`.