### PR TITLE
Patch: add in missing @return annotation tag in MyOApp.sol

### DIFF
--- a/examples/oapp/contracts/MyOApp.sol
+++ b/examples/oapp/contracts/MyOApp.sol
@@ -34,6 +34,7 @@ contract MyOApp is OApp {
      * @param _message The message.
      * @param _options Message execution options (e.g., for sending gas to destination).
      * @param _payInLzToken Whether to return fee in ZRO token.
+     * @return fee A `MessagingFee` struct containing the calculated gas fee in either the native token or ZRO token.
      */
     function quote(
         uint32 _dstEid,


### PR DESCRIPTION
### **Purpose:**

- A patch to add in a missing `@return` annotation tag in the `quote` function from MyOApp.sol.

### **Overview:**

- The annotation tag description is as follows: "A `MessagingFee` struct containing the calculated gas fee in either the native token or ZRO token.".
- The annotation tag description is equivalent to the description defined in the `_quote` function from LayerZero-v2/oapp/contracts/oapp/OAppSender.sol.