### PR TITLE
 🪲Fixing configureEnforcedOptions

### DIFF
--- a/.changeset/long-dolphins-press.md
+++ b/.changeset/long-dolphins-press.md
@@ -1,0 +1,7 @@
+---
+"@layerzerolabs/ua-devtools-evm-hardhat-test": patch
+"@layerzerolabs/ua-devtools-evm": patch
+"@layerzerolabs/ua-devtools": patch
+---
+
+Fixing configureEnforcedOptions

--- a/packages/ua-devtools-evm/src/oapp/sdk.ts
+++ b/packages/ua-devtools-evm/src/oapp/sdk.ts
@@ -97,15 +97,7 @@ export class OApp extends OmniSDK implements IOApp {
     protected serializeExecutorOptions(
         oappEnforcedOptionParam: OAppEnforcedOptionParam[]
     ): SerializedEnforcedOptions[] {
-        const serializedEnforcedOptions: SerializedEnforcedOptions[] = []
-        for (const oAppEnforcedOptionParam of oappEnforcedOptionParam) {
-            serializedEnforcedOptions.push({
-                eid: oAppEnforcedOptionParam.eid,
-                msgType: oAppEnforcedOptionParam.option.msgType,
-                options: oAppEnforcedOptionParam.option.options,
-            })
-        }
-        return serializedEnforcedOptions
+        return oappEnforcedOptionParam.map(({ eid, option: { msgType, options } }) => ({ eid, msgType, options }))
     }
 }
 

