### PR TITLE
🪚 Enable user tests for create-lz-oapp

### DIFF
--- a/.changeset/fast-keys-joke.md
+++ b/.changeset/fast-keys-joke.md
@@ -1,0 +1,5 @@
+---
+"create-lz-oapp": patch
+---
+
+Update repository URL

--- a/.changeset/plenty-cars-jam.md
+++ b/.changeset/plenty-cars-jam.md
@@ -1,0 +1,6 @@
+---
+"@layerzerolabs/oapp-example": patch
+"@layerzerolabs/oft-example": patch
+---
+
+Fix compile & tests scripts for npm

--- a/.github/workflows/reusable-test.yaml
+++ b/.github/workflows/reusable-test.yaml
@@ -81,7 +81,7 @@ jobs:
 
   test-user:
     name: User test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-m
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4

--- a/.github/workflows/reusable-test.yaml
+++ b/.github/workflows/reusable-test.yaml
@@ -81,7 +81,7 @@ jobs:
 
   test-user:
     name: User test
-    runs-on: ubuntu-latest-m
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4

--- a/docker-compose.registry.yaml
+++ b/docker-compose.registry.yaml
@@ -84,7 +84,7 @@ services:
     # If these are not provided, for example if running on a local machine,
     # we'll default them to our repository and and empty ref
     environment:
-      - LAYERZERO_EXAMPLES_REPOSITORY_URL=git@github.com:${GITHUB_REPOSITORY:-LayerZero-Labs/devtools}
+      - LAYERZERO_EXAMPLES_REPOSITORY_URL=https://github.com/${GITHUB_REPOSITORY:-LayerZero-Labs/devtools}.git
       - LAYERZERO_EXAMPLES_REPOSITORY_REF=${GITHUB_REF_NAME}
     working_dir: /app
     command:

--- a/docker-compose.registry.yaml
+++ b/docker-compose.registry.yaml
@@ -93,6 +93,9 @@ services:
       - |
         pnpm config set registry http://npm-registry:4873/
 
+        echo "create-lz-oapp:repository   $LAYERZERO_EXAMPLES_REPOSITORY_URL"
+        echo "create-lz-oapp:ref          $LAYERZERO_EXAMPLES_REPOSITORY_REF"
+
         /app/tests-user/lib/bats-core/bin/bats --verbose-run --recursive ./tests-user/tests
     volumes:
       # If we want to clone from github.com, we'll need its public keys added to our SSH config

--- a/examples/oapp/.eslintignore
+++ b/examples/oapp/.eslintignore
@@ -3,3 +3,5 @@ cache
 dist
 node_modules
 out
+*.sol
+*.yaml

--- a/examples/oapp/.eslintignore
+++ b/examples/oapp/.eslintignore
@@ -3,5 +3,8 @@ cache
 dist
 node_modules
 out
+*.log
 *.sol
 *.yaml
+*.lock
+package-lock.json

--- a/examples/oapp/.prettierignore
+++ b/examples/oapp/.prettierignore
@@ -3,3 +3,6 @@ cache/
 dist/
 node_modules/
 out/
+*.log
+*ignore
+*.yaml

--- a/examples/oapp/.prettierignore
+++ b/examples/oapp/.prettierignore
@@ -6,3 +6,5 @@ out/
 *.log
 *ignore
 *.yaml
+*.lock
+package-lock.json

--- a/examples/oapp/README.md
+++ b/examples/oapp/README.md
@@ -44,10 +44,10 @@ pnpm compile:hardhat
 Or adjust the `package.json` to for example remove `forge` build:
 
 ```diff
-- "compile": "$npm_execpath compile:forge && $npm_execpath compile:hardhat",
+- "compile": "$npm_execpath run compile:forge && $npm_execpath run compile:hardhat",
 - "compile:forge": "forge build",
-- "compile:hardhat": "$npm_execpath hardhat compile",
-+ "compile": "$npm_execpath hardhat compile"
+- "compile:hardhat": "hardhat compile",
++ "compile": "hardhat compile"
 ```
 
 #### Running tests

