### PR TITLE
🗞️ Sign transactions on different chains in parallel

### DIFF
--- a/.changeset/mighty-tigers-beam.md
+++ b/.changeset/mighty-tigers-beam.md
@@ -1,0 +1,6 @@
+---
+"@layerzerolabs/ua-devtools-evm-hardhat-test": patch
+"@layerzerolabs/devtools": patch
+---
+
+Sign transactions for different chains in parallel

--- a/.changeset/three-bobcats-hear.md
+++ b/.changeset/three-bobcats-hear.md
@@ -1,0 +1,5 @@
+---
+"@layerzerolabs/devtools": patch
+---
+
+Add groupTransactionsByEid utility

--- a/packages/devtools/src/transactions/utils.ts
+++ b/packages/devtools/src/transactions/utils.ts
@@ -1,7 +1,24 @@
-import { OmniTransaction } from './types'
+import type { EndpointId } from '@layerzerolabs/lz-definitions'
+import type { OmniTransaction } from './types'
 
 const isNonNullable = <T>(value: T | null | undefined): value is T => value != null
 
 export const flattenTransactions = (
     transations: (OmniTransaction | OmniTransaction[] | null | undefined)[]
 ): OmniTransaction[] => transations.filter(isNonNullable).flat()
+
+/**
+ * Groups transactions by their `eid`, preserving the order per group
+ *
+ * @param {OmniTransaction[]} transactions
+ * @returns {Map<EndpointId, OmniTransaction[]>}
+ */
+export const groupTransactionsByEid = (transactions: OmniTransaction[]): Map<EndpointId, OmniTransaction[]> =>
+    transactions.reduce(
+        (transactionsByEid, transaction) =>
+            transactionsByEid.set(transaction.point.eid, [
+                ...(transactionsByEid.get(transaction.point.eid) ?? []),
+                transaction,
+            ]),
+        new Map<EndpointId, OmniTransaction[]>()
+    )

--- a/tests/ua-devtools-evm-hardhat-test/test/oapp/config.test.ts
+++ b/tests/ua-devtools-evm-hardhat-test/test/oapp/config.test.ts
@@ -585,7 +585,7 @@ describe('oapp/config', () => {
         })
 
         describe('configureConfig configureSendConfig and configureReceiveConfig separately', () => {
-            let bscContract: OmniContract, bscPoint: OmniPoint, bscOAppSdk: OApp
+            let bscContract: OmniContract, bscPoint: OmniPoint, bscOAppSdk: IOApp
 
             beforeEach(async () => {
                 bscContract = await contractFactory(bscPointHardhat)

--- a/tests/ua-devtools-evm-hardhat-test/test/task/oapp/wire.test.ts
+++ b/tests/ua-devtools-evm-hardhat-test/test/task/oapp/wire.test.ts
@@ -219,7 +219,13 @@ describe(`task ${TASK_LZ_OAPP_WIRE}`, () => {
                 const oappConfig = configPathFixture('valid.config.connected.js')
                 const [successful, errors, pending] = await hre.run(TASK_LZ_OAPP_WIRE, { oappConfig, ci: true })
 
+                // The transactions are being grouped by chain and signed in parallel
+                // so we expect one failure per chain
                 expect(errors).toEqual([
+                    {
+                        error,
+                        transaction: expectTransaction,
+                    },
                     {
                         error,
                         transaction: expectTransaction,
@@ -290,10 +296,11 @@ describe(`task ${TASK_LZ_OAPP_WIRE}`, () => {
                     },
                 ])
 
-                // Since we failed on the first transaction, we expect
-                // all the transaction to still be pending and none of them to be successful
-                expect(successful).toEqual([])
-                expect(pending).toEqual([expectTransaction, expectTransaction])
+                // Since we failed on the first transaction (on one chain only),
+                // we expect one transaction on the other chain to go though just fine
+                // and the failed one to appear in the pending array
+                expect(successful).toEqual([expectTransactionWithReceipt])
+                expect(pending).toEqual([expectTransaction])
             })
 
             it('should not retry successful transactions', async () => {


### PR DESCRIPTION
### In this PR

- Adjusting `createSignAndSend` to group the transactions by `eid` and sign these groups in parallel. This makes testing a bit more cumbersome because in general the order of the resulting successful transactions does not match the order of input transactions, the order is only enforced per-group
- Adding `groupTransactionsByEid` utility