### PR TITLE
🧹 Set correct exit codes for failed hardhat tasks

### DIFF
--- a/.changeset/stupid-falcons-hope.md
+++ b/.changeset/stupid-falcons-hope.md
@@ -1,0 +1,6 @@
+---
+"@layerzerolabs/ua-devtools-evm-hardhat": patch
+"@layerzerolabs/devtools-evm-hardhat": patch
+---
+
+Mark hardhat tasks with exit code 1 if they were not successful

--- a/packages/devtools-evm-hardhat/src/tasks/deploy.ts
+++ b/packages/devtools-evm-hardhat/src/tasks/deploy.ts
@@ -261,6 +261,9 @@ const action: ActionType<TaskArgs> = async (
             }))
         )
 
+    // Mark the process as unsuccessful (only if it has not yet been marked as such)
+    process.exitCode = process.exitCode || 1
+
     return results
 }
 

--- a/packages/ua-devtools-evm-hardhat/src/tasks/oapp/wire/index.ts
+++ b/packages/ua-devtools-evm-hardhat/src/tasks/oapp/wire/index.ts
@@ -61,10 +61,14 @@ const action: ActionType<TaskArgs> = async (
         )
     )
     // Now sign & send the transactions
-    const signAndSendResult = await hre.run(SUBTASK_LZ_SIGN_AND_SEND, {
+    const signAndSendResult: SignAndSendResult = await hre.run(SUBTASK_LZ_SIGN_AND_SEND, {
         transactions,
         ci,
     } satisfies SignAndSendTaskArgs)
+
+    // Mark the process as unsuccessful if there were any errors (only if it has not yet been marked as such)
+    const [, failed] = signAndSendResult
+    if (failed.length !== 0) process.exitCode = process.exitCode || 1
 
     return signAndSendResult
 }

--- a/tests/ua-devtools-evm-hardhat-test/test/task/oapp/wire.test.ts
+++ b/tests/ua-devtools-evm-hardhat-test/test/task/oapp/wire.test.ts
@@ -198,10 +198,22 @@ describe(`task ${TASK_LZ_OAPP_WIRE}`, () => {
                 sendTransactionMock.mockRestore()
             })
 
+            it('should set the exit code to 1', async () => {
+                const error = new Error('Oh god dammit')
+
+                // We want to make the transaction fail
+                sendTransactionMock.mockRejectedValue(error)
+
+                const oappConfig = configPathFixture('valid.config.connected.js')
+                await hre.run(TASK_LZ_OAPP_WIRE, { oappConfig, ci: true })
+
+                expect(process.exitCode).toBe(1)
+            })
+
             it('should return a list of failed transactions in the CI mode', async () => {
                 const error = new Error('Oh god dammit')
 
-                // We want to make the fail
+                // We want to make the transaction fail
                 sendTransactionMock.mockRejectedValue(error)
 
                 const oappConfig = configPathFixture('valid.config.connected.js')


### PR DESCRIPTION
### In this PR

- Set correct error exit codes when hardhat tasks fail. This is necessary to be able to correctly detect the state of the task on the command line since in case of error we don't want to throw or exit (for composability reasons) to be able to pass the exact error state to the consumer [*]

[*] JavaScript errors are not typed so for us to be able to pass a typed information about the error state we would need to resort to a bit more advanced techniques like [`Either`](https://itnext.io/either-monad-a-functional-approach-to-error-handling-in-js-ffdc2917ab2) which we can do but not as of yet