### PR TITLE
🗞️ warn user if no lzReceive gas is supplied

### DIFF
--- a/.changeset/three-pigs-give.md
+++ b/.changeset/three-pigs-give.md
@@ -1,0 +1,5 @@
+---
+"build-lz-options": patch
+---
+
+Warn users if lzReceive gas is not set.

--- a/packages/build-lz-options/src/components/outputOptions.tsx
+++ b/packages/build-lz-options/src/components/outputOptions.tsx
@@ -15,8 +15,14 @@ export const OutputOptions: React.FC<OptionOutputProps> = ({
 }: OptionOutputProps) => {
   return (
     <Box flexDirection="column">
+      {props.warning.length > 0 && (
+        <Text color={"yellow"}>
+          <Text bold={true}>Warning:</Text> {props.warning}
+        </Text>
+      )}
       <Text>
-        Result: <Text color={"green"}>{props.hex}</Text>
+        <Text bold={true}>Result:</Text>{" "}
+        <Text color={"green"}>{props.hex}</Text>
       </Text>
     </Box>
   );

--- a/packages/build-lz-options/src/components/outputOptions.tsx
+++ b/packages/build-lz-options/src/components/outputOptions.tsx
@@ -15,14 +15,13 @@ export const OutputOptions: React.FC<OptionOutputProps> = ({
 }: OptionOutputProps) => {
   return (
     <Box flexDirection="column">
-      {props.warning.length > 0 && (
-        <Text color={"yellow"}>
-          <Text bold={true}>Warning:</Text> {props.warning}
+      {props.warning.map((warning) => (
+        <Text color="yellow">
+          <Text bold>Warning:</Text> {warning}
         </Text>
-      )}
+      ))}
       <Text>
-        <Text bold={true}>Result:</Text>{" "}
-        <Text color={"green"}>{props.hex}</Text>
+        <Text bold>Result:</Text> <Text color="green">{props.hex}</Text>
       </Text>
     </Box>
   );

--- a/packages/build-lz-options/src/index.tsx
+++ b/packages/build-lz-options/src/index.tsx
@@ -32,6 +32,7 @@ new Command("build-lz-options")
     render(<ConfigSummary value={config} />).unmount();
 
     let output: string = "";
+    const warning: string[] = [];
 
     switch (config.type.id) {
       case OptionType.TYPE_1: {
@@ -66,10 +67,14 @@ new Command("build-lz-options")
       }
       case OptionType.TYPE_3: {
         const options = await promptForOptionType3();
+        const lzReceiveOption = options.decodeExecutorLzReceiveOption();
+        if (!lzReceiveOption || lzReceiveOption.gas < 1) {
+          warning.push("Options do not specify any lzReceive gas.");
+        }
         output = options.toHex();
         break;
       }
     }
-    render(<OutputOptions props={{ hex: output }} />);
+    render(<OutputOptions props={{ hex: output, warning }} />);
   })
   .parseAsync();

--- a/packages/build-lz-options/src/types.ts
+++ b/packages/build-lz-options/src/types.ts
@@ -20,6 +20,7 @@ export interface OptionTypeInput {
  */
 export interface OptionOutput {
     hex: string
+    warning: string[]
 }
 
 /**


### PR DESCRIPTION
Warn the user if:
* There is no lzReceive option.  compose gas does not count towards lzReceive gas for the default ExecutorFeeLib implementation.
* lzReceive option is specified, but with 0 destination gas.