### PR TITLE
🪚 OmniGraph™ Standalone error parser for EVM

### DIFF
--- a/packages/utils-evm/src/errors/types.ts
+++ b/packages/utils-evm/src/errors/types.ts
@@ -1,0 +1,3 @@
+import type { ContractError } from './errors'
+
+export type OmniContractErrorParser = (error: unknown) => ContractError

--- a/packages/utils-evm/src/omnigraph/sdk.ts
+++ b/packages/utils-evm/src/omnigraph/sdk.ts
@@ -1,13 +1,19 @@
 import { OmniPoint, OmniTransaction } from '@layerzerolabs/utils'
 import { IOmniSDK, OmniContract } from './types'
 import { omniContractToPoint } from './coordinates'
+import { createContractErrorParser } from '@/errors/parser'
+import { OmniContractErrorParser } from '@/errors/types'
+import { ContractError } from '..'
 
 /**
  * Base class for all EVM SDKs, providing some common functionality
  * to reduce the boilerplate
  */
 export abstract class OmniSDK implements IOmniSDK {
-    constructor(public readonly contract: OmniContract) {}
+    constructor(
+        public readonly contract: OmniContract,
+        protected readonly errorParser: OmniContractErrorParser = createContractErrorParser(contract)
+    ) {}
 
     get point(): OmniPoint {
         return omniContractToPoint(this.contract)
@@ -18,5 +24,9 @@ export abstract class OmniSDK implements IOmniSDK {
             point: this.point,
             data,
         }
+    }
+
+    protected parseError(error: unknown): ContractError {
+        return this.errorParser(error)
     }
 }


### PR DESCRIPTION
### In this PR

- Add a standalone `parseError` function for situations where `createErrorParser` is too heavy