### PR TITLE
🗞️ Add docker compose spec generation functionality

### DIFF
--- a/.changeset/hungry-scissors-report.md
+++ b/.changeset/hungry-scissors-report.md
@@ -1,0 +1,5 @@
+---
+"@layerzerolabs/devtools": patch
+---
+
+Add docker compose spec generation capabilities

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,6 +42,9 @@ RUN apt-get install --yes \
 RUN curl -L https://foundry.paradigm.xyz | bash
 RUN foundryup
 
+# Install docker
+RUN curl -sSL https://get.docker.com/ | sh
+
 # Enable corepack, new node package manager manager
 # 
 # See more here https://nodejs.org/api/corepack.html
@@ -55,6 +58,7 @@ RUN forge --version
 RUN anvil --version
 RUN chisel --version
 RUN cast --version
+RUN docker compose version
 
 #   .-.-.   .-.-.   .-.-.   .-.-.   .-.-.   .-.-.   .-.-.   .-.-
 #  / / \ \ / / \ \ / / \ \ / / \ \ / / \ \ / / \ \ / / \ \ / / \

--- a/packages/devtools/package.json
+++ b/packages/devtools/package.json
@@ -31,7 +31,8 @@
     "test": "jest --ci --forceExit"
   },
   "dependencies": {
-    "exponential-backoff": "~3.1.1"
+    "exponential-backoff": "~3.1.1",
+    "js-yaml": "~4.1.0"
   },
   "devDependencies": {
     "@ethersproject/bytes": "~5.7.0",

--- a/packages/devtools/src/docker/compose.ts
+++ b/packages/devtools/src/docker/compose.ts
@@ -1,0 +1,4 @@
+import { dump } from 'js-yaml'
+import type { ComposeSpec } from './types'
+
+export const serializeDockerComposeSpec = (spec: ComposeSpec): string => dump(spec)

--- a/packages/devtools/src/docker/index.ts
+++ b/packages/devtools/src/docker/index.ts
@@ -1,0 +1,2 @@
+export * from './compose'
+export * from './types'

--- a/packages/devtools/src/docker/types.ts
+++ b/packages/devtools/src/docker/types.ts
@@ -1,0 +1,113 @@
+export type ComposeSpecVersion = '3.9'
+
+export interface ComposeSpecServiceHealthcheck {
+    disable?: boolean
+    interval?: string
+    retries?: number
+    test?: string | string[]
+    timeout?: string
+    start_period?: string
+    start_interval?: string
+}
+
+export interface ComposeSpecServiceBuild {
+    context?: string
+    dockerfile?: string
+    dockerfile_inline?: string
+    args?: ListOrDict
+    ssh?: ListOrDict
+    labels?: ListOrDict
+    cache_from?: string[]
+    cache_to?: string[]
+    no_cache?: boolean
+    additional_contexts?: ListOrDict
+    network?: string
+    pull?: boolean
+    target?: string
+    shm_size?: number | string
+    extra_hosts?: ListOrDict
+    isolation?: string
+    privileged?: boolean
+    //   secrets?: ServiceConfigOrSecret;
+    tags?: string[]
+    //   ulimits?: Ulimits;
+    platforms?: string[]
+}
+
+export interface ComposeSpecPortDefinition {
+    name?: string
+    mode?: string
+    host_ip?: string
+    target?: number
+    published?: string | number
+    protocol?: string
+}
+
+export type ComposeSpecPortNumber = string | number
+
+export type ComposeSpecPort =
+    | `${ComposeSpecPortNumber}:${ComposeSpecPortNumber}`
+    | ComposeSpecPortNumber
+    | ComposeSpecPortDefinition
+
+export interface ComposeSpecServiceVolumeDefinition {
+    type: string
+    source?: string
+    target?: string
+    read_only?: boolean
+    consistency?: string
+    bind?: {
+        propagation?: string
+        create_host_path?: boolean
+        selinux?: 'z' | 'Z'
+    }
+    volume?: {
+        nocopy?: boolean
+    }
+    tmpfs?: {
+        size?: number | string
+        mode?: number
+    }
+}
+
+export type ComposeSpecServiceVolume = string | ComposeSpecServiceVolumeDefinition
+
+export type ComposeSpecDependencyCondition = 'service_started' | 'service_healthy' | 'service_completed_successfully'
+
+export interface ComposeSpecDependsOnDefinition {
+    restart?: boolean
+    required?: boolean
+    condition: ComposeSpecDependencyCondition
+}
+
+export type ComposeSpecServiceDependsOn = string[] | Record<string, ComposeSpecDependsOnDefinition>
+
+export type ComposeSpecServiceCommand = string | string[]
+
+export interface ComposeSpecService {
+    depends_on?: ComposeSpecServiceDependsOn
+    build?: string | ComposeSpecServiceBuild
+    image?: string
+    expose?: ComposeSpecPortNumber[]
+    command?: ComposeSpecServiceCommand
+    ports?: ComposeSpecPort[]
+    volumes?: ComposeSpecServiceVolume[]
+    healthcheck?: ComposeSpecServiceHealthcheck
+}
+
+export interface ComposeSpecVolumeDefinition {
+    name?: string
+    driver?: string
+    driver_opts?: Record<string, string | number>
+    labels?: ListOrDict
+}
+
+export type ComposeSpecVolume = null | ComposeSpecVolumeDefinition
+
+export interface ComposeSpec {
+    version: ComposeSpecVersion
+    services?: Record<string, ComposeSpecService>
+    volumes?: Record<string, ComposeSpecVolume>
+}
+
+export type ListOrDict = Record<string, string | number | boolean | null> | string[]

--- a/packages/devtools/src/docker/types.ts
+++ b/packages/devtools/src/docker/types.ts
@@ -20,17 +20,11 @@ export interface ComposeSpecServiceBuild {
     cache_from?: string[]
     cache_to?: string[]
     no_cache?: boolean
-    additional_contexts?: ListOrDict
     network?: string
     pull?: boolean
     target?: string
-    shm_size?: number | string
-    extra_hosts?: ListOrDict
-    isolation?: string
     privileged?: boolean
-    //   secrets?: ServiceConfigOrSecret;
     tags?: string[]
-    //   ulimits?: Ulimits;
     platforms?: string[]
 }
 

--- a/packages/devtools/src/index.ts
+++ b/packages/devtools/src/index.ts
@@ -1,4 +1,5 @@
 export * from './common'
+export * from './docker'
 export * from './omnigraph'
 export * from './transactions'
 export * from './types'

--- a/packages/devtools/test/docker/__snapshots__/compose.test.ts.snap
+++ b/packages/devtools/test/docker/__snapshots__/compose.test.ts.snap
@@ -1,0 +1,27 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`docker/compose serializeDockerComposeSpec should create a valid compose spec if called with basic services 1`] = `
+"version: '3.9'
+services:
+  redis:
+    image: redis:latest
+  codebase:
+    build: .
+    command: pnpm build
+    volumes:
+      - ./packages:/app/packages
+  postgres:
+    image: postgres
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+volumes:
+  pgdata: null
+  somevolume:
+    name: somevolumename
+"
+`;
+
+exports[`docker/compose serializeDockerComposeSpec should create a valid compose spec if called with no services 1`] = `
+"version: '3.9'
+"
+`;

