### PR TITLE
:broom: devtools;  fix JSDoc names, spelling, typing, etc.

### DIFF
--- a/packages/devtools/src/common/assertion.ts
+++ b/packages/devtools/src/common/assertion.ts
@@ -8,7 +8,7 @@ import { deepStrictEqual } from 'assert'
  * const theyDontMatch = isDeepEqual({ a: 1 }, { a: '1' }) // false
  * ```
  *
- * @param {T} a
+ * @param {unknown} a
  * @param {unknown} b
  * @returns {boolean}
  */

--- a/packages/devtools/src/common/bytes.ts
+++ b/packages/devtools/src/common/bytes.ts
@@ -39,7 +39,7 @@ export const isZero = (value: PossiblyBytes | PossiblyBigInt | null | undefined)
 /**
  * Turns a potentially zero address into undefined
  *
- * @param {PossiblyBytes | PossiblyBigInt | null | undefined} address
+ * @param {PossiblyBytes | PossiblyBigInt | null | undefined} value
  *
  * @returns {string | undefined}
  */

--- a/packages/devtools/src/common/promise.ts
+++ b/packages/devtools/src/common/promise.ts
@@ -143,7 +143,9 @@ type RetryStrategy<TInput extends unknown[]> = Factory<
  * @returns {<TOutput>(task: Factory<TInput, TOutput>) => Factory<TInput, TOutput>}
  */
 export const createRetryFactory =
-    <TInput extends unknown[]>(strategy: RetryStrategy<TInput> = createSimpleRetryStrategy(3)) =>
+    <TInput extends unknown[]>(
+        strategy: RetryStrategy<TInput> = createSimpleRetryStrategy(3)
+    ): (<TOutput>(task: Factory<TInput, TOutput>) => Factory<TInput, TOutput>) =>
     <TOutput>(task: Factory<TInput, TOutput>): Factory<TInput, TOutput> =>
     async (...input) => {
         // We'll store the last used input in this variable

--- a/packages/devtools/src/transactions/signer.ts
+++ b/packages/devtools/src/transactions/signer.ts
@@ -38,7 +38,7 @@ export const createSignAndSend =
         const successful: OmniTransactionWithReceipt[] = []
 
         for (const [index, transaction] of transactions.entries()) {
-            // We want to refer to this transaction by index so we create an ordinal for it (1st, 2nd etc)
+            // We want to refer to this transaction by index, so we create an ordinal for it (1st, 2nd etc.)
             const ordinal = pluralizeOrdinal(index + 1)
 
             try {


### PR DESCRIPTION
These are mostly cosmetic changes to avoid warnings.