### PR TITLE
🧹 Make lint-staged more explicit

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,11 +1,3 @@
 .turbo
 dist
 node_modules
-*.exp
-*.md
-*.sol
-*.toml
-*.yaml
-Dockerfile
-Makefile
-*.bats

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "test:user": "docker compose -f docker-compose.registry.yaml run --build --rm $DOCKER_COMPOSE_ARGS tests"
   },
   "lint-staged": {
-    "**/*": [
+    "**/*.{js,ts,tsx,json}": [
       "pnpm prettier --write --ignore-unknown",
       "pnpm eslint --fix"
     ]


### PR DESCRIPTION
### In this PR

- Make `lint-staged` more explicit when it comes to file extensions so we don't need to pile the ignored files in `.eslintignore`