### PR TITLE
🚧 Update timeout for long running tests

### DIFF
--- a/tests/devtools-evm-hardhat-test/jest.config.js
+++ b/tests/devtools-evm-hardhat-test/jest.config.js
@@ -3,7 +3,7 @@ module.exports = {
     preset: 'ts-jest',
     cache: false,
     testEnvironment: 'node',
-    testTimeout: 300_000,
+    testTimeout: 150_000,
     moduleNameMapper: {
         '^@/(.*)$': '<rootDir>/src/$1',
     },

--- a/tests/devtools-evm-test/jest.config.js
+++ b/tests/devtools-evm-test/jest.config.js
@@ -3,7 +3,7 @@ module.exports = {
     preset: 'ts-jest',
     cache: false,
     testEnvironment: 'node',
-    testTimeout: 15000,
+    testTimeout: 150_000,
     moduleNameMapper: {
         '^@/(.*)$': '<rootDir>/src/$1',
     },


### PR DESCRIPTION
### In this PR

- Updating timeout for long running tests in `devtools-evm-test`