### PR TITLE
🚧 Fix security flaw for docker compose

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -119,7 +119,14 @@ RUN \
     rm -rf .npmrc .npmrctemplate
 
 # Run the package scripts in a separate step in which the NPM_TOKEN is not available
-RUN yarn install --frozen-lockfile --offline
+RUN \
+    #  Mount yarn cache
+    --mount=type=cache,target=/tmp/yarn_cache \
+    # Run the scripts
+    # 
+    # yarn does not have a dedicated command to do this so to emulate that
+    # we will do an offline install which will reinstall the packages from local cache and run the scripts
+    yarn install --frozen-lockfile --offline
 
 #   .-.-.   .-.-.   .-.-.   .-.-.   .-.-.   .-.-.   .-.-.   .-.-
 #  / / \ \ / / \ \ / / \ \ / / \ \ / / \ \ / / \ \ / / \ \ / / \


### PR DESCRIPTION
### In this PR

- Don't allow external packages to access the `NPM_TOKEN` in `Dockerfile`. This is only important if we go public with this repo before going public with the monorepo packages but you never know
- After going public with the monorepo packages we need to remove the `NPM_TOKEN` from all installation steps (great, lots of lines of code gone) and only keep it in publishing steps