### PR TITLE
🪲 Revert pipeline updates

### DIFF
--- a/.github/workflows/actions/setup-environment/action.yaml
+++ b/.github/workflows/actions/setup-environment/action.yaml
@@ -3,9 +3,11 @@ description: Setup node & package manager, checkout code
 runs:
   using: "composite"
   steps:
-    - name: Enable corepack
-      shell: bash
-      run: corepack enable
+    - uses: pnpm/action-setup@v2
+      name: Install pnpm
+      with:
+        version: 8
+        run_install: false
 
     - name: Setup Node.js
       uses: actions/setup-node@v4

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,4 @@
 #!/usr/bin/env sh
 . "$(dirname -- "$0")/_/husky.sh"
 
-npx lint-staged
+pnpm lint-staged

--- a/package.json
+++ b/package.json
@@ -25,8 +25,8 @@
   },
   "lint-staged": {
     "**/*": [
-      "npx prettier --write --ignore-unknown",
-      "npx eslint --fix"
+      "pnpm prettier --write --ignore-unknown",
+      "pnpm eslint --fix"
     ]
   },
   "resolutions": {


### PR DESCRIPTION
### In this PR

- Revert removal of `pnpm/action-setup` that caused `lint-staged` to fail in the publish step. Further investigation as well as a better testing setup is needed since `main` is now failing