### PR TITLE
🪲 Add resolutions to examples

### DIFF
--- a/examples/oapp/package.json
+++ b/examples/oapp/package.json
@@ -18,6 +18,7 @@
   },
   "resolutions": {
     "@openzeppelin/contracts": "^5.0.1",
+    "@openzeppelin/contracts-upgradeable": "^5.0.1",
     "ethers": "^5.7.2"
   },
   "devDependencies": {
@@ -58,11 +59,13 @@
   },
   "overrides": {
     "@openzeppelin/contracts": "^5.0.1",
+    "@openzeppelin/contracts-upgradeable": "^5.0.1",
     "ethers": "^5.7.2"
   },
   "pnpm": {
     "overrides": {
       "@openzeppelin/contracts": "^5.0.1",
+      "@openzeppelin/contracts-upgradeable": "^5.0.1",
       "ethers": "^5.7.2"
     }
   }

--- a/examples/oft/package.json
+++ b/examples/oft/package.json
@@ -18,6 +18,7 @@
   },
   "resolutions": {
     "@openzeppelin/contracts": "^5.0.1",
+    "@openzeppelin/contracts-upgradeable": "^5.0.1",
     "ethers": "^5.7.2"
   },
   "devDependencies": {
@@ -58,11 +59,13 @@
   },
   "overrides": {
     "@openzeppelin/contracts": "^5.0.1",
+    "@openzeppelin/contracts-upgradeable": "^5.0.1",
     "ethers": "^5.7.2"
   },
   "pnpm": {
     "overrides": {
       "@openzeppelin/contracts": "^5.0.1",
+      "@openzeppelin/contracts-upgradeable": "^5.0.1",
       "ethers": "^5.7.2"
     }
   }


### PR DESCRIPTION
### In this PR

- Adding resolutions for `@openzeppelin/contracts-upgradeable` to example projects since NPM installation in the user tests started failing because of a peer dependency requirement not being met