### PR TITLE
🪲 Make verify-contract package public again

### DIFF
--- a/packages/verify-contract/package.json
+++ b/packages/verify-contract/package.json
@@ -45,5 +45,8 @@
     "tsup": "^8.0.1",
     "typescript": "^5.3.3",
     "zod": "^3.22.4"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }


### PR DESCRIPTION
### In this PR

- Adding public access configuration to `@layerzerolabs/verify-contract`