### PR TITLE
🧹 Update cache action version

### DIFF
--- a/.github/workflows/actions/setup-build-cache/action.yaml
+++ b/.github/workflows/actions/setup-build-cache/action.yaml
@@ -8,7 +8,7 @@ runs:
     # This step will speed up workflow runs that don't touch the whole codebase
     # (or the ones that don't touch the codebase at all)
     - name: Cache turbo build setup
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: node_modules/.cache/turbo
         key: ${{ runner.os }}-turbo-${{ github.ref_name }}-${{ github.sha }}
@@ -20,7 +20,7 @@ runs:
     #
     # This step will speed up workflow runs that use hardhat compilation
     - name: Cache hardhat compilers
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: .cache/hardhat
         key: ${{ runner.os }}-hardhat-${{ github.ref_name }}-${{ github.sha }}


### PR DESCRIPTION
### In this PR

- Updating the version of `actions/cache` to `v4` since Node 16 actions have been deprecated 