### PR TITLE
🧹 Use matrix strategy for the test job

### DIFF
--- a/.github/workflows/reusable-test.yaml
+++ b/.github/workflows/reusable-test.yaml
@@ -47,6 +47,9 @@ jobs:
   test:
     name: Test
     runs-on: ubuntu-latest-4xlarge
+    strategy:
+      matrix:
+        filter: ["'./examples/*'", "'./packages/*'", "'./tests/*'"]
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
@@ -64,6 +67,8 @@ jobs:
 
       - name: Test
         run: pnpm test:ci
+        env:
+          DOCKER_COMPOSE_RUN_TESTS_TURBO_ARGS: "--filter=${{ matrix.filter }}"
 
       # We'll collect the docker compose logs from all containers on failure
       - name: Collect docker logs on failure

--- a/.github/workflows/reusable-test.yaml
+++ b/.github/workflows/reusable-test.yaml
@@ -49,7 +49,7 @@ jobs:
     runs-on: ubuntu-latest-4xlarge
     strategy:
       matrix:
-        filter: ["'./examples/*'", "'./packages/*'", "'./tests/*'"]
+        filter: ["./examples/*", "./packages/*", "./tests/*"]
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4


### PR DESCRIPTION
### In this PR

- To bring down the pipeline runtime, `matrix` strategy is introduced for the test github workflow. This strategy splits the test run into three verticals - testing samples, packages and tests separately. The downside is the duplicated environment setup (the bootstrap of the container) and the partially duplicated build step. The duplicated environment setup could be fixed by introducing a prebuilt docker image but that's a story for another day