### PR TITLE
🧹 Update retry logic & exclude typescript from the bundle

### DIFF
--- a/.changeset/cool-spiders-ring.md
+++ b/.changeset/cool-spiders-ring.md
@@ -1,0 +1,5 @@
+---
+"@layerzerolabs/ua-devtools-evm-hardhat": patch
+---
+
+Use retry functionality provided by devtools

--- a/packages/ua-devtools-evm-hardhat/package.json
+++ b/packages/ua-devtools-evm-hardhat/package.json
@@ -36,7 +36,6 @@
     "lint:fix": "eslint --fix '**/*.{js,ts,json}'"
   },
   "dependencies": {
-    "exponential-backoff": "~3.1.1",
     "p-memoize": "~4.0.4",
     "typescript": "^5.3.3"
   },

--- a/packages/ua-devtools-evm-hardhat/package.json
+++ b/packages/ua-devtools-evm-hardhat/package.json
@@ -37,7 +37,8 @@
   },
   "dependencies": {
     "exponential-backoff": "~3.1.1",
-    "p-memoize": "~4.0.4"
+    "p-memoize": "~4.0.4",
+    "typescript": "^5.3.3"
   },
   "devDependencies": {
     "@ethersproject/abi": "^5.7.0",
@@ -66,7 +67,6 @@
     "jest": "^29.7.0",
     "ts-node": "^10.9.2",
     "tsup": "~8.0.1",
-    "typescript": "^5.3.3",
     "zod": "^3.22.4"
   },
   "peerDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1319,12 +1319,12 @@ importers:
 
   packages/ua-devtools-evm-hardhat:
     dependencies:
-      exponential-backoff:
-        specifier: ~3.1.1
-        version: 3.1.1
       p-memoize:
         specifier: ~4.0.4
         version: 4.0.4
+      typescript:
+        specifier: ^5.3.3
+        version: 5.3.3
     devDependencies:
       '@ethersproject/abi':
         specifier: ^5.7.0
@@ -1404,9 +1404,6 @@ importers:
       tsup:
         specifier: ~8.0.1
         version: 8.0.1(@swc/core@1.4.0)(ts-node@10.9.2)(typescript@5.3.3)
-      typescript:
-        specifier: ^5.3.3
-        version: 5.3.3
       zod:
         specifier: ^3.22.4
         version: 3.22.4
@@ -7695,6 +7692,7 @@ packages:
     dependencies:
       is-hex-prefixed: 1.0.0
       strip-hex-prefix: 1.0.0
+    bundledDependencies: false
 
   /eventemitter3@4.0.4:
     resolution: {integrity: sha512-rlaVLnVxtxvoyLsQQFBx53YmXHDxRIzzTLbdfxqi4yocpSjAxXwkU0cScM5JgSKMqEhrZpnvQ2D9gjylR0AimQ==}


### PR DESCRIPTION
### In this PR

- Use the existing retry logic when generating LayerZero configs
- Don't include `typescript` in the bundle, move it to `dependencies` instead