### PR TITLE
🪚 Composite actions

### DIFF
--- a/.github/workflows/actions/install-dependencies/action.yaml
+++ b/.github/workflows/actions/install-dependencies/action.yaml
@@ -1,0 +1,20 @@
+name: Install project dependencies
+description: Install everything we need to build this repo
+inputs:
+  NPM_TOKEN:
+    description: "NPM_TOKEN that grants permissions to private @layerzerolabs packages"
+    required: true
+runs:
+  using: "composite"
+  steps:
+    # Fetch the dependencies without running the post-install scripts
+    - name: Fetch Dependencies
+      shell: bash
+      run: pnpm fetch --frozen-lockfile --prefer-offline --ignore-scripts
+      env:
+        NPM_TOKEN: ${{ inputs.NPM_TOKEN }}
+
+    # Install the dependencies and run the post-install scripts
+    - name: Install Dependencies
+      shell: bash
+      run: pnpm install --frozen-lockfile --offline

--- a/.github/workflows/actions/setup-build-cache/action.yaml
+++ b/.github/workflows/actions/setup-build-cache/action.yaml
@@ -1,0 +1,27 @@
+name: Setup build cache
+description: Setup cache for turbo builds & hardhat compilers
+runs:
+  using: "composite"
+  steps:
+    # Cache build artifacts from turbo
+    #
+    # This step will speed up workflow runs that don't touch the whole codebase
+    # (or the ones that don't touch the codebase at all)
+    - name: Cache turbo build setup
+      uses: actions/cache@v3
+      with:
+        path: node_modules/.cache/turbo
+        key: ${{ runner.os }}-turbo-${{ github.ref_name }}
+        restore-keys: |
+          ${{ runner.os }}-turbo-
+
+    # Cache hardhat compilers
+    #
+    # This step will speed up workflow runs that use hardhat compilation
+    - name: Cache hardhat compilers
+      uses: actions/cache@v3
+      with:
+        path: .cache/hardhat
+        key: ${{ runner.os }}-hardhat-${{ github.ref_name }}
+        restore-keys: |
+          ${{ runner.os }}-hardhat-

--- a/.github/workflows/actions/setup-environment/action.yaml
+++ b/.github/workflows/actions/setup-environment/action.yaml
@@ -1,0 +1,16 @@
+name: Setup environment
+description: Setup node & package manager, checkout code
+runs:
+  using: "composite"
+  steps:
+    - uses: pnpm/action-setup@v2
+      name: Install pnpm
+      with:
+        version: 8
+        run_install: false
+
+    - name: Setup Node.js
+      uses: actions/setup-node@v3
+      with:
+        node-version-file: ".nvmrc"
+        cache: "pnpm"

--- a/.github/workflows/reusable-publish.yaml
+++ b/.github/workflows/reusable-publish.yaml
@@ -22,52 +22,19 @@ jobs:
     name: Publish
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout repo
+        uses: actions/checkout@v3
 
-      - uses: pnpm/action-setup@v2
-        name: Install pnpm
+      - name: Setup environment
+        uses: ./.github/workflows/actions/setup-environment
+
+      - name: Install dependencies
+        uses: ./.github/workflows/actions/install-dependencies
         with:
-          version: 8
-          run_install: false
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v3
-        with:
-          node-version-file: ".nvmrc"
-          cache: "pnpm"
-
-      # Fetch the dependencies without running the post-install scripts
-      - name: Fetch Dependencies
-        run: pnpm fetch --frozen-lockfile --prefer-offline --ignore-scripts
-        env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
-      # Install the dependencies and run the post-install scripts
-      - name: Install Dependencies
-        run: pnpm install --frozen-lockfile --offline
-
-      # Cache build artifacts from turbo
-      #
-      # This step will speed up workflow runs that don't touch the whole codebase
-      # (or the ones that don't touch the codebase at all)
-      - name: Cache turbo build setup
-        uses: actions/cache@v3
-        with:
-          path: node_modules/.cache/turbo
-          key: ${{ runner.os }}-turbo-${{ github.ref_name }}
-          restore-keys: |
-            ${{ runner.os }}-turbo-
-
-      # Cache hardhat compilers
-      #
-      # This step will speed up workflow runs that use hardhat compilation
-      - name: Cache hardhat compilers
-        uses: actions/cache@v3
-        with:
-          path: .cache/hardhat
-          key: ${{ runner.os }}-hardhat-${{ github.ref_name }}
-          restore-keys: |
-            ${{ runner.os }}-hardhat-
+      - name: Setup build cache
+        uses: ./.github/workflows/actions/setup-build-cache
 
       - name: Build
         run: pnpm build

--- a/.github/workflows/reusable-test.yaml
+++ b/.github/workflows/reusable-test.yaml
@@ -18,56 +18,23 @@ env:
   NPM_TOKEN: ""
 
 jobs:
-  build-and-test:
-    name: Build, Lint & Test
+  build:
+    name: Build & Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout repo
+        uses: actions/checkout@v3
 
-      - uses: pnpm/action-setup@v2
-        name: Install pnpm
+      - name: Setup environment
+        uses: ./.github/workflows/actions/setup-environment
+
+      - name: Install dependencies
+        uses: ./.github/workflows/actions/install-dependencies
         with:
-          version: 8
-          run_install: false
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v3
-        with:
-          node-version-file: ".nvmrc"
-          cache: "pnpm"
-
-      # Fetch the dependencies without running the post-install scripts
-      - name: Fetch Dependencies
-        run: pnpm fetch --frozen-lockfile --prefer-offline --ignore-scripts
-        env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
-      # Install the dependencies and run the post-install scripts
-      - name: Install Dependencies
-        run: pnpm install --frozen-lockfile --offline
-
-      # Cache build artifacts from turbo
-      #
-      # This step will speed up workflow runs that don't touch the whole codebase
-      # (or the ones that don't touch the codebase at all)
-      - name: Cache turbo build setup
-        uses: actions/cache@v3
-        with:
-          path: node_modules/.cache/turbo
-          key: ${{ runner.os }}-turbo-${{ github.ref_name }}
-          restore-keys: |
-            ${{ runner.os }}-turbo-
-
-      # Cache hardhat compilers
-      #
-      # This step will speed up workflow runs that use hardhat compilation
-      - name: Cache hardhat compilers
-        uses: actions/cache@v3
-        with:
-          path: .cache/hardhat
-          key: ${{ runner.os }}-hardhat-${{ github.ref_name }}
-          restore-keys: |
-            ${{ runner.os }}-hardhat-
+      - name: Setup build cache
+        uses: ./.github/workflows/actions/setup-build-cache
 
       - name: Lint
         run: pnpm lint


### PR DESCRIPTION
### In this PR

This is a PR that prepares the ground for splitting the github `Build, Lint & Test` job into two jobs that run in parallel.

- Introducing composite actions for the common tasks - setting up the environment, installing dependencies, setting up build cache. You can read more about composite actions [here](https://docs.github.com/en/actions/creating-actions/creating-a-composite-action)