### PR TITLE
🪲 Adjust schemas after making the ULN config types optional

### DIFF
--- a/.changeset/mean-chicken-tell.md
+++ b/.changeset/mean-chicken-tell.md
@@ -1,0 +1,6 @@
+---
+"@layerzerolabs/protocol-devtools": patch
+"@layerzerolabs/ua-devtools": patch
+---
+
+Adjust schemas after making ULN config types optional

--- a/packages/protocol-devtools/src/uln302/schema.ts
+++ b/packages/protocol-devtools/src/uln302/schema.ts
@@ -1,6 +1,6 @@
 import { AddressSchema, UIntBigIntSchema, UIntNumberSchema } from '@layerzerolabs/devtools'
 import { z } from 'zod'
-import { Uln302ExecutorConfig, Uln302UlnConfig } from './types'
+import { Uln302ExecutorConfig, Uln302UlnConfig, Uln302UlnUserConfig } from './types'
 
 export const Uln302ExecutorConfigSchema = z.object({
     executor: AddressSchema,
@@ -13,3 +13,10 @@ export const Uln302UlnConfigSchema = z.object({
     optionalDVNs: z.array(AddressSchema),
     optionalDVNThreshold: UIntNumberSchema,
 }) satisfies z.ZodSchema<Uln302UlnConfig, z.ZodTypeDef, unknown>
+
+export const Uln302UlnUserConfigSchema = z.object({
+    confirmations: UIntBigIntSchema.optional(),
+    requiredDVNs: z.array(AddressSchema),
+    optionalDVNs: z.array(AddressSchema).optional(),
+    optionalDVNThreshold: UIntNumberSchema.optional(),
+}) satisfies z.ZodSchema<Uln302UlnUserConfig, z.ZodTypeDef, unknown>

--- a/packages/ua-devtools/src/oapp/schema.ts
+++ b/packages/ua-devtools/src/oapp/schema.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod'
 import { AddressSchema, UIntBigIntSchema, UIntNumberSchema } from '@layerzerolabs/devtools'
-import { Uln302ExecutorConfigSchema, Uln302UlnConfigSchema, TimeoutSchema } from '@layerzerolabs/protocol-devtools'
+import { Uln302ExecutorConfigSchema, Uln302UlnUserConfigSchema, TimeoutSchema } from '@layerzerolabs/protocol-devtools'
 import {
     ExecutorComposeOption,
     ExecutorLzReceiveOption,
@@ -20,12 +20,12 @@ export const OAppReceiveLibraryConfigSchema = z.object({
 }) satisfies z.ZodSchema<OAppReceiveLibraryConfig, z.ZodTypeDef, unknown>
 
 export const OAppSendConfigSchema = z.object({
-    executorConfig: Uln302ExecutorConfigSchema,
-    ulnConfig: Uln302UlnConfigSchema,
+    executorConfig: Uln302ExecutorConfigSchema.optional(),
+    ulnConfig: Uln302UlnUserConfigSchema.optional(),
 }) satisfies z.ZodSchema<OAppSendConfig, z.ZodTypeDef, unknown>
 
 export const OAppReceiveConfigSchema = z.object({
-    ulnConfig: Uln302UlnConfigSchema,
+    ulnConfig: Uln302UlnUserConfigSchema.optional(),
 }) satisfies z.ZodSchema<OAppReceiveConfig, z.ZodTypeDef, unknown>
 
 export const ExecutorLzReceiveOptionSchema = z.object({


### PR DESCRIPTION
### In this PR

- Adjust validation schemas after the configuration types have been made less strict