### PR TITLE
🚧 Restore explicit dependency of OFT example compilation on OApp example compilation

### DIFF
--- a/examples/oft/turbo.json
+++ b/examples/oft/turbo.json
@@ -1,0 +1,9 @@
+{
+  "extends": ["//"],
+  "pipeline": {
+    "compile": {
+      "dependsOn": ["@layerzerolabs/oapp-example#compile"],
+      "description": "We include this dependency to make sure that the compilation is executed in series to avoid race conditions with solc compilers in foundry"
+    }
+  }
+}


### PR DESCRIPTION
### In this PR

- Restoring the workaround for parallel foundry compilation in OFT example that got removed when adding serial compilation
