### PR TITLE
🗞️ Compile project before running lz:deploy

### DIFF
--- a/.changeset/khaki-garlics-run.md
+++ b/.changeset/khaki-garlics-run.md
@@ -1,0 +1,7 @@
+---
+"@layerzerolabs/devtools-evm-hardhat-test": patch
+"@layerzerolabs/devtools-evm-hardhat": patch
+"@layerzerolabs/toolbox-hardhat": patch
+---
+
+Compile project before depolying in lz:deploy


### PR DESCRIPTION
### In this PR

- To make the UX even better, we'll run hardhat's `TASK_COMPILE` before deploying contracts in `lz:deploy`. That way the only thing a person needs to do is set a `MNEMONIC`/`PRIVATE_KEY` and run `npx hardhat lz:deploy`