--- a/examples/oapp/package.json
+++ b/examples/oapp/package.json
@@ -5,14 +5,14 @@
   "license": "MIT",
   "scripts": {
     "clean": "rm -rf artifacts cache out",
-    "compile": "$npm_execpath compile:forge && $npm_execpath compile:hardhat",
+    "compile": "$npm_execpath run compile:forge && $npm_execpath run compile:hardhat",
     "compile:forge": "forge build",
     "compile:hardhat": "$npm_execpath hardhat compile",
     "lint": "$npm_execpath lint:js && $npm_execpath lint:sol",
     "lint:fix": "$npm_execpath prettier --write . && solhint 'contracts/**/*.sol' --fix --noPrompt",
     "lint:js": "$npm_execpath eslint '**/*.js' && $npm_execpath prettier --check .",
     "lint:sol": "solhint 'contracts/**/*.sol'",
-    "test": "$npm_execpath test:forge && $npm_execpath test:hardhat",
+    "test": "$npm_execpath run test:forge && $npm_execpath run test:hardhat",
     "test:forge": "forge test",
     "test:hardhat": "$npm_execpath hardhat test"
   },

--- a/examples/oapp/package.json
+++ b/examples/oapp/package.json
@@ -7,14 +7,14 @@
     "clean": "rm -rf artifacts cache out",
     "compile": "$npm_execpath run compile:forge && $npm_execpath run compile:hardhat",
     "compile:forge": "forge build",
-    "compile:hardhat": "$npm_execpath hardhat compile",
-    "lint": "$npm_execpath lint:js && $npm_execpath lint:sol",
-    "lint:fix": "$npm_execpath prettier --write . && solhint 'contracts/**/*.sol' --fix --noPrompt",
-    "lint:js": "$npm_execpath eslint '**/*.js' && $npm_execpath prettier --check .",
+    "compile:hardhat": "hardhat compile",
+    "lint": "$npm_execpath run lint:js && $npm_execpath run lint:sol",
+    "lint:fix": "eslint --fix '**/*.js' && prettier --write . && solhint 'contracts/**/*.sol' --fix --noPrompt",
+    "lint:js": "eslint '**/*.js' && prettier --check .",
     "lint:sol": "solhint 'contracts/**/*.sol'",
     "test": "$npm_execpath run test:forge && $npm_execpath run test:hardhat",
     "test:forge": "forge test",
