### PR TITLE
🚧 OmniGraph™ Support bigints in printJson

### DIFF
--- a/packages/io-utils/src/stdio/printer.ts
+++ b/packages/io-utils/src/stdio/printer.ts
@@ -1,7 +1,12 @@
 import Table, { HorizontalTableRow } from 'cli-table3'
 import type { ZodError } from 'zod'
 
-export const printJson = (obj: unknown, pretty = true): string => JSON.stringify(obj, null, pretty ? '\t' : undefined)
+export const printJson = (obj: unknown, pretty = true): string =>
+    JSON.stringify(
+        obj,
+        (key, value) => (typeof value === 'bigint' ? value.toString(10) : value),
+        pretty ? '\t' : undefined
+    )
 
 export const printRecord = <TRecord extends object>(obj: TRecord, title?: string | number): string => {
     const table = new Table({

--- a/packages/io-utils/test/stdio/__snapshots__/printer.test.ts.snap
+++ b/packages/io-utils/test/stdio/__snapshots__/printer.test.ts.snap
@@ -1,5 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`stdio/printer printJson should handle bigints 1`] = `
+"{
+	"bigint": "1684996666696914987166688442938726917102321526408785780068975640575"
+}"
+`;
+
 exports[`stdio/printer printRecord should return a list of items with indices for an array 1`] = `
 "┌───┬──────────────────┐
 │ 0 │ something        │

--- a/packages/io-utils/test/stdio/printer.test.ts
+++ b/packages/io-utils/test/stdio/printer.test.ts
@@ -1,4 +1,4 @@
-import { printRecord, printZodErrors } from '@/stdio'
+import { printJson, printRecord, printZodErrors } from '@/stdio'
 import assert from 'assert'
 import { z } from 'zod'
 
@@ -136,6 +136,18 @@ describe('stdio/printer', () => {
             expect(printZodErrors(propertyObjectError5)).toMatchSnapshot()
             expect(printZodErrors(propertyObjectError6)).toMatchSnapshot()
             expect(printZodErrors(noPropertyObjectError)).toMatchSnapshot()
+        })
+    })
+
+    describe('printJson', () => {
+        it('should handle bigints', () => {
+            expect(
+                printJson({
+                    bigint: BigInt(
+                        '0b1111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111'
+                    ),
+                })
+            ).toMatchSnapshot()
         })
     })
 })


### PR DESCRIPTION
### In this PR

- `JSON.stringify` cannot process `bigint` natively so we're adding a replacer to our `printJson` utility so that we can log JSON objects okay