### PR TITLE
🗞️ Retry helpers

### DIFF
--- a/.changeset/witty-elephants-sing.md
+++ b/.changeset/witty-elephants-sing.md
@@ -1,0 +1,5 @@
+---
+"@layerzerolabs/devtools": patch
+---
+
+Add retry helpers

--- a/packages/devtools/package.json
+++ b/packages/devtools/package.json
@@ -29,6 +29,9 @@
     "lint": "$npm_execpath eslint '**/*.{js,ts,json}'",
     "test": "jest --ci --forceExit"
   },
+  "dependencies": {
+    "exponential-backoff": "~3.1.1"
+  },
   "devDependencies": {
     "@ethersproject/bytes": "~5.7.0",
     "@ethersproject/constants": "~5.7.0",

--- a/packages/devtools/src/common/promise.ts
+++ b/packages/devtools/src/common/promise.ts
@@ -75,8 +75,8 @@ export const firstFactory =
         await first(factories.map((factory) => () => factory(...input)))
 
 /**
- * RetryStrategy is a way of having a fine grain control
- * over execution of retried function.
+ * RetryStrategy represents a function that, when passed to `createRetryFactory`,
+ * controls the execution of a retried function.
  *
  * It will be executed on every failed attempt and has the ability to modify the
  * input originally passed to the retried function.
@@ -92,16 +92,16 @@ export const firstFactory =
  * const functionThatCanFail = (money: number): Promise<void> => { ... }
  *
  * // We can create a strategy that will keep adding 1 to the amount of money
- * const strategy: RetryStrategy<[money: number]> = (attempt, error, [previousMoney]) => [previousMoney + 1]
+ * const strategy: RetryStrategy<[money: number]> = (attempt, error, [previousMoney], [originalMoney]) => [previousMoney + 1]
  *
  * // Or we can create a strategy that will adjust the money based on the initial value
  * //
  * // In this made up case it will take the original amount and will add 2 for every failed attempt
- * const strategy: RetryStrategy<[money: number]> = (attempt, error, _, [originalMoney]) => [originalMoney + attempt * 2]
+ * const strategy: RetryStrategy<[money: number]> = (attempt, error, [previousMoney], [originalMoney]) => [originalMoney + attempt * 2]
  *
  * // Or we can go insane with our logic and can, because without objective morality
  * // everything is permissible, update the amount on every other attempt
- * const strategy: RetryStrategy<[money: number]> = (attempt, error, _, [originalMoney]) => attempt % 2 ? [previousMoney + 1] : true
+ * const strategy: RetryStrategy<[money: number]> = (attempt, error, [previousMoney], [originalMoney]) => attempt % 2 ? [previousMoney + 1] : true
  * ```
  *
  * @param {number} attempt The 0-indexed attempt that the retry function is performing

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -390,6 +390,10 @@ importers:
         version: 4.0.0
 
   packages/devtools:
+    dependencies:
+      exponential-backoff:
+        specifier: ~3.1.1
+        version: 3.1.1
     devDependencies:
       '@ethersproject/bytes':
         specifier: ~5.7.0
@@ -6526,6 +6530,7 @@ packages:
     dependencies:
       is-hex-prefixed: 1.0.0
       strip-hex-prefix: 1.0.0
+    bundledDependencies: false
 
   /eventemitter3@4.0.7:
     resolution: {integrity: sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==}
@@ -6585,6 +6590,10 @@ packages:
       jest-message-util: 29.7.0
       jest-util: 29.7.0
     dev: true
+
+  /exponential-backoff@3.1.1:
+    resolution: {integrity: sha512-dX7e/LHVJ6W3DE1MHWi9S1EYzDESENfLrYohG2G++ovZrYOkm4Knwa0mc1cn84xJOR4KEU0WSchhLbd0UklbHw==}
+    dev: false
 
   /extendable-error@0.1.7:
     resolution: {integrity: sha512-UOiS2in6/Q0FK0R0q6UY9vYpQ21mr/Qn1KOnte7vsACuNJf514WvCCUHSRCPcgjPT2bAhNIJdlE6bVap1GKmeg==}


### PR DESCRIPTION
### In this PR

- After exploring the options of retrying failed calls on several levels (SDK, configuration and RPC provider), I created composable retry functionality that can be used on all three levels - yet after seeing that retrying on the provider level is very error-prone, I think we should retry on the configuration level.
- The way the code is structured, allows us to create retry strategies that will for example bump the gas limit on transactions if we need to

```typescript
// This is not a financial advice
//
// This strategy will be bumping the. `gasLimit` on a transaction to infinity
// exponentially by factor of 2
//
// (Being a sketch, it does not account for gasLimit being a string or being 0)
const strategy: RetryStrategy<OmniTransaction> = (attempt, error, [previousTransaction]) => [{
  ...previousTransaction,
  gasLimit: previousTransaction.gasLimit * 2
}]

// This will create a wrapper that can retry any function that matches the strategy signature
const retryWithMyStrategy = createRetryFactory(strategy)
const retriedSignAndSend = retryWithMyStrategy(signAndSend)
await retriedSignAndSend({ data: '0x...' }) 
```