### PR TITLE
🧹 Make properties of Uln302 config optional

### DIFF
--- a/.changeset/tasty-cougars-tie.md
+++ b/.changeset/tasty-cougars-tie.md
@@ -1,0 +1,7 @@
+---
+"@layerzerolabs/protocol-devtools-evm": patch
+"@layerzerolabs/protocol-devtools": patch
+"@layerzerolabs/ua-devtools": patch
+---
+
+Make properties of Uln302 config optional

--- a/packages/protocol-devtools-evm/src/endpointv2/sdk.ts
+++ b/packages/protocol-devtools-evm/src/endpointv2/sdk.ts
@@ -8,6 +8,7 @@ import type {
     Uln302Factory,
     Uln302SetUlnConfig,
     Uln302UlnConfig,
+    Uln302UlnUserConfig,
 } from '@layerzerolabs/protocol-devtools'
 import {
     formatEid,
@@ -296,7 +297,12 @@ export class EndpointV2 extends OmniSDK implements IEndpointV2 {
     /**
      * @see {@link IEndpointV2.hasAppUlnConfig}
      */
-    async hasAppUlnConfig(oapp: string, uln: OmniAddress, eid: EndpointId, config: Uln302UlnConfig): Promise<boolean> {
+    async hasAppUlnConfig(
+        oapp: string,
+        uln: OmniAddress,
+        eid: EndpointId,
+        config: Uln302UlnUserConfig
+    ): Promise<boolean> {
         const ulnSdk = await this.getUln302SDK(uln)
 
         return ulnSdk.hasAppUlnConfig(eid, oapp, config)

--- a/packages/protocol-devtools-evm/src/uln302/sdk.ts
+++ b/packages/protocol-devtools-evm/src/uln302/sdk.ts
@@ -1,5 +1,10 @@
 import type { EndpointId } from '@layerzerolabs/lz-definitions'
-import type { IUln302, Uln302ExecutorConfig, Uln302UlnConfig } from '@layerzerolabs/protocol-devtools'
+import type {
+    IUln302,
+    Uln302ExecutorConfig,
+    Uln302UlnConfig,
+    Uln302UlnUserConfig,
+} from '@layerzerolabs/protocol-devtools'
 import {
     OmniAddress,
     formatEid,
@@ -53,7 +58,7 @@ export class Uln302 extends OmniSDK implements IUln302 {
     /**
      * @see {@link IUln302.hasAppUlnConfig}
      */
-    async hasAppUlnConfig(eid: EndpointId, oapp: string, config: Uln302UlnConfig): Promise<boolean> {
+    async hasAppUlnConfig(eid: EndpointId, oapp: string, config: Uln302UlnUserConfig): Promise<boolean> {
         const currentConfig = await this.getAppUlnConfig(eid, oapp)
         const currentSerializedConfig = this.serializeUlnConfig(currentConfig)
         const serializedConfig = this.serializeUlnConfig(config)
@@ -142,14 +147,14 @@ export class Uln302 extends OmniSDK implements IUln302 {
         return Uln302UlnConfigSchema.parse({ ...rtnConfig })
     }
 
-    encodeUlnConfig(config: Uln302UlnConfig): string {
+    encodeUlnConfig(config: Uln302UlnUserConfig): string {
         const serializedConfig = this.serializeUlnConfig(config)
         const encoded = this.contract.contract.interface.encodeFunctionResult('getUlnConfig', [serializedConfig])
 
         return assert(typeof encoded === 'string', 'Must be a string'), encoded
     }
 
-    async setDefaultUlnConfig(eid: EndpointId, config: Uln302UlnConfig): Promise<OmniTransaction> {
+    async setDefaultUlnConfig(eid: EndpointId, config: Uln302UlnUserConfig): Promise<OmniTransaction> {
         const serializedConfig = this.serializeUlnConfig(config)
         const data = this.contract.contract.interface.encodeFunctionData('setDefaultUlnConfigs', [
             [
@@ -173,15 +178,15 @@ export class Uln302 extends OmniSDK implements IUln302 {
      * contracts (for optimization purposes) but don't need to be present
      * in our configuration and ensuring correct checksum on the DVN addresses.
      *
-     * @param {Uln302UlnConfig} config
+     * @param {Uln302UlnUserConfig} config
      * @returns {SerializedUln302UlnConfig}
      */
     protected serializeUlnConfig({
-        confirmations,
+        confirmations = BigInt(0),
         requiredDVNs,
-        optionalDVNs,
-        optionalDVNThreshold,
-    }: Uln302UlnConfig): SerializedUln302UlnConfig {
+        optionalDVNs = [],
+        optionalDVNThreshold = 0,
+    }: Uln302UlnUserConfig): SerializedUln302UlnConfig {
         return {
             confirmations,
             optionalDVNThreshold,

--- a/packages/protocol-devtools/src/endpointv2/types.ts
+++ b/packages/protocol-devtools/src/endpointv2/types.ts
@@ -9,7 +9,7 @@ import type {
     PossiblyBytes,
 } from '@layerzerolabs/devtools'
 import type { EndpointId } from '@layerzerolabs/lz-definitions'
-import type { IUln302, Uln302ExecutorConfig, Uln302UlnConfig } from '@/uln302/types'
+import type { IUln302, Uln302ExecutorConfig, Uln302UlnConfig, Uln302UlnUserConfig } from '@/uln302/types'
 
 export interface IEndpointV2 extends IOmniSDK {
     getUln302SDK(address: OmniAddress): Promise<IUln302>
@@ -158,10 +158,10 @@ export interface IEndpointV2 extends IOmniSDK {
      * @param {OmniAddress} oapp
      * @param {OmniAddress} uln
      * @param {EndpointId} eid
-     * @param {Uln302UlnConfig} config
+     * @param {Uln302UlnUserConfig} config
      * @returns {Promise<boolean>} `true` if the config has been explicitly set, `false` otherwise
      */
-    hasAppUlnConfig(oapp: OmniAddress, uln: OmniAddress, eid: EndpointId, config: Uln302UlnConfig): Promise<boolean>
+    hasAppUlnConfig(oapp: OmniAddress, uln: OmniAddress, eid: EndpointId, config: Uln302UlnUserConfig): Promise<boolean>
 
     setUlnConfig(oapp: OmniAddress, uln: OmniAddress, setUlnConfig: Uln302SetUlnConfig[]): Promise<OmniTransaction>
 
@@ -179,7 +179,7 @@ export interface Uln302SetExecutorConfig {
 
 export interface Uln302SetUlnConfig {
     eid: EndpointId
-    ulnConfig: Uln302UlnConfig
+    ulnConfig: Uln302UlnUserConfig
 }
 
 export interface SetConfigParam {

--- a/packages/protocol-devtools/src/uln302/types.ts
+++ b/packages/protocol-devtools/src/uln302/types.ts
@@ -36,12 +36,12 @@ export interface IUln302 extends IOmniSDK {
      *
      * @param {EndpointId} eid
      * @param {OmniAddress} oapp
-     * @param {Uln302UlnConfig} config
+     * @param {Uln302UlnUserConfig} config
      * @returns {Promise<boolean>} `true` if the config has been explicitly set, `false` otherwise
      */
-    hasAppUlnConfig(eid: EndpointId, oapp: OmniAddress, config: Uln302UlnConfig): Promise<boolean>
+    hasAppUlnConfig(eid: EndpointId, oapp: OmniAddress, config: Uln302UlnUserConfig): Promise<boolean>
 
-    setDefaultUlnConfig(eid: EndpointId, config: Uln302UlnConfig): Promise<OmniTransaction>
+    setDefaultUlnConfig(eid: EndpointId, config: Uln302UlnUserConfig): Promise<OmniTransaction>
 
     /**
      * Gets the Executor config for a given endpoint ID and an address.
@@ -97,9 +97,20 @@ export interface Uln302UlnConfig {
     optionalDVNs: string[]
 }
 
+/**
+ * Uln302UlnConfig interface with optional properties left out
+ * for user convenience.
+ */
+export interface Uln302UlnUserConfig {
+    confirmations?: bigint
+    optionalDVNThreshold?: number
+    requiredDVNs: string[]
+    optionalDVNs?: string[]
+}
+
 export interface Uln302NodeConfig {
     defaultExecutorConfigs: [eid: EndpointId, config: Uln302ExecutorConfig][]
-    defaultUlnConfigs: [eid: EndpointId, config: Uln302UlnConfig][]
+    defaultUlnConfigs: [eid: EndpointId, config: Uln302UlnUserConfig][]
 }
 
 export type Uln302OmniGraph = OmniGraph<Uln302NodeConfig, unknown>

--- a/packages/ua-devtools/src/oapp/types.ts
+++ b/packages/ua-devtools/src/oapp/types.ts
@@ -1,5 +1,5 @@
 import type { EndpointId } from '@layerzerolabs/lz-definitions'
-import type { IEndpointV2, Timeout, Uln302ExecutorConfig, Uln302UlnConfig } from '@layerzerolabs/protocol-devtools'
+import type { IEndpointV2, Timeout, Uln302ExecutorConfig, Uln302UlnUserConfig } from '@layerzerolabs/protocol-devtools'
 import type {
     Bytes,
     Factory,
@@ -29,11 +29,11 @@ export interface OAppReceiveLibraryConfig {
 
 export interface OAppSendConfig {
     executorConfig?: Uln302ExecutorConfig
-    ulnConfig?: Uln302UlnConfig
+    ulnConfig?: Uln302UlnUserConfig
 }
 
 export interface OAppReceiveConfig {
-    ulnConfig?: Uln302UlnConfig
+    ulnConfig?: Uln302UlnUserConfig
 }
 
 export interface OAppEdgeConfig {


### PR DESCRIPTION
### In this PR

- Creating a new type for Uln302 configuration user input - `Uln302UlnUserConfig`. This type makes some of the properties optional in order to simplify user configuration