### PR TITLE
🚧 Use more specific keys when it comes to build cache

### DIFF
--- a/.github/workflows/actions/setup-build-cache/action.yaml
+++ b/.github/workflows/actions/setup-build-cache/action.yaml
@@ -11,8 +11,9 @@ runs:
       uses: actions/cache@v3
       with:
         path: node_modules/.cache/turbo
-        key: ${{ runner.os }}-turbo-${{ github.ref_name }}
+        key: ${{ runner.os }}-turbo-${{ github.ref_name }}-${{ github.sha }}
         restore-keys: |
+          ${{ runner.os }}-turbo-${{ github.ref_name }}-
           ${{ runner.os }}-turbo-
 
     # Cache hardhat compilers
@@ -22,6 +23,7 @@ runs:
       uses: actions/cache@v3
       with:
         path: .cache/hardhat
-        key: ${{ runner.os }}-hardhat-${{ github.ref_name }}
+        key: ${{ runner.os }}-hardhat-${{ github.ref_name }}-${{ github.sha }}
         restore-keys: |
+          ${{ runner.os }}-hardhat-${{ github.ref_name }}-
           ${{ runner.os }}-hardhat-


### PR DESCRIPTION
### In this PR

- When creating the cache entries in github actions, we used to only use the branch name (i.e. `${{ github.ref_name }}`). This though means that new cache will not be created for subsequent runs on the same branch - for example for `main`, github sees that there already is a cache entry for `main` and will not update the cache. This means that the first ever cache entry will be used in the workflow runs until it's deleted which is not what we want. The fix for this is to use a more specific cache key (using the commit hash) but allow the cache to be restored for a less specific key