### PR TITLE
🪚 Add test-devtools-evm-hardhat package with hardhat runtime helpers

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1137,6 +1137,24 @@ importers:
         specifier: ^5.3.3
         version: 5.3.3
 
+  tests/test-devtools-evm-hardhat:
+    devDependencies:
+      hardhat:
+        specifier: ^2.19.4
+        version: 2.19.4(ts-node@10.9.2)(typescript@5.3.3)
+      ts-node:
+        specifier: ^10.9.2
+        version: 10.9.2(@types/node@18.18.14)(typescript@5.3.3)
+      tslib:
+        specifier: ~2.6.2
+        version: 2.6.2
+      tsup:
+        specifier: ~8.0.1
+        version: 8.0.1(ts-node@10.9.2)(typescript@5.3.3)
+      typescript:
+        specifier: ^5.3.3
+        version: 5.3.3
+
   tests/test-evm-node:
     devDependencies:
       hardhat:

--- a/tests/test-devtools-evm-hardhat/.eslintrc.json
+++ b/tests/test-devtools-evm-hardhat/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../.eslintrc.json"
+}

--- a/tests/test-devtools-evm-hardhat/README.md
+++ b/tests/test-devtools-evm-hardhat/README.md
@@ -1,0 +1,19 @@
+<p align="center">
+  <a href="https://layerzero.network">
+    <img alt="LayerZero" style="max-width: 500px" src="https://d3a2dpnnrypp5h.cloudfront.net/bridge-app/lz.png"/>
+  </a>
+</p>
+
+<h1 align="center">@layerzerolabs/test-devtools-evm-hardhat</h1>
+
+<!-- The badges section -->
+<p align="center">
+  <!-- Shields.io NPM published package version -->
+  <a href="https://www.npmjs.com/package/@layerzerolabs/test-devtools-evm-hardhat"><img alt="NPM Version" src="https://img.shields.io/npm/v/@layerzerolabs/test-devtools-evm-hardhat"/></a>
+  <!-- Shields.io NPM downloads -->
+  <a href="https://www.npmjs.com/package/@layerzerolabs/test-devtools-evm-hardhat"><img alt="Downloads" src="https://img.shields.io/npm/dm/@layerzerolabs/test-devtools-evm-hardhat"/></a>
+  <!-- Shields.io license badge -->
+  <a href="https://www.npmjs.com/package/@layerzerolabs/test-devtools-evm-hardhat"><img alt="NPM License" src="https://img.shields.io/npm/l/@layerzerolabs/test-devtools-evm-hardhat"/></a>
+</p>
+
+Collection of internal helpers for testing LayerZero packages in `hardhat` environment

--- a/tests/test-devtools-evm-hardhat/package.json
+++ b/tests/test-devtools-evm-hardhat/package.json
@@ -1,0 +1,42 @@
+{
+  "name": "@layerzerolabs/test-devtools-evm-hardhat",
+  "version": "0.0.2",
+  "private": true,
+  "description": "Internal utilities for testing LayerZero packages",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/LayerZero-Labs/devtools.git",
+    "directory": "tests/test-devtools-evm-hardhat"
+  },
+  "license": "MIT",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "require": "./dist/index.js",
+      "import": "./dist/index.mjs"
+    }
+  },
+  "main": "dist/index.js",
+  "module": "dist/index.mjs",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist/index.*"
+  ],
+  "scripts": {
+    "prebuild": "tsc -noEmit",
+    "build": "$npm_execpath tsup",
+    "clean": "rm -rf dist",
+    "dev": "$npm_execpath tsup --watch",
+    "lint": "$npm_execpath eslint '**/*.{js,ts,json}'"
+  },
+  "devDependencies": {
+    "hardhat": "^2.19.4",
+    "ts-node": "^10.9.2",
+    "tslib": "~2.6.2",
+    "tsup": "~8.0.1",
+    "typescript": "^5.3.3"
+  },
+  "peerDependencies": {
+    "hardhat": "^2.19.4"
+  }
+}

--- a/tests/test-devtools-evm-hardhat/src/index.ts
+++ b/tests/test-devtools-evm-hardhat/src/index.ts
@@ -1,0 +1,1 @@
+export * from './runtime'

--- a/tests/test-devtools-evm-hardhat/src/runtime.ts
+++ b/tests/test-devtools-evm-hardhat/src/runtime.ts
@@ -1,0 +1,36 @@
+import type { HardhatRuntimeEnvironment, HardhatArguments } from 'hardhat/types'
+
+import { HardhatContext } from 'hardhat/internal/context'
+import { Environment as HardhatRuntimeEnvironmentImplementation } from 'hardhat/internal/core/runtime-environment'
+import { loadConfigAndTasks } from 'hardhat/internal/core/config/config-loading'
+
+/**
+ * Creates a test HardhatRuntimeEnvironment with specific arguments
+ *
+ * ```typescript
+ * const env = getTestHre({ networkName: "bsc-testnet", config: "./hardhat.config.other.ts" });
+ * ```
+ *
+ * @returns {HardhatRuntimeEnvironment}
+ */
+export const getTestHre = (args: Partial<HardhatArguments>): HardhatRuntimeEnvironment => {
+    const context = HardhatContext.getHardhatContext()
+    const environment = context.getHardhatRuntimeEnvironment()
+
+    const hardhatArguments: HardhatArguments = { ...environment.hardhatArguments, ...args }
+    const { resolvedConfig, userConfig } = loadConfigAndTasks(hardhatArguments)
+
+    return new HardhatRuntimeEnvironmentImplementation(
+        resolvedConfig,
+        hardhatArguments,
+        environment.tasks,
+        environment.scopes,
+        context.environmentExtenders,
+        context.experimentalHardhatNetworkMessageTraceHooks,
+        userConfig,
+        context.providerExtenders
+        // This is a bit annoying - the environmentExtenders are not stronly typed
+        // so TypeScript complains that the properties required by HardhatRuntimeEnvironment
+        // are not present on HardhatRuntimeEnvironmentImplementation
+    ) as unknown as HardhatRuntimeEnvironment
+}

--- a/tests/test-devtools-evm-hardhat/tsconfig.json
+++ b/tests/test-devtools-evm-hardhat/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.json",
+  "exclude": ["dist", "node_modules"],
+  "include": ["src"],
+  "compilerOptions": {
+    "types": ["node"],
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  }
+}

--- a/tests/test-devtools-evm-hardhat/tsup.config.ts
+++ b/tests/test-devtools-evm-hardhat/tsup.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from 'tsup'
+
+export default defineConfig({
+    entry: ['src/index.ts'],
+    outDir: './dist',
+    clean: true,
+    dts: true,
+    sourcemap: true,
+    splitting: false,
+    treeshake: true,
+    format: ['esm', 'cjs'],
+})


### PR DESCRIPTION
### In this PR

- Add `test-devtools-evm-hardhat` test package, containing test helpers for hardhat environments. At the moment there's only one helper - `getTestHre` - that allows you to get a `HardhatRuntimeEnvironment` with specific arguments. This is useful when you want to test a task using e.g. different `hardhat.config` files

```typescript
// Create a runtime environment using specific parameters, e.g. a different config file
const hreWithAnotherConfig = getTestHre({ config: './path/to/some/other/hardhat.config.ts' })

// The task will be run using the config specified
await  hreWithAnotherConfig.run('some:task', {})
```