### PR TITLE
🚧 Don't allow skip in tests

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -18,7 +18,10 @@
     {
       "files": ["test/**"],
       "plugins": ["jest"],
-      "extends": ["plugin:jest/recommended"]
+      "extends": ["plugin:jest/recommended"],
+      "rules": {
+        "jest/no-disabled-tests": "error"
+      }
     }
   ],
   "parserOptions": {


### PR DESCRIPTION
### In this PR

- Make sure there are not `.skip` statements in tests. Read more [here](https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/no-disabled-tests.md)