--- a/packages/devtools/test/docker/compose.test.ts
+++ b/packages/devtools/test/docker/compose.test.ts
@@ -21,6 +21,8 @@ describe('docker/compose', () => {
             await writeFile(SPEC_FILE_PATH, spec)
 
             expect(validateSpec().status).toBe(0)
+
+            expect(spec).toMatchSnapshot()
         })
 
         it('should create a valid compose spec if called with basic services', async () => {
@@ -51,6 +53,8 @@ describe('docker/compose', () => {
             await writeFile(SPEC_FILE_PATH, spec)
 
             expect(validateSpec().status).toBe(0)
+
+            expect(spec).toMatchSnapshot()
         })
     })
 })

--- a/packages/devtools/test/docker/compose.test.ts
+++ b/packages/devtools/test/docker/compose.test.ts
@@ -1,0 +1,56 @@
+import { serializeDockerComposeSpec } from '@/docker/compose'
+import { spawnSync } from 'child_process'
+import { rm, writeFile } from 'fs/promises'
+import { join } from 'path'
+
+describe('docker/compose', () => {
+    describe('serializeDockerComposeSpec', () => {
+        const SPEC_FILE_PATH = join(__dirname, 'docker-compose.yaml')
+
+        const validateSpec = () => spawnSync('docker', ['compose', '-f', SPEC_FILE_PATH, 'config'])
+
+        afterEach(async () => {
+            await rm(SPEC_FILE_PATH, { force: true })
+        })
+
+        it('should create a valid compose spec if called with no services', async () => {
+            const spec = serializeDockerComposeSpec({
+                version: '3.9',
+            })
+
+            await writeFile(SPEC_FILE_PATH, spec)
+
+            expect(validateSpec().status).toBe(0)
+        })
+
+        it('should create a valid compose spec if called with basic services', async () => {
+            const spec = serializeDockerComposeSpec({
+                version: '3.9',
+                services: {
+                    redis: {
+                        image: 'redis:latest',
+                    },
+                    codebase: {
+                        build: '.',
+                        command: 'pnpm build',
+                        volumes: ['./packages:/app/packages'],
+                    },
+                    postgres: {
+                        image: 'postgres',
+                        volumes: ['pgdata:/var/lib/postgresql/data'],
+                    },
+                },
+                volumes: {
+                    pgdata: null,
+                    somevolume: {
+                        name: 'somevolumename',
+                    },
+                },
+            })
+
+            await writeFile(SPEC_FILE_PATH, spec)
+
+            expect(validateSpec().status).toBe(0)
+        })
+    })
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -417,6 +417,9 @@ importers:
       exponential-backoff:
         specifier: ~3.1.1
         version: 3.1.1
+      js-yaml:
+        specifier: ~4.1.0
+        version: 4.1.0
     devDependencies:
       '@ethersproject/bytes':
         specifier: ~5.7.0


### PR DESCRIPTION
### In this PR

- Adding generic code generation capabilities for `docker-compose.yaml` files. These will eventually support a dynamic containerized local development environment. The types have been generated from a JSON schema [here](https://raw.githubusercontent.com/compose-spec/compose-spec/master/schema/compose-spec.json) and pruned a bit