### PR TITLE
:broom: update build lz options README.md with warning information

### DIFF
--- a/.changeset/wild-brooms-tell.md
+++ b/.changeset/wild-brooms-tell.md
@@ -1,0 +1,5 @@
+---
+"build-lz-options": patch
+---
+
+Update build-lz-options README.md with warning information

--- a/packages/build-lz-options/README.md
+++ b/packages/build-lz-options/README.md
@@ -29,3 +29,12 @@ pnpm build-lz-options
 # or
 bunx build-lz-options
 ```
+
+## Warnings
+
+### :warning: Warning: Options do not specify any lzReceive gas
+
+The default LayerZero ExecutorFeeLib requires the sum of lzReceive gas for all Options for a message is a positive
+integer. This is classified as a warning and not an error, as `build-lz-options` tool is not aware of the context in
+which the generated Options are used. For example, Options may be combined elsewhere in the application, perhaps with
+OApp Enforced Options, and the result will have a positive lzReceive gas sum.


### PR DESCRIPTION
Just a small update to README.md which explains the one warning emitted by the tool so far.