### PR TITLE
🧹 Fix lint warnings for verify-contract

### DIFF
--- a/.changeset/lucky-pillows-hunt.md
+++ b/.changeset/lucky-pillows-hunt.md
@@ -1,0 +1,5 @@
+---
+"@layerzerolabs/verify-contract": patch
+---
+
+Fix lint warnings for verify-contract package

--- a/packages/verify-contract/src/cli.ts
+++ b/packages/verify-contract/src/cli.ts
@@ -1,9 +1,25 @@
 import { Command, InvalidOptionArgumentError, Option } from 'commander'
 import { verifyTarget, verifyNonTarget } from './hardhat-deploy/verify'
 import { COLORS } from './common/logger'
-import { createLogger } from '@layerzerolabs/io-devtools'
-import { VerifyHardhatNonTargetConfig, type VerifyHardhatTargetConfig } from './hardhat-deploy/types'
+import { type LogLevel, createLogger } from '@layerzerolabs/io-devtools'
+import { type VerifyHardhatNonTargetConfig, type VerifyHardhatTargetConfig } from './hardhat-deploy/types'
 import { version } from '../package.json'
+
+interface CommonArgs {
+    apiKey?: string
+    apiUrl?: string
+    deployments?: string
+    dryRun?: boolean
+    logLevel: LogLevel
+    network: string
+}
+
+interface NonTargetArgs extends CommonArgs {
+    address: string
+    arguments?: string[]
+    deployment: string
+    name: string
+}
 
 const logLevelOption = new Option('-l,--log-level <level>', 'Log level')
     .choices(['error', 'warn', 'info', 'http', 'verbose', 'debug', 'silly'])
@@ -51,7 +67,7 @@ const verifyNonTargetCommand = new Command('non-target')
             }
         }
     )
-    .action(async (args: any) => {
+    .action(async (args: NonTargetArgs) => {
         const logger = createLogger(args.logLevel)
         const config: VerifyHardhatNonTargetConfig = {
             dryRun: args.dryRun,
@@ -84,6 +100,10 @@ const verifyNonTargetCommand = new Command('non-target')
         }
     })
 
+interface TargetArgs extends CommonArgs {
+    contracts?: string[]
+}
+
 const verifyTargetCommand = new Command('target')
     .description('Verifies contracts that have been a part of a deployment, i.e. have their own deployment files')
     .addOption(logLevelOption)
@@ -99,7 +119,7 @@ const verifyTargetCommand = new Command('target')
             return value?.trim() ? value.split(',').map((c: string) => c.trim()) : undefined
         }
     )
-    .action(async (args: any) => {
+    .action(async (args: TargetArgs) => {
         const logger = createLogger(args.logLevel)
         const config: VerifyHardhatTargetConfig = {
             dryRun: args.dryRun,

--- a/packages/verify-contract/src/common/abi.ts
+++ b/packages/verify-contract/src/common/abi.ts
@@ -1,5 +1,5 @@
 import assert from 'assert'
-import { Interface } from '@ethersproject/abi'
+import { Interface, type JsonFragment } from '@ethersproject/abi'
 import { type MinimalAbi } from './schema'
 import * as parser from '@solidity-parser/parser'
 import { TypeName, type FunctionDefinition } from '@solidity-parser/parser/dist/src/ast-types'
@@ -12,7 +12,7 @@ import { TypeName, type FunctionDefinition } from '@solidity-parser/parser/dist/
  * @param args Constructor arguments
  * @returns
  */
-export const encodeContructorArguments = (abi: any[], args: unknown[] | undefined): string | undefined => {
+export const encodeContructorArguments = (abi: JsonFragment[], args: unknown[] | undefined): string | undefined => {
     if (args == null || args.length === 0) return undefined
 
     const iface = new Interface(abi)


### PR DESCRIPTION
### In this PR

- Remove `any` types in favour of interfaces for the `@layerzerolabs/verify-contract` package