### PR TITLE
🧹 Make value attribute optional in enforced options

### DIFF
--- a/.changeset/dry-humans-smash.md
+++ b/.changeset/dry-humans-smash.md
@@ -1,0 +1,5 @@
+---
+"@layerzerolabs/ua-devtools": patch
+---
+
+Make value optional in enforced options

--- a/packages/ua-devtools/src/oapp/schema.ts
+++ b/packages/ua-devtools/src/oapp/schema.ts
@@ -32,7 +32,7 @@ export const ExecutorLzReceiveOptionSchema = z.object({
     msgType: UIntNumberSchema,
     optionType: z.literal(ExecutorOptionType.LZ_RECEIVE),
     gas: UIntNumberSchema,
-    value: UIntNumberSchema,
+    value: UIntNumberSchema.optional(),
 }) satisfies z.ZodSchema<ExecutorLzReceiveOption, z.ZodTypeDef, unknown>
 
 export const ExecutorNativeDropOptionSchema = z.object({
@@ -47,7 +47,7 @@ export const ExecutorComposeOptionSchema = z.object({
     optionType: z.literal(ExecutorOptionType.COMPOSE),
     index: UIntNumberSchema,
     gas: UIntNumberSchema,
-    value: UIntNumberSchema,
+    value: UIntNumberSchema.optional(),
 }) satisfies z.ZodSchema<ExecutorComposeOption, z.ZodTypeDef, unknown>
 
 export const ExecutorOrderedExecutionOptionSchema = z.object({

--- a/packages/ua-devtools/src/oapp/types.ts
+++ b/packages/ua-devtools/src/oapp/types.ts
@@ -60,7 +60,7 @@ export interface EncodedOption extends BaseExecutorOption {
 export interface ExecutorLzReceiveOption extends BaseExecutorOption {
     optionType: ExecutorOptionType.LZ_RECEIVE
     gas: PossiblyBigInt
-    value: PossiblyBigInt
+    value?: PossiblyBigInt
 }
 
 export interface ExecutorNativeDropOption extends BaseExecutorOption {
@@ -73,7 +73,7 @@ export interface ExecutorComposeOption extends BaseExecutorOption {
     optionType: ExecutorOptionType.COMPOSE
     index: number
     gas: PossiblyBigInt
-    value: PossiblyBigInt
+    value?: PossiblyBigInt
 }
 
 export interface ExecutorOrderedExecutionOption extends BaseExecutorOption {


### PR DESCRIPTION
### In this PR

- `value` property is not required and has been made optional in `ExecutorComposeOption` and `ExecutorLzReceiveOption`