### PR TITLE
🚧 Add missing types package for prompts

### DIFF
--- a/packages/io-devtools/package.json
+++ b/packages/io-devtools/package.json
@@ -44,6 +44,7 @@
   "devDependencies": {
     "@types/ink-gradient": "^2.0.4",
     "@types/jest": "^29.5.11",
+    "@types/prompts": "^2.4.9",
     "@types/react": "^17.0.74",
     "fast-check": "^3.15.0",
     "ink": "^3.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -423,6 +423,9 @@ importers:
       '@types/jest':
         specifier: ^29.5.11
         version: 29.5.11
+      '@types/prompts':
+        specifier: ^2.4.9
+        version: 2.4.9
       '@types/react':
         specifier: ^17.0.74
         version: 17.0.74


### PR DESCRIPTION
### In this PR

- `prompts` package does not come with its own types and was missing `@types/prompts`