### PR TITLE
🧪 See if we can run tests in parallel

### DIFF
--- a/tests/ua-devtools-evm-hardhat-test/account.config.ts
+++ b/tests/ua-devtools-evm-hardhat-test/account.config.ts
@@ -1,0 +1,13 @@
+import type { HDAccountsUserConfig } from 'hardhat/types'
+
+const MNEMONIC = process.env.MNEMONIC ?? ''
+
+const account: HDAccountsUserConfig = {
+    mnemonic: MNEMONIC,
+    // We'll offset the initial index for the accounts by 10
+    // for every test project so that the project can use 10 accounts
+    // without getting any nonce race conditions with other test runs
+    initialIndex: 10,
+}
+
+export default account

--- a/tests/ua-devtools-evm-hardhat-test/hardhat.config.ts
+++ b/tests/ua-devtools-evm-hardhat-test/hardhat.config.ts
@@ -7,7 +7,7 @@ import type { HardhatUserConfig } from 'hardhat/types'
 // using your own keyboard (using exposed networks)
 import './tasks'
 
-const MNEMONIC = process.env.MNEMONIC ?? ''
+import account from './account.config'
 
 /**
  * This is a dummy hardhat config that enables us to test
@@ -27,13 +27,7 @@ const config: HardhatUserConfig = {
             //
             // See root README.md for usage with exposed network
             url: process.env.NETWORK_URL_VENGABOYS ?? 'http://localhost:10001',
-            accounts: {
-                mnemonic: MNEMONIC,
-                // We'll offset the initial index for the accounts by 10
-                // for every test project so that the project can use 10 accounts
-                // without getting any nonce race conditions with other test runs
-                initialIndex: 10,
-            },
+            accounts: account,
         },
         britney: {
             eid: EndpointId.AVALANCHE_V2_MAINNET,
@@ -44,13 +38,7 @@ const config: HardhatUserConfig = {
             //
             // See root README.md for usage with exposed network
             url: process.env.NETWORK_URL_BRITNEY ?? 'http://localhost:10002',
-            accounts: {
-                mnemonic: MNEMONIC,
-                // We'll offset the initial index for the accounts by 10
-                // for every test project so that the project can use 10 accounts
-                // without getting any nonce race conditions with other test runs
-                initialIndex: 10,
-            },
+            accounts: account,
         },
     },
 }

--- a/tests/ua-devtools-evm-hardhat-test/package.json
+++ b/tests/ua-devtools-evm-hardhat-test/package.json
@@ -13,7 +13,7 @@
     "clean": "rm -rf artifacts cache deployments",
     "compile": "$npm_execpath hardhat compile",
     "lint": "$npm_execpath eslint '**/*.{js,ts,json}'",
