### PR TITLE
🪚 Setup foundry in github action

### DIFF
--- a/.github/workflows/actions/setup-environment/action.yaml
+++ b/.github/workflows/actions/setup-environment/action.yaml
@@ -14,3 +14,6 @@ runs:
       with:
         node-version-file: ".nvmrc"
         cache: "pnpm"
+
+    - name: Setup Foundry
+      uses: foundry-rs/foundry-toolchain@v1


### PR DESCRIPTION
### In this PR

- Setting up `foundry` in the github action. This is one of two possible approaches to having `forge-std` in our repo:
  1. Install `forge-std` in the `prepare` script. This way we don't keep the `lib` directory in our repo, we always create a new one when the project / example is installed
    - Turns out this might be the way to go. The way our CLI works it will not download the submodules (and it does not support them atm) PLUS it's super cumbersome to install the submodules in github actions 
  3. Add the `lib` directory with `forge-std` as a git submodule 