### PR TITLE
🚧 Use fixtures when deploying test contracts

### DIFF
--- a/tests/devtools-evm-hardhat-test/deploy/001_Thrower.ts
+++ b/tests/devtools-evm-hardhat-test/deploy/001_Thrower.ts
@@ -1,0 +1,26 @@
+import { type DeployFunction } from 'hardhat-deploy/types'
+import assert from 'assert'
+
+/**
+ * This deploy function will deploy and configure the Thrower contract
+ *
+ * @param env `HardhatRuntimeEnvironment`
+ */
+const deploy: DeployFunction = async ({ getUnnamedAccounts, deployments, network }) => {
+    const [deployer] = await getUnnamedAccounts()
+    assert(deployer, 'Missing deployer')
+
+    await deployments.delete('Thrower')
+    const throwerDeployment = await deployments.deploy('Thrower', {
+        from: deployer,
+    })
+
+    console.table({
+        Network: `${network.name}`,
+        Thrower: throwerDeployment.address,
+    })
+}
+
+deploy.tags = ['Thrower']
+
+export default deploy

--- a/tests/devtools-evm-hardhat-test/deploy/002_TestProxy.ts
+++ b/tests/devtools-evm-hardhat-test/deploy/002_TestProxy.ts
@@ -1,0 +1,36 @@
+import { type DeployFunction } from 'hardhat-deploy/types'
+import assert from 'assert'
+
+/**
+ * This deploy function will deploy and configure the TestProxy contract
+ *
+ * @param env `HardhatRuntimeEnvironment`
+ */
+const deploy: DeployFunction = async ({ getUnnamedAccounts, deployments, network }) => {
+    const [deployer] = await getUnnamedAccounts()
+    assert(deployer, 'Missing deployer')
+
+    await deployments.delete('TestProxy')
+    const testProxyDeployment = await deployments.deploy('TestProxy', {
+        from: deployer,
+        proxy: {
+            owner: deployer,
+            proxyContract: 'OptimizedTransparentProxy',
+            execute: {
+                init: {
+                    methodName: 'initialize',
+                    args: [],
+                },
+            },
+        },
+    })
+
+    console.table({
+        Network: `${network.name}`,
+        TestProxy: testProxyDeployment.address,
+    })
+}
+
+deploy.tags = ['TestProxy']
+
+export default deploy

--- a/tests/devtools-evm-hardhat-test/test/errors/parser.test.ts
+++ b/tests/devtools-evm-hardhat-test/test/errors/parser.test.ts
@@ -3,11 +3,10 @@ import 'hardhat'
 import { BigNumber } from '@ethersproject/bignumber/lib/bignumber'
 import { Contract } from '@ethersproject/contracts'
 import { CustomError, UnknownError } from '@layerzerolabs/devtools-evm'
-import { createErrorParser, createSignerFactory } from '@layerzerolabs/devtools-evm-hardhat'
+import { createConnectedContractFactory, createErrorParser } from '@layerzerolabs/devtools-evm-hardhat'
 import { OmniError } from '@layerzerolabs/devtools'
 import { pointArbitrary } from '@layerzerolabs/test-devtools'
 import { getHreByNetworkName, getEidForNetworkName } from '@layerzerolabs/devtools-evm-hardhat'
-import assert from 'assert'
 
 describe('errors/parser', () => {
     describe('createErrorParser', () => {
@@ -35,18 +34,15 @@ describe('errors/parser', () => {
             // Get the environment
             const env = await getHreByNetworkName('britney')
             const eid = getEidForNetworkName('britney')
-            const { signer } = await createSignerFactory()(eid)
 
-            // Get the deployer account
-            const [deployer] = await env.getUnnamedAccounts()
-            assert(deployer, 'Missing deployer account')
+            // Deploy a fixture
+            await env.deployments.fixture(['Thrower'])
 
-            // Deploy the Thrower contract
-            const deployment = await env.deployments.deploy('Thrower', {
-                from: deployer,
-            })
+            // And get the contract
+            const contractFactory = createConnectedContractFactory()
+            const omniContract = await contractFactory({ contractName: 'Thrower', eid })
 
-            contract = new Contract(deployment.address, deployment.abi, signer)
+            contract = omniContract.contract
         })
 
         it('should parse a custom an error with no arguments coming from the contract itself', async () => {

--- a/tests/devtools-evm-hardhat-test/test/omnigraph/coordinates.test.ts
+++ b/tests/devtools-evm-hardhat-test/test/omnigraph/coordinates.test.ts
@@ -5,7 +5,6 @@ import {
     getEidForNetworkName,
     getHreByNetworkName,
 } from '@layerzerolabs/devtools-evm-hardhat'
-import assert from 'assert'
 
 describe('omnigraph/coordinates', () => {
     describe('createContractFactory', () => {
@@ -13,24 +12,8 @@ describe('omnigraph/coordinates', () => {
             const env = await getHreByNetworkName('britney')
             const eid = getEidForNetworkName('britney')
 
-            // Get the deployer account
-            const [deployer] = await env.getUnnamedAccounts()
-            assert(deployer, 'Missing deployer account')
-
-            // Deploy the TestProxy contract
-            await env.deployments.deploy('TestProxy', {
-                from: deployer,
-                proxy: {
-                    owner: deployer,
-                    proxyContract: 'OptimizedTransparentProxy',
-                    execute: {
-                        init: {
-                            methodName: 'initialize',
-                            args: [],
-                        },
-                    },
-                },
-            })
+            // Deploy a fixture
+            await env.deployments.fixture(['TestProxy'])
 
             // Now we create a contract factory and observe that the resulting contract has all the contract methods
             const contractFactory = createContractFactory()


### PR DESCRIPTION
### In this PR

- Use `hardhat-deploy` fixtures when deploying test contracts. I noticed that the leftover `deployments` folder causes issues when re-running tests on local (`hardhat-deploy` fails to find a deployment on the network since the network has been torn down)