-    "test": "jest --runInBand --forceExit"
+    "test": "jest --forceExit"
   },
   "devDependencies": {
     "@babel/core": "^7.23.7",

--- a/tests/ua-devtools-evm-hardhat-test/test/endpoint/config.test.ts
+++ b/tests/ua-devtools-evm-hardhat-test/test/endpoint/config.test.ts
@@ -5,6 +5,11 @@ import { EndpointId } from '@layerzerolabs/lz-definitions'
 import { deployEndpoint, getDefaultUlnConfig, setupDefaultEndpoint } from '../__utils__/endpoint'
 import { createEndpointFactory, createUln302Factory } from '@layerzerolabs/protocol-devtools-evm'
 
+jest.mock('../../account.config.ts', () => ({
+    ...jest.requireActual('../../account.config.ts').default,
+    initialIndex: 19,
+}))
+
 describe('endpoint/config', () => {
     const ethEndpoint = { eid: EndpointId.ETHEREUM_V2_MAINNET, contractName: 'EndpointV2' }
     const ethReceiveUln = { eid: EndpointId.ETHEREUM_V2_MAINNET, contractName: 'ReceiveUln302' }

--- a/tests/ua-devtools-evm-hardhat-test/test/oapp/check.test.ts
+++ b/tests/ua-devtools-evm-hardhat-test/test/oapp/check.test.ts
@@ -7,6 +7,12 @@ import { deployOApp } from '../__utils__/oapp'
 import { deployEndpoint, setupDefaultEndpoint } from '../__utils__/endpoint'
 import { checkOAppPeers } from '@layerzerolabs/ua-devtools'
 import { omniContractToPoint } from '@layerzerolabs/devtools-evm'
+
+jest.mock('../../account.config.ts', () => ({
+    ...jest.requireActual('../../account.config.ts').default,
+    initialIndex: 18,
+}))
+
 describe('oapp/check', () => {
     const ethPointHardhat = { eid: EndpointId.ETHEREUM_V2_MAINNET, contractName: 'DefaultOApp' }
     const avaxPointHardhat = { eid: EndpointId.AVALANCHE_V2_MAINNET, contractName: 'DefaultOApp' }

--- a/tests/ua-devtools-evm-hardhat-test/test/oapp/config.test.ts
+++ b/tests/ua-devtools-evm-hardhat-test/test/oapp/config.test.ts
@@ -25,6 +25,11 @@ import {
     deployEndpoint,
 } from '../__utils__/endpoint'
 
+jest.mock('../../account.config.ts', () => ({
+    ...jest.requireActual('../../account.config.ts').default,
+    initialIndex: 17,
+}))
+
 describe('oapp/config', () => {
     const ethPointHardhat = { eid: EndpointId.ETHEREUM_V2_MAINNET, contractName: 'DefaultOApp' }
     const avaxPointHardhat = { eid: EndpointId.AVALANCHE_V2_MAINNET, contractName: 'DefaultOApp' }

--- a/tests/ua-devtools-evm-hardhat-test/test/omnicounter/options.test.ts
+++ b/tests/ua-devtools-evm-hardhat-test/test/omnicounter/options.test.ts
@@ -79,6 +79,11 @@ const composedIndexArbitrary: fc.Arbitrary<number> = fc.integer({ min: MIN_COMPO
  */
 const applyPremium = (input: bigint) => (BigInt(input) * BigInt(110)) / BigInt(100)
 
+jest.mock('../../account.config.ts', () => ({
+    ...jest.requireActual('../../account.config.ts').default,
+    initialIndex: 16,
+}))
+
 // Test the OApp options using the OmniCounter OApp as the test contract.
 describe('oapp/options', () => {
     const ethOmniCounter = { eid: EndpointId.ETHEREUM_V2_MAINNET, contractName: 'OmniCounter' }

--- a/tests/ua-devtools-evm-hardhat-test/test/task/oapp/config.check.test.ts
+++ b/tests/ua-devtools-evm-hardhat-test/test/task/oapp/config.check.test.ts
@@ -5,6 +5,11 @@ import { deployOApp } from '../../__utils__/oapp'
 import { TASK_LZ_OAPP_CONFIG_CHECK, TASK_LZ_OAPP_WIRE } from '@layerzerolabs/ua-devtools-evm-hardhat'
 import { deployEndpoint, setupDefaultEndpoint } from '../../__utils__/endpoint'
 
+jest.mock('../../../account.config.ts', () => ({
+    ...jest.requireActual('../../../account.config.ts').default,
+    initialIndex: 15,
+}))
+
 describe(`task ${TASK_LZ_OAPP_CONFIG_CHECK}`, () => {
     const CONFIGS_BASE_DIR = resolve(__dirname, '__data__', 'configs')
     const configPathFixture = (fileName: string): string => {

--- a/tests/ua-devtools-evm-hardhat-test/test/task/oapp/config.get.default.test.ts
+++ b/tests/ua-devtools-evm-hardhat-test/test/task/oapp/config.get.default.test.ts
@@ -9,6 +9,11 @@ import hre from 'hardhat'
 import { TASK_LZ_OAPP_CONFIG_GET_DEFAULT } from '@layerzerolabs/ua-devtools-evm-hardhat'
 import { omniContractToPoint } from '@layerzerolabs/devtools-evm'
 
+jest.mock('../../../account.config.ts', () => ({
+    ...jest.requireActual('../../../account.config.ts').default,
+    initialIndex: 14,
+}))
+
 describe(`task ${TASK_LZ_OAPP_CONFIG_GET_DEFAULT}`, () => {
     beforeEach(async () => {
         await deployEndpoint()

--- a/tests/ua-devtools-evm-hardhat-test/test/task/oapp/config.get.test.ts
+++ b/tests/ua-devtools-evm-hardhat-test/test/task/oapp/config.get.test.ts
@@ -10,6 +10,11 @@ import { AddressZero } from '@ethersproject/constants'
 import { TASK_LZ_OAPP_CONFIG_GET } from '@layerzerolabs/ua-devtools-evm-hardhat'
 import { omniContractToPoint } from '@layerzerolabs/devtools-evm'
 
+jest.mock('../../../account.config.ts', () => ({
+    ...jest.requireActual('../../../account.config.ts').default,
+    initialIndex: 13,
+}))
+
 describe(`task ${TASK_LZ_OAPP_CONFIG_GET}`, () => {
     beforeEach(async () => {
         await deployEndpoint()

--- a/tests/ua-devtools-evm-hardhat-test/test/task/oapp/init.test.ts
+++ b/tests/ua-devtools-evm-hardhat-test/test/task/oapp/init.test.ts
@@ -11,6 +11,11 @@ jest.mock('@layerzerolabs/io-devtools', () => {
     }
 })
 
+jest.mock('../../../account.config.ts', () => ({
+    ...jest.requireActual('../../../account.config.ts').default,
+    initialIndex: 12,
+}))
+
 const promptToContinueMock = promptToContinue as jest.Mock
 
 describe(`task ${TASK_LZ_OAPP_CONFIG_INIT}`, () => {

--- a/tests/ua-devtools-evm-hardhat-test/test/task/oapp/wire.test.ts
+++ b/tests/ua-devtools-evm-hardhat-test/test/task/oapp/wire.test.ts
@@ -16,6 +16,11 @@ jest.mock('@layerzerolabs/io-devtools', () => {
     }
 })
 
+jest.mock('../../../account.config.ts', () => ({
+    ...jest.requireActual('../../../account.config.ts').default,
+    initialIndex: 11,
+}))
+
 const promptToContinueMock = promptToContinue as jest.Mock
 
 describe(`task ${TASK_LZ_OAPP_WIRE}`, () => {


### PR DESCRIPTION
### In this PR

Investigation of possibilities of parallel E2E test runs. The only blocking factor was the fact that the same signers were used in all the tests and the nonces started causing issues. 

This PR addresses the issue by adjusting the `initialIndex` property of the `accounts` config for `hardhat`. In order to minimize the amount of mocking code, the `accounts` config has been taken out of `hardhat.config.ts` and placed in an individual file. This way we can mock it using `jest.mock` quite easily.

#### Pros

- A relatively short snippet of code in every test file (could still be reduced by introducing a simple utility if `jest` allows it - usually the calls to `jest.mock` etc needed to be hardcoded in the test file)
- No code changes needed for `hardhat.config.ts` - no need to introduce any callbacks or test code into our configuration
- No code changes needed for the tested code

#### Cons

- A snippet of code in every test file
- We need to coordinate the `initialIndex` field across the test suites