### PR TITLE
🧹 Disable lint warnings for tests

### DIFF
--- a/packages/devtools/test/common/map.test.ts
+++ b/packages/devtools/test/common/map.test.ts
@@ -23,7 +23,9 @@ describe('common/map', () => {
         const valueArbitrary = fc.anything()
 
         describe.each(testCases)(`for %s`, (_, keyArbitrary, hash) => {
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
             class TestMap extends AbstractMap<any, any> {
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
                 protected override hash(key: any) {
                     return hash(key)
                 }


### PR DESCRIPTION
### In this PR

- Disable ESLint warnings about `any` type used in a test file. The other solution would require a very overkill solution with complex generics, way too much for a test case