### PR TITLE
🪲 Fix lint staged commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,8 +25,8 @@
   },
   "lint-staged": {
     "**/*": [
-      "pnpm prettier --write --ignore-unknown",
-      "pnpm eslint --fix"
+      "npx prettier --write --ignore-unknown",
+      "npx eslint --fix"
     ]
   },
   "resolutions": {


### PR DESCRIPTION
### In this PR

- Changed `pnpm` to `npx` for `lint-staged` commands to fix pipeline failures after removing deprecated `pnpm/action-setup`