### PR TITLE
🚧 Install dependencies even if we don't need them to avoid a post-setup failure

### DIFF
--- a/.github/workflows/reusable-test.yaml
+++ b/.github/workflows/reusable-test.yaml
@@ -89,6 +89,9 @@ jobs:
       - name: Setup environment
         uses: ./.github/workflows/actions/setup-environment
 
+      - name: Install dependencies
+        uses: ./.github/workflows/actions/install-dependencies
+
       - name: Test
         run: pnpm test:user
 


### PR DESCRIPTION
### In this PR

- Install NPM dependencies for the user testing action even if we don't need them. This is just to use the cache location and work around this (still open) [issue with caching action](https://github.com/actions/setup-node/issues/801)