### PR TITLE
🚧 Ignore markdown & lockfile in ESLint; only ignore lockfile in prettier

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,3 +1,5 @@
 .turbo
 dist
 node_modules
+*.md
+pnpm-lock.yaml

--- a/.prettierignore
+++ b/.prettierignore
@@ -3,4 +3,4 @@
 .prettierignore
 .netrc
 *ignore
-pnpm-*.yaml
+pnpm-lock.yaml


### PR DESCRIPTION
### In this PR

- Ignore markdown files and the generated `pnpm-lock.yaml` in ESLint
- Only ignore `pnpm-lock.yaml` in Prettier, `pnpm-workspace.yaml` can be prettified