### PR TITLE
🪲 Export ABIs as constants for better viem integration

### DIFF
--- a/.changeset/shiny-years-join.md
+++ b/.changeset/shiny-years-join.md
@@ -1,0 +1,6 @@
+---
+"@layerzerolabs/export-deployments-test": patch
+"@layerzerolabs/export-deployments": patch
+---
+
+Export all ABIs as constants

--- a/packages/export-deployments/src/generator/typescript/generate.ts
+++ b/packages/export-deployments/src/generator/typescript/generate.ts
@@ -11,6 +11,7 @@ import {
     createExportConst,
     createIdentifier,
     createStringLiteral,
+    creteAsConst,
     normalizeIdentifierName,
     printTSFile,
     recordToObjectLiteral,
@@ -128,7 +129,16 @@ const transformGroupedContractInformation = ({ addresses, abis, transactionHashe
                 uniqueAbis,
                 // Take the array of unique ABIs and turn them into a list of variable declarations
                 A.mapWithIndex((index, abi) =>
-                    pipe(abi, runtimeObjectToExpressionSafe, E.map(createConst()(createAbiIdentifier(index))))
+                    pipe(
+                        abi,
+                        runtimeObjectToExpressionSafe,
+                        // Add "as const" to the exported ABIs
+                        //
+                        // This is very useful for e.g. viem that infers a lot of the information
+                        // based on the shape of the ABI
+                        E.map(creteAsConst),
+                        E.map(createConst()(createAbiIdentifier(index)))
+                    )
                 ),
                 A.sequence(E.Applicative),
                 // With the declarations ready, we can construct an object that maps a network name

--- a/packages/export-deployments/src/generator/typescript/typescript.ts
+++ b/packages/export-deployments/src/generator/typescript/typescript.ts
@@ -31,6 +31,18 @@ export const createConst =
             )
         )
 
+/**
+ * Wraps an expression with "as const"
+ *
+ * @param {Expression} expression
+ * @returns {Expression}
+ */
+export const creteAsConst = (expression: Expression): Expression =>
+    factory.createAsExpression(
+        expression,
+        factory.createTypeReferenceNode(factory.createIdentifier('const'), undefined)
+    )
+
 export const createIdentifier = factory.createIdentifier
 
 export const createStringLiteral = factory.createStringLiteral

--- a/tests/export-deployments-test/test/export.test.ts
+++ b/tests/export-deployments-test/test/export.test.ts
@@ -4,6 +4,7 @@
 import { spawnSync } from 'child_process'
 import { join } from 'path'
 import { isDirectory } from '@layerzerolabs/io-devtools'
+import { readFileSync } from 'fs'
 
 describe(`export`, () => {
     describe('expectations', () => {
@@ -101,6 +102,15 @@ describe(`export`, () => {
                     tango: expect.any(String),
                 },
             })
+        })
+
+        it('should include "as const" when exporting the ABIs', async () => {
+            const result = runExpect('export-all')
+
+            expect(result.status).toBe(0)
+
+            const generated = readFileSync(join(__dirname, '..', 'generated', 'Test.ts'), 'utf8')
+            expect(generated).toMatch(/as const/)
         })
     })
 })


### PR DESCRIPTION
### In this PR

- `viem` relies on ABIs defined as constant expressions, without type widening, for ABI type inferrence. This PR adds `as const` to ABI exports to better support `viem` in all its adventures