### PR TITLE
🚧 Fix error output when deploying EndpointV2 in tests

### DIFF
--- a/tests/ua-devtools-evm-hardhat-test/test/__utils__/endpoint.ts
+++ b/tests/ua-devtools-evm-hardhat-test/test/__utils__/endpoint.ts
@@ -534,9 +534,7 @@ export const setupDefaultEndpoint = async (): Promise<void> => {
     if (errors.length === 0) return
 
     const errorParser = await createErrorParser()
-    const parsedErrors = await Promise.all(
-        errors.map(({ error, transaction: { point } }) => errorParser({ error, point }))
-    )
+    const parsedErrors = await Promise.all(errors.map(({ error }) => errorParser(error)))
 
     throw new Error(`Endpoint deployment failed:\n\n${parsedErrors.join('\n')}`)
 }


### PR DESCRIPTION
### In this PR

- Incorrect object was being passed to the error parser when deploying the test `EndpointV2`. This fixes it which means the correct (in most cases decoded custom) error is being displayed if anything goes wrong in the tests