### PR TITLE
🪲 Fix lint-staged command

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,4 @@
 #!/usr/bin/env sh
 . "$(dirname -- "$0")/_/husky.sh"
 
-pnpm lint-staged
+npx lint-staged


### PR DESCRIPTION
### In this PR

- After removing the `pnpm/action-setup` in favor of `corepack enable`, the `lint-staged` command [failed to execute on the `main` branch](https://github.com/LayerZero-Labs/devtools/actions/runs/7804238907/job/21287844498). The fix here is to use the `npx` executable instead of the `pnpm` one