### PR TITLE
🪲 Workflow triggers

### DIFF
--- a/.github/workflows/on-develop.yaml
+++ b/.github/workflows/on-develop.yaml
@@ -11,10 +11,8 @@
 name: Check code submission
 
 on:
-  push:
-    # We have package publishing workflow running on main so this one is redundant
-    branches-ignore:
-      - "main"
+  pull_request:
+  workflow_dispatch:
 
 # We want the workflow to stop and yield to a new run if new code is pushed
 concurrency:

--- a/.github/workflows/reusable-test.yaml
+++ b/.github/workflows/reusable-test.yaml
@@ -98,7 +98,7 @@ jobs:
         run: pnpm test:user
         env:
           LAYERZERO_EXAMPLES_REPOSITORY_URL: https://github.com/${{ github.repository }}.git
-          LAYERZERO_EXAMPLES_REPOSITORY_REF: ${{ github.ref_name }}
+          LAYERZERO_EXAMPLES_REPOSITORY_REF: ${{ github.ref }}
 
       # We'll collect the docker compose logs from all containers on failure
       - name: Collect docker logs on failure


### PR DESCRIPTION
### In this PR

- Fixing an issue with workflows from forks not being run at all. The problem is that pull requests from forks don't trigger a `push` github event ([see here](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull-request-events-for-forked-repositories)) so these workflows would never get triggered and the button [mentioned here](https://docs.github.com/en/actions/managing-workflow-runs/approving-workflow-runs-from-public-forks#approving-workflow-runs-on-a-pull-request-from-a-public-fork) does not appear at all
- To allow an arbitrary workflow run on a branch for which there is no PR (some work in progress branch), `workflow_dispatch` trigger has been added as well