### PR TITLE
🚧 Get rid of nonce conflicts

### DIFF
--- a/tests/devtools-evm-hardhat-test/hardhat.config.ts
+++ b/tests/devtools-evm-hardhat-test/hardhat.config.ts
@@ -25,6 +25,7 @@ const config: HardhatUserConfig = {
             url: process.env.NETWORK_URL_VENGABOYS ?? 'http://localhost:10001',
             accounts: {
                 mnemonic: MNEMONIC,
+                initialIndex: 0,
             },
         },
         britney: {
@@ -38,6 +39,7 @@ const config: HardhatUserConfig = {
             url: process.env.NETWORK_URL_BRITNEY ?? 'http://localhost:10002',
             accounts: {
                 mnemonic: MNEMONIC,
+                initialIndex: 0,
             },
         },
     },

--- a/tests/test-evm-node/hardhat.config.ts
+++ b/tests/test-evm-node/hardhat.config.ts
@@ -13,6 +13,14 @@ const config: HardhatUserConfig = {
         hardhat: {
             accounts: {
                 mnemonic: MNEMONIC,
+                // We'll reserve 10 accounts per every test project
+                //
+                // When adding new E2E test projects, bumpt this number
+                // and set the initialIndex in your project's network config
+                // so that the accounts the projects uses do not overlap with other projects
+                //
+                // This will ensure that there are no nonce race conditions when running the tests in parallel
+                count: 20,
             },
         },
     },

--- a/tests/ua-devtools-evm-hardhat-test/hardhat.config.ts
+++ b/tests/ua-devtools-evm-hardhat-test/hardhat.config.ts
@@ -29,6 +29,10 @@ const config: HardhatUserConfig = {
             url: process.env.NETWORK_URL_VENGABOYS ?? 'http://localhost:10001',
             accounts: {
                 mnemonic: MNEMONIC,
+                // We'll offset the initial index for the accounts by 10
+                // for every test project so that the project can use 10 accounts
+                // without getting any nonce race conditions with other test runs
+                initialIndex: 10,
             },
         },
         britney: {
@@ -42,6 +46,10 @@ const config: HardhatUserConfig = {
             url: process.env.NETWORK_URL_BRITNEY ?? 'http://localhost:10002',
             accounts: {
                 mnemonic: MNEMONIC,
+                // We'll offset the initial index for the accounts by 10
+                // for every test project so that the project can use 10 accounts
+                // without getting any nonce race conditions with other test runs
+                initialIndex: 10,
             },
         },
     },


### PR DESCRIPTION
### In this PR

- Allocate 10 accounts per every E2E test project to get rid of the nonce conflicts. This means everytime we add a new E2E test project, we can bump the `count` in the `test-evm-node` and set the `initialIndex` to be `max(<existing initialIndices>) + 10`