### PR TITLE
🚧 Make test-devtools-evm-hardhat public

### DIFF
--- a/tests/test-devtools-evm-hardhat/package.json
+++ b/tests/test-devtools-evm-hardhat/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@layerzerolabs/test-devtools-evm-hardhat",
   "version": "0.0.4",
-  "private": true,
   "description": "Helpers for testing LayerZero EVM contracts using hardhat",
   "repository": {
     "type": "git",
@@ -50,5 +49,8 @@
   "peerDependencies": {
     "hardhat": "^2.19.4",
     "solidity-bytes-utils": "^0.8.2"
+  },
+  "publishConfig": {
+    "access": "restricted"
   }
 }


### PR DESCRIPTION
### In this PR

- Since `test-devtools-evm-hardhat` now contains the `EndpointV2Mock`, we'll publish it along with the rest of the packages