### PR TITLE
🧹 Lock versions of ethers & @openzeppelin/contracts in examples

### DIFF
--- a/.changeset/polite-jeans-clap.md
+++ b/.changeset/polite-jeans-clap.md
@@ -1,0 +1,7 @@
+---
+"create-lz-oapp": patch
+"@layerzerolabs/oapp-example": patch
+"@layerzerolabs/oft-example": patch
+---
+
+Lock versions of ethers & @openzeppelin/contracts in packages; Put pnpm first in create-lz-oapp

--- a/examples/oapp/package.json
+++ b/examples/oapp/package.json
@@ -16,6 +16,10 @@
     "test:forge": "forge test",
     "test:hardhat": "hardhat test"
   },
+  "resolutions": {
+    "@openzeppelin/contracts": "^5.0.1",
+    "ethers": "^5.7.2"
+  },
   "devDependencies": {
     "@babel/core": "^7.23.9",
     "@layerzerolabs/eslint-config-next": "^2.1.7",
@@ -51,5 +55,15 @@
   },
   "engines": {
     "node": ">=18.16.0"
+  },
+  "overrides": {
+    "@openzeppelin/contracts": "^5.0.1",
+    "ethers": "^5.7.2"
+  },
+  "pnpm": {
+    "overrides": {
+      "@openzeppelin/contracts": "^5.0.1",
+      "ethers": "^5.7.2"
+    }
   }
 }

--- a/examples/oft/package.json
+++ b/examples/oft/package.json
@@ -16,6 +16,10 @@
     "test:forge": "forge test",
     "test:hardhat": "hardhat test"
   },
+  "resolutions": {
+    "@openzeppelin/contracts": "^5.0.1",
+    "ethers": "^5.7.2"
+  },
   "devDependencies": {
     "@babel/core": "^7.23.9",
     "@layerzerolabs/eslint-config-next": "^2.1.7",
@@ -51,5 +55,15 @@
   },
   "engines": {
     "node": ">=18.16.0"
+  },
+  "overrides": {
+    "@openzeppelin/contracts": "^5.0.1",
+    "ethers": "^5.7.2"
+  },
+  "pnpm": {
+    "overrides": {
+      "@openzeppelin/contracts": "^5.0.1",
+      "ethers": "^5.7.2"
+    }
   }
 }

--- a/packages/create-lz-oapp/src/config.ts
+++ b/packages/create-lz-oapp/src/config.ts
@@ -35,9 +35,15 @@ export const EXAMPLES: Example[] = [
 
 export const PACKAGE_MANAGERS: PackageManager[] = [
     {
+        id: 'pnpm',
+        executable: 'pnpm',
+        args: ['install'],
+        label: 'pnpm (recommended)',
+    },
+    {
         id: 'npm',
         executable: 'npm',
-        args: ['install', '--legacy-peer-deps'],
+        args: ['install'],
         label: 'npm',
     },
     {
@@ -45,12 +51,6 @@ export const PACKAGE_MANAGERS: PackageManager[] = [
         executable: 'yarn',
         args: ['install'],
         label: 'yarn',
-    },
-    {
-        id: 'pnpm',
-        executable: 'pnpm',
-        args: ['install'],
-        label: 'pnpm (recommended)',
     },
     {
         id: 'bun',


### PR DESCRIPTION
### In this PR

- Lock versions of ethers & @openzeppelin/contracts in examples to prevent installation issues (having to use `npm install --force`)
- List `pnpm` as the first option in `create-lz-oapp` since we recommend it