### PR TITLE
🚧 Segmentation fault in jest/mocha

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,17 @@
+# We will alow consumers to specify the node version in case we want
+# to test under different versions (since we cannot control users environment)
+# 
+# There is nothing wrong with 18.16.0 except for a tiny issue
+# in docker compose - a segmentation fault that happens
+# when we try to use a dynamic import in our tests (affecting both mocha & jest)
+# 
+# The issue has been described here https://github.com/jestjs/jest/issues/12286
+# And relates to this node issue here https://github.com/nodejs/node/issues/43205
+# 
+# This issue does not affect users, it's only related to the test runner
+# so the code will still work on node 18.16.0
+ARG NODE_VERSION=20.10.0
+
 #   .-.-.   .-.-.   .-.-.   .-.-.   .-.-.   .-.-.   .-.-.   .-.-
 #  / / \ \ / / \ \ / / \ \ / / \ \ / / \ \ / / \ \ / / \ \ / / \
 # `-'   `-`-'   `-`-'   `-`-'   `-`-'   `-`-'   `-`-'   `-`-'
@@ -7,7 +21,7 @@
 #   .-.-.   .-.-.   .-.-.   .-.-.   .-.-.   .-.-.   .-.-.   .-.-
 #  / / \ \ / / \ \ / / \ \ / / \ \ / / \ \ / / \ \ / / \ \ / / \
 # `-'   `-`-'   `-`-'   `-`-'   `-`-'   `-`-'   `-`-'   `-`-'
-FROM node:18.16.0 as base
+FROM node:$NODE_VERSION as base
 
 ENV YARN_CACHE_FOLDER=/tmp/yarn_cache
 

--- a/docker-compose.templates.yaml
+++ b/docker-compose.templates.yaml
@@ -48,9 +48,3 @@ services:
       interval: 2s
       retries: 20
       test: ["CMD", "curl", "-f", "http://0.0.0.0:8545/"]
-
-  # Service that can build this package
-  tests:
-    extends:
-      service: project
-    working_dir: /app/packages/ua-utils-evm-hardhat-test

