### PR TITLE
🚧 Preinstall solc to avoid parallel execution errors

### DIFF
--- a/.github/workflows/actions/setup-build-cache/action.yaml
+++ b/.github/workflows/actions/setup-build-cache/action.yaml
@@ -27,3 +27,15 @@ runs:
         restore-keys: |
           ${{ runner.os }}-hardhat-${{ github.ref_name }}-
           ${{ runner.os }}-hardhat-
+
+    # Cache foundry compilers
+    #
+    # This step will speed up workflow runs that use hardhat compilation
+    - name: Cache foundry compilers
+      uses: actions/cache@v3
+      with:
+        path: ~/.svm
+        key: ${{ runner.os }}-foundry-${{ github.ref_name }}-${{ github.sha }}
+        restore-keys: |
+          ${{ runner.os }}-foundry-${{ github.ref_name }}-
+          ${{ runner.os }}-foundry-


### PR DESCRIPTION
### In this PR

- Preinstall `solc` using `svm` so that we avoid `Text file busy` errors caused by two processes trying to install `solc` at the same time ([issue here](https://github.com/foundry-rs/foundry/issues/4736)). This though is time-intensive since we need to install both `rust`/`cargo` and `svm` when building the image