-    "test:hardhat": "$npm_execpath hardhat test"
+    "test:hardhat": "hardhat test"
   },
   "devDependencies": {
     "@babel/core": "^7.23.7",

--- a/examples/oft/.eslintignore
+++ b/examples/oft/.eslintignore
@@ -3,3 +3,5 @@ cache
 dist
 node_modules
 out
+*.sol
+*.yaml

--- a/examples/oft/.eslintignore
+++ b/examples/oft/.eslintignore
@@ -3,5 +3,8 @@ cache
 dist
 node_modules
 out
+*.log
 *.sol
 *.yaml
+*.lock
+package-lock.json

--- a/examples/oft/.prettierignore
+++ b/examples/oft/.prettierignore
@@ -3,3 +3,6 @@ cache/
 dist/
 node_modules/
 out/
+*.log
+*ignore
+*.yaml

--- a/examples/oft/.prettierignore
+++ b/examples/oft/.prettierignore
@@ -6,3 +6,5 @@ out/
 *.log
 *ignore
 *.yaml
+*.lock
+package-lock.json

--- a/examples/oft/README.md
+++ b/examples/oft/README.md
@@ -44,10 +44,10 @@ pnpm compile:hardhat
 Or adjust the `package.json` to for example remove `forge` build:
 
 ```diff
-- "compile": "$npm_execpath compile:forge && $npm_execpath compile:hardhat",
+- "compile": "$npm_execpath run compile:forge && $npm_execpath run compile:hardhat",
 - "compile:forge": "forge build",
-- "compile:hardhat": "$npm_execpath hardhat compile",
-+ "compile": "$npm_execpath hardhat compile"
+- "compile:hardhat": "hardhat compile",
++ "compile": "hardhat compile"
 ```
 
 #### Running tests

--- a/examples/oft/package.json
+++ b/examples/oft/package.json
@@ -4,14 +4,14 @@
   "private": true,
   "license": "MIT",
   "scripts": {
-    "compile": "$npm_execpath compile:forge && $npm_execpath compile:hardhat",
+    "compile": "$npm_execpath run compile:forge && $npm_execpath run compile:hardhat",
     "compile:forge": "forge build",
     "compile:hardhat": "$npm_execpath hardhat compile",
     "lint": "$npm_execpath lint:js && $npm_execpath lint:sol",
     "lint:fix": "$npm_execpath prettier --write . && solhint 'contracts/**/*.sol' --fix --noPrompt",
     "lint:js": "$npm_execpath eslint '**/*.js' && $npm_execpath prettier --check .",
     "lint:sol": "solhint 'contracts/**/*.sol'",
-    "test": "$npm_execpath test:forge && $npm_execpath test:hardhat",
+    "test": "$npm_execpath run test:forge && $npm_execpath run test:hardhat",
     "test:forge": "forge test",
     "test:hardhat": "$npm_execpath hardhat test"
   },

--- a/examples/oft/package.json
+++ b/examples/oft/package.json
@@ -4,16 +4,17 @@
   "private": true,
   "license": "MIT",
   "scripts": {
+    "clean": "rm -rf artifacts cache out",
     "compile": "$npm_execpath run compile:forge && $npm_execpath run compile:hardhat",
     "compile:forge": "forge build",
-    "compile:hardhat": "$npm_execpath hardhat compile",
-    "lint": "$npm_execpath lint:js && $npm_execpath lint:sol",
-    "lint:fix": "$npm_execpath prettier --write . && solhint 'contracts/**/*.sol' --fix --noPrompt",
-    "lint:js": "$npm_execpath eslint '**/*.js' && $npm_execpath prettier --check .",
+    "compile:hardhat": "hardhat compile",
+    "lint": "$npm_execpath run lint:js && $npm_execpath run lint:sol",
+    "lint:fix": "eslint --fix '**/*.js' && prettier --write . && solhint 'contracts/**/*.sol' --fix --noPrompt",
+    "lint:js": "eslint '**/*.js' && prettier --check .",
     "lint:sol": "solhint 'contracts/**/*.sol'",
     "test": "$npm_execpath run test:forge && $npm_execpath run test:hardhat",
     "test:forge": "forge test",
-    "test:hardhat": "$npm_execpath hardhat test"
+    "test:hardhat": "hardhat test"
   },
   "devDependencies": {
     "@babel/core": "^7.23.7",

--- a/packages/create-lz-oapp/src/config.ts
+++ b/packages/create-lz-oapp/src/config.ts
@@ -5,7 +5,7 @@ import { isPackageManagerAvailable } from './utilities/installation'
  * To enable example development in a custom repository
  * we open the repository URL field to be taken from the environment
  */
-const repository = process.env['LAYERZERO_EXAMPLES_REPOSITORY_URL'] || 'git@github.com:LayerZero-Labs/devtools'
+const repository = process.env['LAYERZERO_EXAMPLES_REPOSITORY_URL'] || 'https://github.com/LayerZero-Labs/devtools.git'
 
 /**
  * To enable example development in a custom branch,

--- a/packages/create-lz-oapp/src/utilities/cloning.ts
+++ b/packages/create-lz-oapp/src/utilities/cloning.ts
@@ -64,7 +64,7 @@ export const cloneExample = async ({ example, destination }: Config) => {
             }
         }
 
-        throw new CloningError()
+        throw new CloningError(`Unknown error: ${error}`)
     }
 }
 

--- a/tests-user/tests/create-lz-oapp.bats
+++ b/tests-user/tests/create-lz-oapp.bats
@@ -86,7 +86,6 @@ teardown() {
     local DESTINATION="$PROJECTS_DIRECTORY/pnpm-oapp"
 
     npx --yes create-lz-oapp --ci --example oapp --destination $DESTINATION --package-manager pnpm
-    assert_success
     cd "$DESTINATION"
     pnpm compile
     pnpm test

--- a/tests-user/tests/create-lz-oapp.bats
+++ b/tests-user/tests/create-lz-oapp.bats
@@ -83,7 +83,6 @@ teardown() {
 }
 
 @test "should work with pnpm & oapp example in CI mode" {
-    skip
     local DESTINATION="$PROJECTS_DIRECTORY/pnpm-oapp"
 
     npx --yes create-lz-oapp --ci --example oapp --destination $DESTINATION --package-manager pnpm
@@ -94,7 +93,6 @@ teardown() {
 }
 
 @test "should work with pnpm & oft example in CI mode" {
-    skip
     local DESTINATION="$PROJECTS_DIRECTORY/pnpm-oft"
 
     npx --yes create-lz-oapp --ci --example oft --destination $DESTINATION --package-manager pnpm
@@ -104,7 +102,6 @@ teardown() {
 }
 
 @test "should work with yarn & oapp example in CI mode" {
-    skip
     local DESTINATION="$PROJECTS_DIRECTORY/yarn-oapp"
 
     npx --yes create-lz-oapp --ci --example oapp --destination $DESTINATION --package-manager yarn
@@ -114,7 +111,6 @@ teardown() {
 }
 
 @test "should work with yarn & oft example in CI mode" {
-    skip
     local DESTINATION="$PROJECTS_DIRECTORY/yarn-oft"
 
     npx --yes create-lz-oapp --ci --example oft --destination $DESTINATION --package-manager yarn
@@ -124,7 +120,6 @@ teardown() {
 }
 
 @test "should work with npm & oapp example in CI mode" {
-    skip
     local DESTINATION="$PROJECTS_DIRECTORY/npm-oapp"
 
     npx --yes create-lz-oapp --ci --example oapp --destination $DESTINATION --package-manager npm
@@ -134,7 +129,6 @@ teardown() {
 }
 
 @test "should work with npm & oft example in CI mode" {
-    skip
     local DESTINATION="$PROJECTS_DIRECTORY/npm-oft"
 
     npx --yes create-lz-oapp --ci --example oft --destination $DESTINATION --package-manager npm

--- a/tests-user/tests/create-lz-oapp.bats
+++ b/tests-user/tests/create-lz-oapp.bats
@@ -89,6 +89,8 @@ teardown() {
     cd "$DESTINATION"
     pnpm compile
     pnpm test
+    pnpm lint
+    pnpm lint:fix
 }
 
 @test "should work with pnpm & oft example in CI mode" {
@@ -98,6 +100,8 @@ teardown() {
     cd "$DESTINATION"
     pnpm compile
     pnpm test
+    pnpm lint
+    pnpm lint:fix
 }
 
 @test "should work with yarn & oapp example in CI mode" {
@@ -107,6 +111,8 @@ teardown() {
     cd "$DESTINATION"
     yarn compile
     yarn test
+    yarn lint
+    yarn lint:fix
 }
 
 @test "should work with yarn & oft example in CI mode" {
@@ -116,6 +122,8 @@ teardown() {
     cd "$DESTINATION"
     yarn compile
     yarn test
+    yarn lint
+    yarn lint:fix
 }
 
 @test "should work with npm & oapp example in CI mode" {
@@ -125,6 +133,8 @@ teardown() {
     cd "$DESTINATION"
     npm run compile
     npm run test
+    npm run lint
+    npm run lint:fix
 }
 
 @test "should work with npm & oft example in CI mode" {
@@ -134,4 +144,6 @@ teardown() {
     cd "$DESTINATION"
     npm run compile
     npm run test
+    npm run lint
+    npm run lint:fix
 }


### PR DESCRIPTION
### In this PR

- Enable user tests for `create-lz-oapp`
- Update the repository URL to the https one (since we are public it's easier than struggling with SSH)
- Fix a typo is a test case
- Use the medium runner for the user tests since they grew after this change
- Fix `compile` and `test` scripts for examples - they were not playing nice with `npm` that requires `npm run compile` instead of `npm compile`
- Show a bit more output to the user if the cloning fails