### PR TITLE
🧹 Silence the bigint-buffer warning

### DIFF
--- a/.changeset/lucky-garlics-end.md
+++ b/.changeset/lucky-garlics-end.md
@@ -1,0 +1,32 @@
+---
+"@layerzerolabs/oapp-example": patch
+"@layerzerolabs/oft-example": patch
+"build-lz-options": patch
+"create-lz-oapp": patch
+"@layerzerolabs/devtools": patch
+"@layerzerolabs/devtools-evm": patch
+"@layerzerolabs/devtools-evm-hardhat": patch
+"@layerzerolabs/export-deployments": patch
+"@layerzerolabs/io-devtools": patch
+"@layerzerolabs/omnicounter-devtools": patch
+"@layerzerolabs/omnicounter-devtools-evm": patch
+"@layerzerolabs/protocol-devtools": patch
+"@layerzerolabs/protocol-devtools-evm": patch
+"@layerzerolabs/test-devtools": patch
+"@layerzerolabs/test-devtools-evm-foundry": patch
+"@layerzerolabs/test-devtools-evm-hardhat": patch
+"@layerzerolabs/toolbox-foundry": patch
+"@layerzerolabs/toolbox-hardhat": patch
+"@layerzerolabs/ua-devtools": patch
+"@layerzerolabs/ua-devtools-evm": patch
+"@layerzerolabs/ua-devtools-evm-hardhat": patch
+"@layerzerolabs/verify-contract": patch
+"@layerzerolabs/devtools-evm-hardhat-test": patch
+"@layerzerolabs/devtools-evm-test": patch
+"@layerzerolabs/export-deployments-test": patch
+"@layerzerolabs/test-evm-node": patch
+"@layerzerolabs/ua-devtools-evm-hardhat-test": patch
+"@layerzerolabs/ua-devtools-evm-hardhat-v1-test": patch
+---
+
+Silence bigint-buffer warning

--- a/Dockerfile
+++ b/Dockerfile
@@ -74,6 +74,9 @@ WORKDIR /app
 
 COPY pnpm-*.yaml .npmrc ./
 
+# Get the node_modules patches since we need them for installation
+COPY patches/ patches/
+
 RUN \
     #  Mount pnpm store
     --mount=type=cache,id=pnpm-store,target=/pnpm \

--- a/package.json
+++ b/package.json
@@ -60,5 +60,10 @@
   "packageManager": "pnpm@8.14.0",
   "engines": {
     "node": ">=18.16.0"
+  },
+  "pnpm": {
+    "patchedDependencies": {
+      "bigint-buffer@1.1.5": "patches/bigint-buffer@1.1.5.patch"
+    }
   }
 }

--- a/patches/bigint-buffer@1.1.5.patch
+++ b/patches/bigint-buffer@1.1.5.patch
@@ -1,0 +1,15 @@
+diff --git a/dist/node.js b/dist/node.js
+index 513168c89e387668a79b6beb109587b3eb41a7d0..9047683d2efecd1bc8a413d259be42888d0b3ac1 100644
+--- a/dist/node.js
++++ b/dist/node.js
+@@ -7,7 +7,9 @@ let converter;
+         converter = require('bindings')('bigint_buffer');
+     }
+     catch (e) {
+-        console.warn('bigint: Failed to load bindings, pure JS will be used (try npm run rebuild?)');
++        if (process.env.WARN_ABOUT_BIGING_BUFFER) {
++            console.warn('bigint: Failed to load bindings, pure JS will be used (try npm run rebuild?)');
++        }
+     }
+ }
+ /**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,6 +10,11 @@ overrides:
   hardhat-deploy: ^0.12.1
   rustbn.js: ^0.3.0
 
+patchedDependencies:
+  bigint-buffer@1.1.5:
+    hash: efddntnlu76geqa7be4guatjva
+    path: patches/bigint-buffer@1.1.5.patch
+
 importers:
 
   .:
@@ -4806,7 +4811,7 @@ packages:
       '@noble/hashes': 1.3.3
       '@solana/buffer-layout': 4.0.1
       agentkeepalive: 4.5.0
-      bigint-buffer: 1.1.5
+      bigint-buffer: 1.1.5(patch_hash=efddntnlu76geqa7be4guatjva)
       bn.js: 5.2.1
       borsh: 0.7.0
       bs58: 4.0.1
@@ -5987,12 +5992,13 @@ packages:
       is-windows: 1.0.2
     dev: true
 
-  /bigint-buffer@1.1.5:
+  /bigint-buffer@1.1.5(patch_hash=efddntnlu76geqa7be4guatjva):
     resolution: {integrity: sha512-trfYco6AoZ+rKhKnxA0hgX0HAbVP/s808/EuDSe2JDzUnCp/xAsli35Orvk67UrTEcwuxZqYZDmfA2RXJgxVvA==}
     engines: {node: '>= 10.0.0'}
     requiresBuild: true
     dependencies:
       bindings: 1.5.0
+    patched: true
 
   /bigint-crypto-utils@3.3.0:
     resolution: {integrity: sha512-jOTSb+drvEDxEq6OuUybOAv/xxoh3cuYRUIPyu8sSHQNKM303UQ2R1DAo45o1AkcIXw6fzbaFI1+xGGdaXs2lg==}
@@ -8121,6 +8127,7 @@ packages:
     dependencies:
       is-hex-prefixed: 1.0.0
       strip-hex-prefix: 1.0.0
+    bundledDependencies: false
 
   /eventemitter3@4.0.4:
     resolution: {integrity: sha512-rlaVLnVxtxvoyLsQQFBx53YmXHDxRIzzTLbdfxqi4yocpSjAxXwkU0cScM5JgSKMqEhrZpnvQ2D9gjylR0AimQ==}


### PR DESCRIPTION
### In this PR

- Silencing the `bigint-buffer` warning (safe since it's not being used) warning by patching the package