### PR TITLE
🚧 Loose ends in tests

### DIFF
--- a/.github/workflows/reusable-test.yaml
+++ b/.github/workflows/reusable-test.yaml
@@ -96,6 +96,9 @@ jobs:
 
       - name: Test
         run: pnpm test:user
+        env:
+          LAYERZERO_EXAMPLES_REPOSITORY_URL: "https://github.com/${GITHUB_REPOSITORY}.git"
+          LAYERZERO_EXAMPLES_REPOSITORY_REF: ${GITHUB_REF_NAME}
 
       # We'll collect the docker compose logs from all containers on failure
       - name: Collect docker logs on failure

--- a/.github/workflows/reusable-test.yaml
+++ b/.github/workflows/reusable-test.yaml
@@ -97,7 +97,7 @@ jobs:
       - name: Test
         run: pnpm test:user
         env:
-          LAYERZERO_EXAMPLES_REPOSITORY_URL: "https://github.com/${GITHUB_REPOSITORY}.git"
+          LAYERZERO_EXAMPLES_REPOSITORY_URL: https://github.com/${GITHUB_REPOSITORY}.git
           LAYERZERO_EXAMPLES_REPOSITORY_REF: ${GITHUB_REF_NAME}
 
       # We'll collect the docker compose logs from all containers on failure

--- a/.github/workflows/reusable-test.yaml
+++ b/.github/workflows/reusable-test.yaml
@@ -97,8 +97,8 @@ jobs:
       - name: Test
         run: pnpm test:user
         env:
-          LAYERZERO_EXAMPLES_REPOSITORY_URL: https://github.com/${GITHUB_REPOSITORY}.git
-          LAYERZERO_EXAMPLES_REPOSITORY_REF: ${GITHUB_REF_NAME}
+          LAYERZERO_EXAMPLES_REPOSITORY_URL: https://github.com/${{ github.repository }}.git
+          LAYERZERO_EXAMPLES_REPOSITORY_REF: ${{ github.ref_name }}
 
       # We'll collect the docker compose logs from all containers on failure
       - name: Collect docker logs on failure

--- a/docker-compose.registry.yaml
+++ b/docker-compose.registry.yaml
@@ -84,8 +84,8 @@ services:
     # If these are not provided, for example if running on a local machine,
     # we'll default them to our repository and and empty ref
     environment:
-      - LAYERZERO_EXAMPLES_REPOSITORY_URL=https://github.com/${GITHUB_REPOSITORY:-LayerZero-Labs/devtools}.git
-      - LAYERZERO_EXAMPLES_REPOSITORY_REF=${GITHUB_REF_NAME}
+      - LAYERZERO_EXAMPLES_REPOSITORY_URL=${LAYERZERO_EXAMPLES_REPOSITORY_URL}
+      - LAYERZERO_EXAMPLES_REPOSITORY_REF=${LAYERZERO_EXAMPLES_REPOSITORY_REF}
     working_dir: /app
     command:
       - /bin/bash

--- a/docker-compose.registry.yaml
+++ b/docker-compose.registry.yaml
@@ -93,8 +93,8 @@ services:
       - |
         pnpm config set registry http://npm-registry:4873/
 
-        echo "create-lz-oapp:repository   $LAYERZERO_EXAMPLES_REPOSITORY_URL"
-        echo "create-lz-oapp:ref          $LAYERZERO_EXAMPLES_REPOSITORY_REF"
+        echo "create-lz-oapp:repository   ${LAYERZERO_EXAMPLES_REPOSITORY_URL}"
+        echo "create-lz-oapp:ref          ${LAYERZERO_EXAMPLES_REPOSITORY_REF}"
 
         /app/tests-user/lib/bats-core/bin/bats --verbose-run --recursive ./tests-user/tests
     volumes:

--- a/packages/protocol-devtools-evm/package.json
+++ b/packages/protocol-devtools-evm/package.json
@@ -32,7 +32,7 @@
     "clean": "rm -rf dist",
     "dev": "$npm_execpath tsup --watch",
     "lint": "$npm_execpath eslint '**/*.{js,ts,json}'",
