### PR TITLE
🚧 Rebuild native bindings

### DIFF
--- a/.github/workflows/actions/install-dependencies/action.yaml
+++ b/.github/workflows/actions/install-dependencies/action.yaml
@@ -18,3 +18,8 @@ runs:
     - name: Install Dependencies
       shell: bash
       run: pnpm install --frozen-lockfile --offline
+
+    # Rebuild native bindings
+    - name: Rebuild NPM packages
+      shell: bash
+      run: pnpm rebuild --recursive

--- a/Dockerfile
+++ b/Dockerfile
@@ -110,3 +110,6 @@ RUN \
     --mount=type=cache,id=pnpm-store,target=/pnpm \
     # Install dependencies (fail if we forgot to update the lockfile)
     pnpm install --recursive --offline --frozen-lockfile
+
+# Rebuild native bindings (since the scripts were not executed above, we need to execute them now)
+RUN pnpm rebuild --recursive 


### PR DESCRIPTION
### In this PR

- Running the post-install scripts to get the native bindings (this gets rid of the PureJS error in the docker container)

<img width="799" alt="Screenshot 2024-01-10 at 9 34 13 AM" src="https://github.com/LayerZero-Labs/devtools/assets/1451480/f7846147-8d95-4b13-a2f8-31341227f7d0">
