### PR TITLE
🧹 Preparation work for lz:deploy task

### DIFF
--- a/.changeset/metal-trains-carry.md
+++ b/.changeset/metal-trains-carry.md
@@ -1,0 +1,7 @@
+---
+"@layerzerolabs/devtools-evm-hardhat": patch
+"@layerzerolabs/io-devtools": patch
+"@layerzerolabs/devtools": patch
+---
+
+Remove CommaSeparatedValuesSchema in favor of splitCommaSeparated; Move LogLevelSchema; Export isLogLevel

--- a/packages/devtools-evm-hardhat/src/cli.ts
+++ b/packages/devtools-evm-hardhat/src/cli.ts
@@ -2,21 +2,8 @@ import { types as builtInTypes } from 'hardhat/config'
 import { HardhatError } from 'hardhat/internal/core/errors'
 import { ERRORS } from 'hardhat/internal/core/errors-list'
 import type { CLIArgumentType } from 'hardhat/types'
-import { z } from 'zod'
-import { LogLevel } from '@layerzerolabs/io-devtools'
-
-/**
- * Helper zod schema that splits a comma-separated string
- * into individual values, trimming the results
- */
-const CommaSeparatedValuesSchema = z.string().transform((value) =>
-    value
-        .trim()
-        .split(/\s*,\s*/)
-        .filter(Boolean)
-)
-
-const LogLevelSchema = z.nativeEnum(LogLevel)
+import { splitCommaSeparated } from '@layerzerolabs/devtools'
+import { isLogLevel, LogLevel } from '@layerzerolabs/io-devtools'
 
 /**
  * Hardhat CLI type for a comma separated list of arbitrary strings
@@ -24,16 +11,7 @@ const LogLevelSchema = z.nativeEnum(LogLevel)
 const csv: CLIArgumentType<string[]> = {
     name: 'csv',
     parse(name: string, value: string) {
-        const result = CommaSeparatedValuesSchema.safeParse(value)
-        if (!result.success) {
-            throw new HardhatError(ERRORS.ARGUMENTS.INVALID_VALUE_FOR_TYPE, {
-                value,
-                name: name,
-                type: 'csv',
-            })
-        }
-
-        return result.data
+        return splitCommaSeparated(value)
     },
     validate() {},
 }
@@ -46,8 +24,7 @@ const csv: CLIArgumentType<string[]> = {
 const logLevel: CLIArgumentType<LogLevel> = {
     name: 'logLevel',
     parse(name: string, value: string) {
-        const result = LogLevelSchema.safeParse(value)
-        if (!result.success) {
+        if (!isLogLevel(value)) {
             throw new HardhatError(ERRORS.ARGUMENTS.INVALID_VALUE_FOR_TYPE, {
                 value,
                 name: name,
@@ -55,7 +32,7 @@ const logLevel: CLIArgumentType<LogLevel> = {
             })
         }
 
-        return result.data
+        return value
     },
     validate() {},
 }

--- a/packages/devtools/src/common/index.ts
+++ b/packages/devtools/src/common/index.ts
@@ -1,3 +1,4 @@
 export * from './assertion'
 export * from './bytes'
 export * from './promise'
+export * from './strings'

--- a/packages/devtools/src/common/strings.ts
+++ b/packages/devtools/src/common/strings.ts
@@ -1,0 +1,12 @@
+/**
+ * Splits a comma-separated string into individual values
+ * and discards any whitespace.
+ *
+ * @param {string} value
+ * @returns {string[]}
+ */
+export const splitCommaSeparated = (value: string): string[] =>
+    value
+        .trim()
+        .split(/\s*,\s*/)
+        .filter(Boolean)

--- a/packages/io-devtools/src/stdio/logger.ts
+++ b/packages/io-devtools/src/stdio/logger.ts
@@ -1,5 +1,6 @@
 import type { Format } from 'logform'
 import { createLogger as createWinstonLogger, format, transports, type Logger } from 'winston'
+import { z } from 'zod'
 
 /**
  * Re-export for ease of use
@@ -19,20 +20,22 @@ export enum LogLevel {
     silly = 'silly',
 }
 
+const LogLevelSchema = z.nativeEnum(LogLevel)
+
 /**
- * Type assertion utility for LogLevel
+ * Type assertion utility for `LogLevel`
  *
- * @param value `unknown`
- * @returns `value is LogLevel`
+ * @param {unknown} value
+ * @returns {boolean}
  */
-const isLogLevel = (value: unknown): value is LogLevel => typeof value === 'string' && value in LogLevel
+export const isLogLevel = (value: unknown): value is LogLevel => LogLevelSchema.safeParse(value).success
 
 let DEFAULT_LOG_LEVEL = LogLevel.info
 
 /**
  * Sets the default log level used when creating new loggers.
  *
- * @param level `LogLevel`
+ * @param {string} level
  */
 export const setDefaultLogLevel = (level: string) => {
     if (!isLogLevel(level)) {


### PR DESCRIPTION
### In this PR

- Miniscule code reorganization needed for `lz:deploy` task - moving some schemas around, exporting `isLogLevel` function and removing `CommaSeparatedValuesSchema` in favor of a transformation function that splits a CSV string into individual values, discarding any whitespace