### PR TITLE
🗞️ Add next steps box to create-lz-oapp

### DIFF
--- a/.changeset/good-foxes-crash.md
+++ b/.changeset/good-foxes-crash.md
@@ -1,0 +1,5 @@
+---
+"create-lz-oapp": patch
+---
+
+Add next steps summary to create-lz-oapp

--- a/packages/create-lz-oapp/src/components/error.tsx
+++ b/packages/create-lz-oapp/src/components/error.tsx
@@ -78,10 +78,10 @@ export const ErrorMessage: React.FC<ErrorMessageProps> = ({
             borderColor="gray"
             flexDirection="column"
           >
-            <Text color="green"># Navigate to your project</Text>
+            <Text># Navigate to your project</Text>
             <Text color="cyan">cd {config.destination}</Text>
             <Newline />
-            <Text color="green"># Reattempt the installation</Text>
+            <Text># Reattempt the installation</Text>
             <Text color="cyan">
               {config.packageManager.executable}{" "}
               {config.packageManager.args.join(" ")}

--- a/packages/create-lz-oapp/src/components/setup.tsx
+++ b/packages/create-lz-oapp/src/components/setup.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect } from "react";
 import type { Config } from "@/types";
-import { Box } from "ink";
+import { Box, Newline, Text } from "ink";
 import { cloneExample } from "@/utilities/cloning";
 import { Progress } from "./progress";
 import { installDependencies } from "@/utilities/installation";
@@ -38,6 +38,45 @@ export const Setup: React.FC<Props> = ({ config }) => {
         state={install.state}
         error={({ error }) => <ErrorMessage config={config} error={error} />}
       />
+
+      {setup.state?.success ? <NextSteps config={config} /> : null}
     </Box>
   );
 };
+
+const NextSteps: React.FC<{ config: Config }> = ({ config }) => (
+  <Box flexDirection="column">
+    <Text>
+      <Text color="green">✔</Text> All done!
+    </Text>
+
+    <Box
+      margin={1}
+      borderStyle="round"
+      borderColor="gray"
+      flexDirection="column"
+    >
+      <Text># Navigate to your project</Text>
+      <Text color="cyan">cd {config.destination}</Text>
+      <Newline />
+
+      <Text>#</Text>
+      <Text># Follow the steps in hardhat.config.ts:</Text>
+      <Text>#</Text>
+      <Text># - Create an .env file based on the provided template</Text>
+      <Text># - Adjust the contracts to your liking</Text>
+      <Text>#</Text>
+      <Text># Deploy your contracts</Text>
+      <Text color="cyan">npx hardhat lz:deploy</Text>
+      <Newline />
+
+      <Text bold>
+        Visit our docs page at{" "}
+        <Text underline color="cyan">
+          https://docs.layerzero.network/
+        </Text>{" "}
+        for more info
+      </Text>
+    </Box>
+  </Box>
+);

--- a/packages/create-lz-oapp/src/components/setup.tsx
+++ b/packages/create-lz-oapp/src/components/setup.tsx
@@ -66,6 +66,8 @@ const NextSteps: React.FC<{ config: Config }> = ({ config }) => (
       <Text># - Create an .env file based on the provided template</Text>
       <Text># - Adjust the contracts to your liking</Text>
       <Text>#</Text>
+      <Newline />
+
       <Text># Deploy your contracts</Text>
       <Text color="cyan">npx hardhat lz:deploy</Text>
       <Newline />


### PR DESCRIPTION
### In this PR

- Add a box with next steps after the `create-lz-oapp` flow is done
- Modify the colors of the error next next steps to match this one (swap green comments for white comments)

<img width="1142" alt="Screenshot 2024-02-08 at 1 42 30 PM" src="https://github.com/LayerZero-Labs/devtools/assets/1451480/d8a50676-0cc7-4231-a05e-449dc8e2a0c3">