### PR TITLE
🧹 Use turbo strict environment mode

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -349,3 +349,12 @@ If running into issues with failing deployment transactions when running the tes
 ```bash
 pnpm clean
 ```
+
+### Problems with missing environment variables
+
+If running into issues with missing environment variables when running any of the commands that rely on `turbo` (e.g. `build` or `test`), make sure that these are either:
+
+- Specified as environment variables that have an effect on build output - [env](https://turbo.build/repo/docs/reference/configuration#env) in `turbo.json`
+- Specified as _global_ environment variables that have an effect on build output - [globalEnv](https://turbo.build/repo/docs/reference/configuration#globalenv)
+- Specified as environment variables that don't have an effect on build output - [passThroughEnv](https://turbo.build/repo/docs/reference/configuration#passthroughenv)
+- Specified as _global_ environment variables that don't have an effect on build output - [globalPassThroughEnv](https://turbo.build/repo/docs/reference/configuration#globalpassthroughenv)

--- a/turbo.json
+++ b/turbo.json
@@ -36,5 +36,14 @@
       "outputs": []
     }
   },
-  "globalDependencies": ["tsconfig.json"]
+  "globalDependencies": ["tsconfig.json"],
+  "globalPassThroughEnv": [
+    "LZ_ENABLE_EXPERIMENTAL_TASK_LZ_DEPLOY",
+    "LZ_ENABLE_EXPERIMENTAL_TASK_LZ_OAPP_CONFIG_INIT",
+    "MNEMONIC",
+    "NETWORK_URL_VENGABOYS",
+    "NETWORK_URL_BRITNEY",
+    "NETWORK_URL_TANGO",
+    "CI"
+  ]
 }


### PR DESCRIPTION
### In this PR

- Enable `turbo` [strict environment mode](https://turbo.build/repo/docs/reference/configuration#globalpassthroughenv) - this means that any task executed by running `turbo` will only receive the environment variables that are made available to it. This gets rid of the lint warnings cased by `turbo/no-undeclared-env-vars` ESLint rule