### PR TITLE
🪚 Speed up event parser tests

### DIFF
--- a/tests/devtools-evm-test/package.json
+++ b/tests/devtools-evm-test/package.json
@@ -12,7 +12,7 @@
   "scripts": {
     "lint": "npx eslint '**/*.{js,ts,json}'",
     "pretest": "npx hardhat compile",
-    "test": "jest --passWithNoTests --forceExit"
+    "test": "jest"
   },
   "devDependencies": {
     "@ethersproject/abi": "^5.7.0",


### PR DESCRIPTION
### In this PR

- reduce the number of runs on event parser tests - submitting hundreds of transactions in every test can increase the runtime to five-six minutes per run