### PR TITLE
🚧 Ignore nested deployments, artifacts & cache to prevent the local environment to interact with containerized tests

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -16,13 +16,14 @@ docker-*.yaml
 *ignore
 
 # Dependencies & deployments
-node_modules
-deployments
+**/node_modules
 
 # Build files & cache
-artifacts
-dist
-cache
+**/deployments
+**/dist
+**/artifacts
+**/cache
+**/out
 
 # Metadata
 *.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -71,8 +71,6 @@ RUN \
     #  Mount pnpm store
     --mount=type=cache,id=pnpm-store,target=/pnpm \
     # Fetch dependencies to the pnpm store based on the lockfile
-    # 
-    # We will also skip the package scripts since in this operation the NPM_TOKEN is available
     pnpm fetch --prefer-offline --frozen-lockfile
 
 COPY . .


### PR DESCRIPTION
### In this PR

- Make sure to ignore all nested build artifact folders to prevent the local changes from interacting with the containerized tests. This caused a situation where an existing `deployments` directory created by deploying an `OApp` locally was copied into the containerized environment and was causing cryptic errors since transactions were being sent to non-existent contracts
- Remove forgotten line about NPM_TOKEN in `Dockerfile`