### PR TITLE
feat: omnicounter sdk factory

### DIFF
--- a/packages/omnicounter-utils-evm/src/omnicounter/factory.ts
+++ b/packages/omnicounter-utils-evm/src/omnicounter/factory.ts
@@ -1,0 +1,19 @@
+import pMemoize from 'p-memoize'
+import { OmniCounter } from '@/omnicounter/sdk'
+import { createEndpointFactory } from '@layerzerolabs/protocol-utils-evm'
+import { EndpointFactory } from '@layerzerolabs/protocol-utils'
+import { OAppFactory } from '@layerzerolabs/ua-utils'
+import { OmniContractFactory } from '@layerzerolabs/utils-evm'
+
+/**
+ * Syntactic sugar that creates an instance of EVM `OmniCounter` SDK based on an `OmniPoint` with help of an
+ * `OmniContractFactory` and an (optional) `EndpointFactory`
+ *
+ * @param {OmniContractFactory} contractFactory
+ * @param {EndpointFactory} [endpointFactory]
+ * @returns {EndpointFactory<Endpoint>}
+ */
+export const createOmniCounterFactory = (
+    contractFactory: OmniContractFactory,
+    endpointFactory: EndpointFactory = createEndpointFactory(contractFactory)
+): OAppFactory<OmniCounter> => pMemoize(async (point) => new OmniCounter(await contractFactory(point), endpointFactory))

--- a/packages/omnicounter-utils-evm/src/omnicounter/index.ts
+++ b/packages/omnicounter-utils-evm/src/omnicounter/index.ts
@@ -1,1 +1,2 @@
+export * from './factory'
 export * from './sdk'

--- a/packages/omnicounter-utils-evm/src/omnicounter/sdk.ts
+++ b/packages/omnicounter-utils-evm/src/omnicounter/sdk.ts
@@ -1,8 +1,17 @@
-import { IOmniCounterApp } from '@layerzerolabs/omnicounter-utils'
+import { IOmniCounter } from '@layerzerolabs/omnicounter-utils'
+import { EndpointFactory } from '@layerzerolabs/protocol-utils'
 import { OApp } from '@layerzerolabs/ua-utils-evm'
 import { OmniTransaction } from '@layerzerolabs/utils'
+import { OmniContract } from '@layerzerolabs/utils-evm'
 
-export class OmniCounterApp extends OApp implements IOmniCounterApp {
+export class OmniCounter extends OApp implements IOmniCounter {
+    public constructor(
+        public override contract: OmniContract,
+        protected override endpointFactory: EndpointFactory
+    ) {
+        super(contract, endpointFactory)
+    }
+
     public async increment(eid: number, type: number, options: string): Promise<OmniTransaction> {
         const data = this.contract.contract.interface.encodeFunctionData('increment', [eid, type, options])
         return super.createTransaction(data)

--- a/packages/omnicounter-utils/src/omnicounter/types.ts
+++ b/packages/omnicounter-utils/src/omnicounter/types.ts
@@ -1,6 +1,6 @@
 import { OmniTransaction } from '@layerzerolabs/utils'
 import { EndpointId } from '@layerzerolabs/lz-definitions'
 
-export interface IOmniCounterApp {
+export interface IOmniCounter {
     increment(eid: EndpointId, type: number, options: string): Promise<OmniTransaction>
 }

--- a/packages/ua-utils-evm/src/oapp/sdk.ts
+++ b/packages/ua-utils-evm/src/oapp/sdk.ts
@@ -15,7 +15,7 @@ import { OmniSDK } from '@layerzerolabs/utils-evm'
 export class OApp extends OmniSDK implements IOApp {
     constructor(
         contract: OmniContract,
-        private readonly endpointFactory: EndpointFactory
+        protected readonly endpointFactory: EndpointFactory
     ) {
         super(contract)
     }


### PR DESCRIPTION
- rename everything to OmniCounter, dropping App.
- adapt to new OApp super constructor.
- make endpointFactory protected in OApp so it can be extended.