--- a/packages/ua-devtools-evm/src/oapp/sdk.ts
+++ b/packages/ua-devtools-evm/src/oapp/sdk.ts
@@ -1,4 +1,4 @@
-import type { IOApp, EnforcedOptions, OAppEnforcedOptionConfig } from '@layerzerolabs/ua-devtools'
+import type { IOApp, OAppEnforcedOptionParam } from '@layerzerolabs/ua-devtools'
 import {
     type Bytes32,
     type OmniAddress,
@@ -8,13 +8,13 @@ import {
     areBytes32Equal,
     ignoreZero,
     makeBytes32,
+    Bytes,
 } from '@layerzerolabs/devtools'
 import { type OmniContract, formatOmniContract } from '@layerzerolabs/devtools-evm'
 import type { EndpointId } from '@layerzerolabs/lz-definitions'
 import type { EndpointFactory, IEndpoint } from '@layerzerolabs/protocol-devtools'
 import { OmniSDK } from '@layerzerolabs/devtools-evm'
 import { printJson } from '@layerzerolabs/io-devtools'
-import { ExecutorOptionType, Options } from '@layerzerolabs/lz-v2-utilities'
 
 export class OApp extends OmniSDK implements IOApp {
     constructor(
@@ -71,42 +71,49 @@ export class OApp extends OmniSDK implements IOApp {
         }
     }
 
-    async getEnforcedOptions(eid: EndpointId, msgType: number): Promise<string> {
+    async getEnforcedOptions(eid: EndpointId, msgType: number): Promise<Bytes> {
         this.logger.debug(`Getting enforced options for eid ${eid} (${formatEid(eid)}) and message type ${msgType}`)
 
         return await this.contract.contract.enforcedOptions(eid, msgType)
     }
 
-    async setEnforcedOptions(enforcedOptions: EnforcedOptions[]): Promise<OmniTransaction> {
+    async setEnforcedOptions(enforcedOptions: OAppEnforcedOptionParam[]): Promise<OmniTransaction> {
         this.logger.debug(`Setting enforced options to ${printJson(enforcedOptions)}`)
+        const serializedConfig = this.serializeExecutorOptions(enforcedOptions)
 
-        const data = this.contract.contract.interface.encodeFunctionData('setEnforcedOptions', [enforcedOptions])
+        const data = this.contract.contract.interface.encodeFunctionData('setEnforcedOptions', [serializedConfig])
         return {
             ...this.createTransaction(data),
             description: `Setting enforced options to ${printJson(enforcedOptions)}`,
         }
     }
 
-    encodeEnforcedOptions(enforcedOptionConfig: OAppEnforcedOptionConfig): Options {
-        if ('options' in enforcedOptionConfig) return Options.fromOptions(enforcedOptionConfig.options)
-
-        if (enforcedOptionConfig.msgType == ExecutorOptionType.LZ_RECEIVE) {
-            return Options.newOptions().addExecutorLzReceiveOption(enforcedOptionConfig.gas, enforcedOptionConfig.value)
-        } else if (enforcedOptionConfig.msgType == ExecutorOptionType.NATIVE_DROP) {
-            return Options.newOptions().addExecutorNativeDropOption(
-                enforcedOptionConfig.amount,
-                enforcedOptionConfig.receiver
-            )
-        } else if (enforcedOptionConfig.msgType == ExecutorOptionType.COMPOSE) {
-            return Options.newOptions().addExecutorComposeOption(
-                enforcedOptionConfig.index,
-                enforcedOptionConfig.gas,
-                enforcedOptionConfig.value
-            )
-        } else if (enforcedOptionConfig.msgType == ExecutorOptionType.ORDERED) {
-            return Options.newOptions().addExecutorOrderedExecutionOption()
-        } else {
-            throw new Error(`Invalid ExecutorOptionType`)
+    /**
+     * Prepares the Executor config to be sent to the contract
+     *
+     * @param {OAppEnforcedOptionParam[]}
+     * @returns {SerializedEnforcedOptions[]}
+     */
+    protected serializeExecutorOptions(
+        oappEnforcedOptionParam: OAppEnforcedOptionParam[]
+    ): SerializedEnforcedOptions[] {
+        const serializedEnforcedOptions: SerializedEnforcedOptions[] = []
+        for (const oAppEnforcedOptionParam of oappEnforcedOptionParam) {
+            serializedEnforcedOptions.push({
+                eid: oAppEnforcedOptionParam.eid,
+                msgType: oAppEnforcedOptionParam.option.msgType,
+                options: oAppEnforcedOptionParam.option.options,
+            })
         }
+        return serializedEnforcedOptions
     }
+}
+
+/**
+ * Helper type that matches the solidity implementation
+ */
+interface SerializedEnforcedOptions {
+    eid: number
+    msgType: number
+    options: string
 }

--- a/packages/ua-devtools/src/oapp/schema.ts
+++ b/packages/ua-devtools/src/oapp/schema.ts
@@ -2,13 +2,12 @@ import { z } from 'zod'
 import { AddressSchema, UIntBigIntSchema, UIntNumberSchema } from '@layerzerolabs/devtools'
 import { Uln302ExecutorConfigSchema, Uln302UlnConfigSchema, TimeoutSchema } from '@layerzerolabs/protocol-devtools'
 import {
-    EndcodedOption,
     ExecutorComposeOption,
     ExecutorLzReceiveOption,
     ExecutorNativeDropOption,
     ExecutorOrderedExecutionOption,
     OAppEdgeConfig,
-    OAppEnforcedOptionConfig,
+    OAppEnforcedOption,
     OAppReceiveConfig,
     OAppReceiveLibraryConfig,
     OAppSendConfig,
@@ -28,13 +27,6 @@ export const OAppSendConfigSchema = z.object({
 export const OAppReceiveConfigSchema = z.object({
     ulnConfig: Uln302UlnConfigSchema,
 }) satisfies z.ZodSchema<OAppReceiveConfig, z.ZodTypeDef, unknown>
-
-const ExecutorOptionTypeSchema = z.nativeEnum(ExecutorOptionType)
-
-export const EncodedOptionSchema = z.object({
-    msgType: ExecutorOptionTypeSchema,
-    options: z.string(),
-}) satisfies z.ZodSchema<EndcodedOption, z.ZodTypeDef, unknown>
 
 export const ExecutorLzReceiveOptionSchema = z.object({
     msgType: z.literal(ExecutorOptionType.LZ_RECEIVE),
@@ -60,15 +52,14 @@ export const ExecutorOrderedExecutionOptionSchema = z.object({
 }) satisfies z.ZodSchema<ExecutorOrderedExecutionOption, z.ZodTypeDef, unknown>
 
 export const OAppEnforcedOptionConfigSchema = z.union([
-    EncodedOptionSchema,
     ExecutorLzReceiveOptionSchema,
     ExecutorNativeDropOptionSchema,
     ExecutorComposeOptionSchema,
     ExecutorOrderedExecutionOptionSchema,
-]) satisfies z.ZodSchema<OAppEnforcedOptionConfig, z.ZodTypeDef, unknown>
+]) satisfies z.ZodSchema<OAppEnforcedOption, z.ZodTypeDef, unknown>
 
 export const OAppEnforcedOptionsSchema = z.array(OAppEnforcedOptionConfigSchema) satisfies z.ZodSchema<
-    OAppEnforcedOptionConfig[],
+    OAppEnforcedOption[],
     z.ZodTypeDef,
     unknown
 >

--- a/packages/ua-devtools/src/oapp/types.ts
+++ b/packages/ua-devtools/src/oapp/types.ts
@@ -1,6 +1,7 @@
 import type { EndpointId } from '@layerzerolabs/lz-definitions'
 import type { IEndpoint, Timeout, Uln302ExecutorConfig, Uln302UlnConfig } from '@layerzerolabs/protocol-devtools'
 import type {
+    Bytes,
     Factory,
     IOmniSDK,
     OmniAddress,
@@ -8,23 +9,17 @@ import type {
     OmniPoint,
     OmniTransaction,
     OmniVector,
+    PossiblyBigInt,
 } from '@layerzerolabs/devtools'
-import { ExecutorOptionType, Options } from '@layerzerolabs/lz-v2-utilities'
+import { ExecutorOptionType } from '@layerzerolabs/lz-v2-utilities'
 
 export interface IOApp extends IOmniSDK {
     getEndpointSDK(): Promise<IEndpoint>
     getPeer(eid: EndpointId): Promise<OmniAddress | undefined>
     hasPeer(eid: EndpointId, address: OmniAddress | null | undefined): Promise<boolean>
     setPeer(eid: EndpointId, peer: OmniAddress | null | undefined): Promise<OmniTransaction>
-    getEnforcedOptions(eid: EndpointId, msgType: number): Promise<string>
-    setEnforcedOptions(enforcedOptions: EnforcedOptions[]): Promise<OmniTransaction>
-    encodeEnforcedOptions(enforcedOptionConfig: OAppEnforcedOptionConfig): Options
-}
-
-export type EnforcedOptions = {
-    eid: EndpointId
-    msgType: number
-    options: string
+    getEnforcedOptions(eid: EndpointId, msgType: number): Promise<Bytes>
+    setEnforcedOptions(enforcedOptions: OAppEnforcedOptionParam[]): Promise<OmniTransaction>
 }
 
 export interface OAppReceiveLibraryConfig {
@@ -47,50 +42,59 @@ export interface OAppEdgeConfig {
     receiveLibraryTimeoutConfig?: Timeout
     sendConfig?: OAppSendConfig
     receiveConfig?: OAppReceiveConfig
-    enforcedOptions?: OAppEnforcedOptionConfig[]
+    enforcedOptions?: OAppEnforcedOption[]
 }
 
 export interface BaseExecutorOption {
     msgType: ExecutorOptionType
 }
 
-export interface EndcodedOption extends BaseExecutorOption {
+export interface EncodedOption extends BaseExecutorOption {
     options: string
 }
 
 export interface ExecutorLzReceiveOption extends BaseExecutorOption {
     msgType: ExecutorOptionType.LZ_RECEIVE
-    gas: string | number
-    value: string | number
+    gas: PossiblyBigInt
+    value: PossiblyBigInt
 }
 
 export interface ExecutorNativeDropOption extends BaseExecutorOption {
     msgType: ExecutorOptionType.NATIVE_DROP
-    amount: string | number
+    amount: PossiblyBigInt
     receiver: string
 }
 
 export interface ExecutorComposeOption extends BaseExecutorOption {
     msgType: ExecutorOptionType.COMPOSE
     index: number
-    gas: string | number
-    value: string | number
+    gas: PossiblyBigInt
+    value: PossiblyBigInt
 }
 
 export interface ExecutorOrderedExecutionOption extends BaseExecutorOption {
     msgType: ExecutorOptionType.ORDERED
 }
 
-export type OAppEnforcedOptionConfig =
+export type OAppEnforcedOption =
     | ExecutorLzReceiveOption
     | ExecutorNativeDropOption
     | ExecutorComposeOption
     | ExecutorOrderedExecutionOption
-    | EndcodedOption
+
+export interface OAppEnforcedOptionParam {
+    eid: EndpointId
+    option: EncodedOption
+}
 
 export interface OAppPeers {
     vector: OmniVector
     hasPeer: boolean
+}
+
+export interface OAppEnforcedOptions {
+    vector: OmniVector
+    enforcedOptions: EncodedOption[]
 }
 
 export type OAppOmniGraph = OmniGraph<unknown, OAppEdgeConfig | undefined>


### PR DESCRIPTION
### In this PR

- Fixing configureEnforcedOptions logic to collect EnforcedOptions[] by OApp before executing the transaction. This results in fewer transactions to configure enforced options.