### PR TITLE
🚧 Fix wire task return value

### DIFF
--- a/tests/ua-devtools-evm-hardhat-test/test/task/oapp/wire.test.ts
+++ b/tests/ua-devtools-evm-hardhat-test/test/task/oapp/wire.test.ts
@@ -183,7 +183,7 @@ describe('task/oapp/wire', () => {
                 sendTransactionMock.mockRestore()
             })
 
-            it.only('should return a list of failed transactions in the CI mode', async () => {
+            it('should return a list of failed transactions in the CI mode', async () => {
                 const error = new Error('Oh god dammit')
 
                 // We want to make the fail


### PR DESCRIPTION
### In this PR

- Due to an `.only` in the test, some of the wire task test have not been run. One of them would have caught an error where if `signAndSend` would fail and the user would retry, any successful transactions from the first failed run would not appear in the output.
- The prevention of this situation is coming in another PR with a new ESLint plugin for Jest