### PR TITLE
🚀 Publish packages publicly

### DIFF
--- a/.changeset/mighty-gifts-own.md
+++ b/.changeset/mighty-gifts-own.md
@@ -1,0 +1,20 @@
+---
+"@layerzerolabs/test-devtools-evm-foundry": minor
+"@layerzerolabs/test-devtools-evm-hardhat": minor
+"@layerzerolabs/omnicounter-devtools-evm": minor
+"@layerzerolabs/ua-devtools-evm-hardhat": minor
+"@layerzerolabs/protocol-devtools-evm": minor
+"@layerzerolabs/devtools-evm-hardhat": minor
+"@layerzerolabs/omnicounter-devtools": minor
+"@layerzerolabs/protocol-devtools": minor
+"@layerzerolabs/toolbox-foundry": minor
+"@layerzerolabs/toolbox-hardhat": minor
+"@layerzerolabs/ua-devtools-evm": minor
+"@layerzerolabs/test-devtools": minor
+"@layerzerolabs/devtools-evm": minor
+"@layerzerolabs/io-devtools": minor
+"@layerzerolabs/ua-devtools": minor
+"@layerzerolabs/devtools": minor
+---
+
+Make packages public

--- a/packages/devtools-evm-hardhat/package.json
+++ b/packages/devtools-evm-hardhat/package.json
@@ -88,6 +88,6 @@
     "hardhat-deploy": "^0.11.45"
   },
   "publishConfig": {
-    "access": "restricted"
+    "access": "public"
   }
 }

--- a/packages/devtools-evm/package.json
+++ b/packages/devtools-evm/package.json
@@ -77,6 +77,6 @@
     "zod": "^3.22.4"
   },
   "publishConfig": {
-    "access": "restricted"
+    "access": "public"
   }
 }

--- a/packages/devtools/package.json
+++ b/packages/devtools/package.json
@@ -54,6 +54,6 @@
     "zod": "^3.22.4"
   },
   "publishConfig": {
-    "access": "restricted"
+    "access": "public"
   }
 }

--- a/packages/io-devtools/package.json
+++ b/packages/io-devtools/package.json
@@ -86,6 +86,6 @@
     }
   },
   "publishConfig": {
-    "access": "restricted"
+    "access": "public"
   }
 }

--- a/packages/omnicounter-devtools-evm/package.json
+++ b/packages/omnicounter-devtools-evm/package.json
@@ -62,6 +62,6 @@
     "zod": "^3.22.4"
   },
   "publishConfig": {
-    "access": "restricted"
+    "access": "public"
   }
 }

--- a/packages/omnicounter-devtools/package.json
+++ b/packages/omnicounter-devtools/package.json
@@ -50,6 +50,6 @@
     "zod": "^3.22.4"
   },
   "publishConfig": {
-    "access": "restricted"
+    "access": "public"
   }
 }

--- a/packages/protocol-devtools-evm/package.json
+++ b/packages/protocol-devtools-evm/package.json
@@ -77,6 +77,6 @@
     "zod": "^3.22.4"
   },
   "publishConfig": {
-    "access": "restricted"
+    "access": "public"
   }
 }

--- a/packages/protocol-devtools/package.json
+++ b/packages/protocol-devtools/package.json
@@ -51,6 +51,6 @@
     "zod": "^3.22.4"
   },
   "publishConfig": {
-    "access": "restricted"
+    "access": "public"
   }
 }

--- a/packages/test-devtools-evm-foundry/package.json
+++ b/packages/test-devtools-evm-foundry/package.json
@@ -34,6 +34,6 @@
     "@openzeppelin/contracts-upgradeable": "^4.9.5"
   },
   "publishConfig": {
-    "access": "restricted"
+    "access": "public"
   }
 }

--- a/packages/test-devtools-evm-hardhat/package.json
+++ b/packages/test-devtools-evm-hardhat/package.json
@@ -51,6 +51,6 @@
     "solidity-bytes-utils": "^0.8.2"
   },
   "publishConfig": {
-    "access": "restricted"
+    "access": "public"
   }
 }

--- a/packages/test-devtools/package.json
+++ b/packages/test-devtools/package.json
@@ -41,6 +41,6 @@
     "fast-check": "^3.14.0"
   },
   "publishConfig": {
-    "access": "restricted"
+    "access": "public"
   }
 }

--- a/packages/toolbox-foundry/package.json
+++ b/packages/toolbox-foundry/package.json
@@ -26,6 +26,6 @@
     "typescript": "^5.3.3"
   },
   "publishConfig": {
-    "access": "restricted"
+    "access": "public"
   }
 }

--- a/packages/toolbox-hardhat/package.json
+++ b/packages/toolbox-hardhat/package.json
@@ -74,6 +74,6 @@
     "hardhat-deploy": "^0.11.45"
   },
   "publishConfig": {
-    "access": "restricted"
+    "access": "public"
   }
 }

--- a/packages/ua-devtools-evm-hardhat/package.json
+++ b/packages/ua-devtools-evm-hardhat/package.json
@@ -85,6 +85,6 @@
     "hardhat-deploy": "^0.11.45"
   },
   "publishConfig": {
-    "access": "restricted"
+    "access": "public"
   }
 }

--- a/packages/ua-devtools-evm/package.json
+++ b/packages/ua-devtools-evm/package.json
@@ -70,6 +70,6 @@
     "zod": "^3.22.4"
   },
   "publishConfig": {
-    "access": "restricted"
+    "access": "public"
   }
 }

--- a/packages/ua-devtools/package.json
+++ b/packages/ua-devtools/package.json
@@ -55,6 +55,6 @@
     "zod": "^3.22.4"
   },
   "publishConfig": {
-    "access": "restricted"
+    "access": "public"
   }
 }


### PR DESCRIPTION
### In this PR

- Set the package access to `public`
- Bump our very first minor version, `0.1.0`

**IMPORTANT** The versioning PR might try to bump the versions of dependents to `1.0.0` due to how strict semver works. In strict semver, when we are in `0.X.X` range, patch bump is equivalent to minor bump and minor bump is equivalent to major bump. Once the versioning PR is ready, we might need to adjust this **so please once this is merge, take your time reviewing the versioning**