--- a/packages/io-utils/jest.config.js
+++ b/packages/io-utils/jest.config.js
@@ -1,6 +1,7 @@
 /** @type {import('ts-jest').JestConfigWithTsJest} */
 module.exports = {
     preset: 'ts-jest',
+    cache: false,
     testEnvironment: 'node',
     moduleNameMapper: {
         '^@/(.*)$': '<rootDir>/src/$1',

--- a/packages/omnicounter-utils-evm/jest.config.js
+++ b/packages/omnicounter-utils-evm/jest.config.js
@@ -1,6 +1,7 @@
 /** @type {import('ts-jest').JestConfigWithTsJest} */
 module.exports = {
     preset: 'ts-jest',
+    cache: false,
     testEnvironment: 'node',
     moduleNameMapper: {
         '^@/(.*)$': '<rootDir>/src/$1',

--- a/packages/omnicounter-utils/jest.config.js
+++ b/packages/omnicounter-utils/jest.config.js
@@ -1,6 +1,7 @@
 /** @type {import('ts-jest').JestConfigWithTsJest} */
 module.exports = {
     preset: 'ts-jest',
+    cache: false,
     testEnvironment: 'node',
     moduleNameMapper: {
         '^@/(.*)$': '<rootDir>/src/$1',

--- a/packages/protocol-utils-evm/jest.config.js
+++ b/packages/protocol-utils-evm/jest.config.js
@@ -1,6 +1,7 @@
 /** @type {import('ts-jest').JestConfigWithTsJest} */
 module.exports = {
     preset: 'ts-jest',
+    cache: false,
     testEnvironment: 'node',
     moduleNameMapper: {
         '^@/(.*)$': '<rootDir>/src/$1',

--- a/packages/protocol-utils/jest.config.js
+++ b/packages/protocol-utils/jest.config.js
@@ -1,6 +1,7 @@
 /** @type {import('ts-jest').JestConfigWithTsJest} */
 module.exports = {
     preset: 'ts-jest',
+    cache: false,
     testEnvironment: 'node',
     moduleNameMapper: {
         '^@/(.*)$': '<rootDir>/src/$1',

--- a/packages/toolbox-hardhat/jest.config.js
+++ b/packages/toolbox-hardhat/jest.config.js
@@ -1,6 +1,7 @@
 /** @type {import('ts-jest').JestConfigWithTsJest} */
 module.exports = {
     preset: 'ts-jest',
+    cache: false,
     testEnvironment: 'node',
     testTimeout: 15000,
     moduleNameMapper: {

--- a/packages/ua-utils-evm-hardhat-test/jest.config.js
+++ b/packages/ua-utils-evm-hardhat-test/jest.config.js
@@ -1,6 +1,7 @@
 /** @type {import('ts-jest').JestConfigWithTsJest} */
 module.exports = {
     preset: 'ts-jest',
+    cache: false,
     testEnvironment: 'node',
     testTimeout: 15000,
     moduleNameMapper: {

--- a/packages/ua-utils-evm-hardhat/jest.config.js
+++ b/packages/ua-utils-evm-hardhat/jest.config.js
@@ -1,6 +1,7 @@
 /** @type {import('ts-jest').JestConfigWithTsJest} */
 module.exports = {
     preset: 'ts-jest',
+    cache: false,
     testEnvironment: 'node',
     moduleNameMapper: {
         '^@/(.*)$': '<rootDir>/src/$1',

--- a/packages/ua-utils-evm/jest.config.js
+++ b/packages/ua-utils-evm/jest.config.js
@@ -1,6 +1,7 @@
 /** @type {import('ts-jest').JestConfigWithTsJest} */
 module.exports = {
     preset: 'ts-jest',
+    cache: false,
     testEnvironment: 'node',
     moduleNameMapper: {
         '^@/(.*)$': '<rootDir>/src/$1',

--- a/packages/ua-utils/jest.config.js
+++ b/packages/ua-utils/jest.config.js
@@ -1,6 +1,7 @@
 /** @type {import('ts-jest').JestConfigWithTsJest} */
 module.exports = {
     preset: 'ts-jest',
+    cache: false,
     testEnvironment: 'node',
     moduleNameMapper: {
         '^@/(.*)$': '<rootDir>/src/$1',

--- a/packages/utils-evm-hardhat/jest.config.js
+++ b/packages/utils-evm-hardhat/jest.config.js
@@ -1,6 +1,7 @@
 /** @type {import('ts-jest').JestConfigWithTsJest} */
 module.exports = {
     preset: 'ts-jest',
+    cache: false,
     testEnvironment: 'node',
     moduleNameMapper: {
         '^@/(.*)$': '<rootDir>/src/$1',

--- a/packages/utils-evm-test/jest.config.js
+++ b/packages/utils-evm-test/jest.config.js
@@ -1,6 +1,7 @@
 /** @type {import('ts-jest').JestConfigWithTsJest} */
 module.exports = {
     preset: 'ts-jest',
+    cache: false,
     testEnvironment: 'node',
     testTimeout: 15000,
     moduleNameMapper: {

--- a/packages/utils-evm/jest.config.js
+++ b/packages/utils-evm/jest.config.js
@@ -1,6 +1,7 @@
 /** @type {import('ts-jest').JestConfigWithTsJest} */
 module.exports = {
     preset: 'ts-jest',
+    cache: false,
     testEnvironment: 'node',
     moduleNameMapper: {
         '^@/(.*)$': '<rootDir>/src/$1',

--- a/packages/utils/jest.config.js
+++ b/packages/utils/jest.config.js
@@ -1,6 +1,7 @@
 /** @type {import('ts-jest').JestConfigWithTsJest} */
 module.exports = {
     preset: 'ts-jest',
+    cache: false,
     testEnvironment: 'node',
     moduleNameMapper: {
         '^@/(.*)$': '<rootDir>/src/$1',


### PR DESCRIPTION
### In this PR

There is a nasty problem with test runners - using dynamic `import` inside of a test run triggers a segmentation fault. This prevented a lot of good stuff from happening, namely having a way more sophisticated output in the console (the required modules are ESM and require us to load them using `await import()`.

The error has been reported many times and [fixed in node itself](https://github.com/nodejs/node/issues/43205) after causing many [headaches in tests](https://github.com/jestjs/jest/issues/12286)

The solution consists of two things - updating the base node image and not caching `jest` test runs (jest cache is slow anyways).

To add a feature to a bugfix I made the base node version controllable using `NODE_VERSION` build argument so we can test with any compatible node versions if we want (matrix tests will possibly soon be necessary).

(I also dropped an unused YAML template)