### PR TITLE
🪲 Fix tests since somebody funded the junk mnemonic

### DIFF
--- a/tests-user/tests/create-lz-oapp.bats
+++ b/tests-user/tests/create-lz-oapp.bats
@@ -92,10 +92,10 @@ teardown() {
     cd "$DESTINATION"
 
     MNEMONIC=$MNEMONIC run pnpm hardhat lz:deploy --ci
-    assert_output --partial "insufficient funds for intrinsic transaction cost"
+    refute_output --partial "No deployment found for: EndpointV2"
 
     MNEMONIC=$MNEMONIC run pnpm hardhat deploy --network sepolia
-    assert_output --partial "insufficient funds for intrinsic transaction cost"
+    refute_output --partial "No deployment found for: EndpointV2"
 }
 
 # This test is a bit ridiculous because it basically checks that we error out
@@ -108,10 +108,10 @@ teardown() {
     cd "$DESTINATION"
 
     MNEMONIC=$MNEMONIC run pnpm hardhat lz:deploy --ci
-    assert_output --partial "insufficient funds for intrinsic transaction cost"
+    refute_output --partial "No deployment found for: EndpointV2"
 
     MNEMONIC=$MNEMONIC run pnpm hardhat deploy --network sepolia
-    assert_output --partial "insufficient funds for intrinsic transaction cost"
+    refute_output --partial "No deployment found for: EndpointV2"
 }
 
 @test "should work with pnpm & oapp example in CI mode" {


### PR DESCRIPTION
### In this PR

- Look for the exact problem when deploying contracts in user tests - sometimes the junk `MNEMONIC` turns out to be funded and the contracts actually deploy