### PR TITLE
🪲 Fix typos in example configurations

### DIFF
--- a/examples/oapp/deploy/MyOApp.ts
+++ b/examples/oapp/deploy/MyOApp.ts
@@ -48,4 +48,5 @@ const deploy: DeployFunction = async (hre) => {
 }
 
 deploy.tags = [contractName]
+
 export default deploy

--- a/examples/oapp/hardhat.config.ts
+++ b/examples/oapp/hardhat.config.ts
@@ -50,7 +50,7 @@ const config: HardhatUserConfig = {
     },
     networks: {
         sepolia: {
-            eid: EndpointId.ETHEREUM_V2_TESTNET,
+            eid: EndpointId.SEPOLIA_V2_TESTNET,
             url: 'https://rpc.sepolia.org/',
             accounts,
         },

--- a/examples/oapp/layerzero.config.ts
+++ b/examples/oapp/layerzero.config.ts
@@ -1,7 +1,7 @@
 import { EndpointId } from '@layerzerolabs/lz-definitions'
 
 const sepoliaContract = {
-    eid: EndpointId.ETHEREUM_V2_TESTNET,
+    eid: EndpointId.SEPOLIA_V2_TESTNET,
     contractName: 'MyOApp',
 }
 

--- a/examples/oft/deploy/MyOFT.ts
+++ b/examples/oft/deploy/MyOFT.ts
@@ -48,5 +48,6 @@ const deploy: DeployFunction = async (hre) => {
     console.log(`Deployed contract: ${contractName}, network: ${hre.network.name}, address: ${address}`)
 }
 
-module.exports.tags = [contractName]
+deploy.tags = [contractName]
+
 export default deploy

--- a/examples/oft/hardhat.config.ts
+++ b/examples/oft/hardhat.config.ts
@@ -50,7 +50,7 @@ const config: HardhatUserConfig = {
     },
     networks: {
         sepolia: {
-            eid: EndpointId.ETHEREUM_V2_TESTNET,
+            eid: EndpointId.SEPOLIA_V2_TESTNET,
             url: 'https://rpc.sepolia.org/',
             accounts,
         },

--- a/examples/oft/layerzero.config.ts
+++ b/examples/oft/layerzero.config.ts
@@ -2,7 +2,7 @@
 import { EndpointId } from '@layerzerolabs/lz-definitions'
 
 const sepoliaContract = {
-    eid: EndpointId.ETHEREUM_V2_TESTNET,
+    eid: EndpointId.SEPOLIA_V2_TESTNET,
     contractName: 'MyOFT',
 }
 


### PR DESCRIPTION
### In this PR

- Fix wrong `eid` for Sepolia EndpointV2 deployments in our examples
- Fix deploy script tag for `MyOFT`