-    "test": "jest --ci --forceExit --verbose"
+    "test": "jest --ci"
   },
   "dependencies": {
     "p-memoize": "~4.0.4"

--- a/packages/protocol-devtools-evm/package.json
+++ b/packages/protocol-devtools-evm/package.json
@@ -32,7 +32,7 @@
     "clean": "rm -rf dist",
     "dev": "$npm_execpath tsup --watch",
     "lint": "$npm_execpath eslint '**/*.{js,ts,json}'",
-    "test": "jest --ci"
+    "test": "jest --ci --forceExit"
   },
   "dependencies": {
     "p-memoize": "~4.0.4"

--- a/packages/protocol-devtools-evm/package.json
+++ b/packages/protocol-devtools-evm/package.json
@@ -32,7 +32,7 @@
     "clean": "rm -rf dist",
     "dev": "$npm_execpath tsup --watch",
     "lint": "$npm_execpath eslint '**/*.{js,ts,json}'",
-    "test": "jest --ci --forceExit"
+    "test": "jest --ci --forceExit --verbose"
   },
   "dependencies": {
     "p-memoize": "~4.0.4"

--- a/packages/protocol-devtools-evm/test/uln302/sdk.test.ts
+++ b/packages/protocol-devtools-evm/test/uln302/sdk.test.ts
@@ -73,7 +73,8 @@ describe('uln302/sdk', () => {
                     const ulnConfigEncodedUnsorted = ulnSdk.encodeUlnConfig(ulnConfigUnsorted)
                     const ulnConfigEncodedSorted = ulnSdk.encodeUlnConfig(ulnConfigSorted)
                     expect(ulnConfigEncodedSorted).toBe(ulnConfigEncodedUnsorted)
-                })
+                }),
+                { numRuns: 20 }
             )
         })
     })
@@ -119,7 +120,8 @@ describe('uln302/sdk', () => {
                             ],
                         ])
                     )
-                })
+                }),
+                { numRuns: 20 }
             )
         })
     })
@@ -156,7 +158,8 @@ describe('uln302/sdk', () => {
 
                         await expect(ulnSdk.hasAppUlnConfig(eid, oapp, ulnConfig)).resolves.toBeTruthy()
                     }
-                )
+                ),
+                { numRuns: 20 }
             )
         })
 
@@ -178,7 +181,8 @@ describe('uln302/sdk', () => {
                             })
                         ).resolves.toBeTruthy()
                     }
-                )
+                ),
+                { numRuns: 20 }
             )
         })
 
@@ -200,7 +204,8 @@ describe('uln302/sdk', () => {
                             })
                         ).resolves.toBeTruthy()
                     }
-                )
+                ),
+                { numRuns: 20 }
             )
         })
 
@@ -222,7 +227,8 @@ describe('uln302/sdk', () => {
                             })
                         ).resolves.toBeTruthy()
                     }
-                )
+                ),
+                { numRuns: 20 }
             )
         })
 
@@ -246,7 +252,8 @@ describe('uln302/sdk', () => {
                             })
                         ).resolves.toBeFalsy()
                     }
-                )
+                ),
+                { numRuns: 20 }
             )
         })
 
@@ -270,7 +277,8 @@ describe('uln302/sdk', () => {
                             })
                         ).resolves.toBeFalsy()
                     }
-                )
+                ),
+                { numRuns: 20 }
             )
         })
 
@@ -292,7 +300,8 @@ describe('uln302/sdk', () => {
                             })
                         ).resolves.toBeFalsy()
                     }
-                )
+                ),
+                { numRuns: 20 }
             )
         })
 
@@ -314,7 +323,8 @@ describe('uln302/sdk', () => {
                             })
                         ).resolves.toBeFalsy()
                     }
-                )
+                ),
+                { numRuns: 20 }
             )
         })
     })
@@ -347,7 +357,8 @@ describe('uln302/sdk', () => {
 
                         await expect(ulnSdk.hasAppExecutorConfig(eid, oapp, executorConfig)).resolves.toBeTruthy()
                     }
-                )
+                ),
+                { numRuns: 20 }
             )
         })
 
