### PR TITLE
🪚 OmniGraph™ --ci flag for wire task

### DIFF
--- a/packages/ua-utils-evm-hardhat-test/test/task/oapp/wire.test.ts
+++ b/packages/ua-utils-evm-hardhat-test/test/task/oapp/wire.test.ts
@@ -116,6 +116,17 @@ describe('task/oapp/wire', () => {
             expect(promptToContinueMock).toHaveBeenCalledTimes(2)
         })
 
+        it('should not ask the user for input if --ci flag is truthy and execute all transactions', async () => {
+            const oappConfig = configPathFixture('valid.config.connected.js')
+
+            promptToContinueMock.mockResolvedValue(false)
+
+            const result = await hre.run(TASK_LZ_WIRE_OAPP, { oappConfig, ci: true })
+
+            expect(result).toEqual([])
+            expect(promptToContinueMock).not.toHaveBeenCalled()
+        })
+
         it('should ask the user whether they want to see the transactions & continue', async () => {
             const oappConfig = configPathFixture('valid.config.connected.js')
 

--- a/packages/ua-utils-evm-hardhat/src/tasks/oapp/wire.ts
+++ b/packages/ua-utils-evm-hardhat/src/tasks/oapp/wire.ts
@@ -23,9 +23,13 @@ import { resolve } from 'path'
 interface TaskArgs {
     oappConfig: string
     logLevel?: string
+    ci?: boolean
 }
 
-const action: ActionType<TaskArgs> = async ({ oappConfig: oappConfigPath, logLevel = 'info' }) => {
+const action: ActionType<TaskArgs> = async ({ oappConfig: oappConfigPath, logLevel = 'info', ci = false }) => {
+    // We only want to be asking users for input if we are not in interactive mode
+    const isInteractive = !ci
+
     // We'll set the global logging level to get as much info as needed
     setDefaultLogLevel(logLevel)
 
@@ -129,18 +133,26 @@ const action: ActionType<TaskArgs> = async ({ oappConfig: oappConfigPath, logLev
     )
 
     // Ask them whether they want to see them
-    const previewTransactions = await promptToContinue(`Would you like to preview the transactions before continuing?`)
+    const previewTransactions = isInteractive
+        ? await promptToContinue(`Would you like to preview the transactions before continuing?`)
+        : true
     if (previewTransactions) logger.info(`\n${printTransactions(transactions)}`)
 
     // Now ask the user whether they want to go ahead with signing them
-    const go = await promptToContinue()
-    if (!go) {
-        return undefined
-    }
+    const shouldSubmit = isInteractive
+        ? await promptToContinue(`Would you like to submit the required transactions?`)
+        : true
+    if (!shouldSubmit) return logger.verbose(`User cancelled the operation, exiting`), undefined
 
     return []
 }
 task(TASK_LZ_WIRE_OAPP, 'Wire LayerZero OApp')
     .addParam('oappConfig', 'Path to your LayerZero OApp config', './layerzero.config.js', types.string)
     .addParam('logLevel', 'Logging level. One of: error, warn, info, verbose, debug, silly', 'info', types.string)
+    .addParam(
+        'ci',
+        'Continuous integration (non-interactive) mode. Will not ask for any input from the user',
+        false,
+        types.boolean
+    )
     .setAction(action)


### PR DESCRIPTION
### In this PR

- Adding a `--ci` flag to the wire task for non-interactive environments. If this flag is provided, user will not be prompted to answer any questions and the wiring will continue automatically. This is useful for both tests in our repository (not to have to mock `promptXXX` functions and for automated clients