@@ -368,7 +379,8 @@ describe('uln302/sdk', () => {
                             })
                         ).resolves.toBeTruthy()
                     }
-                )
+                ),
+                { numRuns: 20 }
             )
         })
 
@@ -390,7 +402,8 @@ describe('uln302/sdk', () => {
                             })
                         ).resolves.toBeTruthy()
                     }
-                )
+                ),
+                { numRuns: 20 }
             )
         })
     })

--- a/packages/protocol-devtools-evm/test/uln302/sdk.test.ts
+++ b/packages/protocol-devtools-evm/test/uln302/sdk.test.ts
@@ -20,6 +20,12 @@ describe('uln302/sdk', () => {
         ulnSdk = new Uln302(omniContract)
     })
 
+    afterEach(() => {
+        contract = undefined!
+        omniContract = undefined!
+        ulnSdk = undefined!
+    })
+
     describe('encodeExecutorConfig', () => {
         it('should encode and decode the Uln302ExecutorConfig', async () => {
             const executorConfig: Uln302ExecutorConfig = { executor: AddressZero, maxMessageSize: 100 }
@@ -74,8 +80,6 @@ describe('uln302/sdk', () => {
 
     describe('setDefaultUlnConfig', () => {
         it('should sort requiredDVNs and optionalDVNs', async () => {
-            const encodeFunctionData = jest.spyOn(contract.interface, 'encodeFunctionData')
-
             await fc.assert(
                 fc.asyncProperty(endpointArbitrary, dvnsArbitrary, async (eid, dvns) => {
                     const sortedDvns = [...dvns].sort((a, b) => a.localeCompare(b))
@@ -98,21 +102,23 @@ describe('uln302/sdk', () => {
                     expect(transactionUnsorted).toEqual(transactionsSorted)
 
                     // And let's check that the encoding call is correct and the DVNs are sorted
-                    expect(encodeFunctionData).toHaveBeenLastCalledWith('setDefaultUlnConfigs', [
-                        [
-                            {
-                                eid,
-                                config: {
-                                    confirmations: BigInt(100),
-                                    optionalDVNThreshold: 0,
-                                    optionalDVNs: sortedDvns.map(addChecksum),
-                                    requiredDVNs: sortedDvns.map(addChecksum),
-                                    requiredDVNCount: sortedDvns.length,
-                                    optionalDVNCount: sortedDvns.length,
+                    expect(transactionsSorted.data).toBe(
+                        contract.interface.encodeFunctionData('setDefaultUlnConfigs', [
+                            [
+                                {
+                                    eid,
+                                    config: {
+                                        confirmations: BigInt(100),
+                                        optionalDVNThreshold: 0,
+                                        optionalDVNs: sortedDvns.map(addChecksum),
+                                        requiredDVNs: sortedDvns.map(addChecksum),
+                                        requiredDVNCount: sortedDvns.length,
+                                        optionalDVNCount: sortedDvns.length,
+                                    },
                                 },
-                            },
-                        ],
-                    ])
+                            ],
+                        ])
+                    )
                 })
             )
         })

--- a/packages/protocol-devtools-evm/test/uln302/sdk.test.ts
+++ b/packages/protocol-devtools-evm/test/uln302/sdk.test.ts
@@ -20,12 +20,6 @@ describe('uln302/sdk', () => {
         ulnSdk = new Uln302(omniContract)
     })
 
-    afterEach(() => {
-        contract = undefined!
-        omniContract = undefined!
-        ulnSdk = undefined!
-    })
-
     describe('encodeExecutorConfig', () => {
         it('should encode and decode the Uln302ExecutorConfig', async () => {
             const executorConfig: Uln302ExecutorConfig = { executor: AddressZero, maxMessageSize: 100 }


### PR DESCRIPTION
### In this PR

- Make the `Uln302` SDK tests a bit more straightforward; reduce the number of test runs to 20 not to spend 20 minutes on the test pipeline
- Move the GitHub-specific environment variables out of the compose file for user tests