### PR TITLE
🧹 Add github actions reporter to jest

### DIFF
--- a/packages/build-lz-options/jest.config.js
+++ b/packages/build-lz-options/jest.config.js
@@ -1,6 +1,7 @@
 /** @type {import('ts-jest').JestConfigWithTsJest} */
 module.exports = {
     preset: 'ts-jest',
+    reporters: [['github-actions', { silent: false }], 'summary'],
     testEnvironment: 'node',
     testTimeout: 15000,
     moduleNameMapper: {

--- a/packages/create-lz-oapp/jest.config.js
+++ b/packages/create-lz-oapp/jest.config.js
@@ -1,5 +1,6 @@
 /** @type {import('ts-jest').JestConfigWithTsJest} */
 module.exports = {
+    reporters: [['github-actions', { silent: false }], 'summary'],
     testEnvironment: 'node',
     testTimeout: 15000,
     moduleNameMapper: {

--- a/packages/devtools-evm-hardhat/jest.config.js
+++ b/packages/devtools-evm-hardhat/jest.config.js
@@ -1,6 +1,7 @@
 /** @type {import('ts-jest').JestConfigWithTsJest} */
 module.exports = {
     cache: false,
+    reporters: [['github-actions', { silent: false }], 'summary'],
     testEnvironment: 'node',
     moduleNameMapper: {
         '^@/(.*)$': '<rootDir>/src/$1',

--- a/packages/devtools-evm/jest.config.js
+++ b/packages/devtools-evm/jest.config.js
@@ -1,6 +1,7 @@
 /** @type {import('ts-jest').JestConfigWithTsJest} */
 module.exports = {
     cache: false,
+    reporters: [['github-actions', { silent: false }], 'summary'],
     testEnvironment: 'node',
     setupFilesAfterEnv: ['<rootDir>/jest.setup.js'],
     moduleNameMapper: {

--- a/packages/devtools/jest.config.js
+++ b/packages/devtools/jest.config.js
@@ -1,6 +1,7 @@
 /** @type {import('ts-jest').JestConfigWithTsJest} */
 module.exports = {
     cache: false,
+    reporters: [['github-actions', { silent: false }], 'summary'],
     testEnvironment: 'node',
     setupFilesAfterEnv: ['<rootDir>/jest.setup.js'],
     moduleNameMapper: {

--- a/packages/export-deployments/jest.config.js
+++ b/packages/export-deployments/jest.config.js
@@ -1,5 +1,6 @@
 /** @type {import('ts-jest').JestConfigWithTsJest} */
 module.exports = {
+    reporters: [['github-actions', { silent: false }], 'summary'],
     testEnvironment: 'node',
     testTimeout: 15000,
     moduleNameMapper: {

--- a/packages/io-devtools/jest.config.js
+++ b/packages/io-devtools/jest.config.js
@@ -1,6 +1,7 @@
 /** @type {import('ts-jest').JestConfigWithTsJest} */
 module.exports = {
     cache: false,
+    reporters: [['github-actions', { silent: false }], 'summary'],
     testEnvironment: 'node',
     moduleNameMapper: {
         '^@/(.*)$': '<rootDir>/src/$1',

--- a/packages/omnicounter-devtools-evm/jest.config.js
+++ b/packages/omnicounter-devtools-evm/jest.config.js
@@ -1,6 +1,7 @@
 /** @type {import('ts-jest').JestConfigWithTsJest} */
 module.exports = {
     cache: false,
+    reporters: [['github-actions', { silent: false }], 'summary'],
     testEnvironment: 'node',
     moduleNameMapper: {
         '^@/(.*)$': '<rootDir>/src/$1',

--- a/packages/omnicounter-devtools/jest.config.js
+++ b/packages/omnicounter-devtools/jest.config.js
@@ -1,6 +1,7 @@
 /** @type {import('ts-jest').JestConfigWithTsJest} */
 module.exports = {
     cache: false,
+    reporters: [['github-actions', { silent: false }], 'summary'],
     testEnvironment: 'node',
     moduleNameMapper: {
         '^@/(.*)$': '<rootDir>/src/$1',

--- a/packages/protocol-devtools-evm/jest.config.js
+++ b/packages/protocol-devtools-evm/jest.config.js
@@ -1,6 +1,7 @@
 /** @type {import('ts-jest').JestConfigWithTsJest} */
 module.exports = {
     cache: false,
+    reporters: [['github-actions', { silent: false }], 'summary'],
     testEnvironment: 'node',
     moduleNameMapper: {
         '^@/(.*)$': '<rootDir>/src/$1',

--- a/packages/protocol-devtools/jest.config.js
+++ b/packages/protocol-devtools/jest.config.js
@@ -1,6 +1,7 @@
 /** @type {import('ts-jest').JestConfigWithTsJest} */
 module.exports = {
     cache: false,
+    reporters: [['github-actions', { silent: false }], 'summary'],
     testEnvironment: 'node',
     moduleNameMapper: {
         '^@/(.*)$': '<rootDir>/src/$1',

--- a/packages/toolbox-hardhat/jest.config.js
+++ b/packages/toolbox-hardhat/jest.config.js
@@ -1,6 +1,7 @@
 /** @type {import('ts-jest').JestConfigWithTsJest} */
 module.exports = {
     cache: false,
+    reporters: [['github-actions', { silent: false }], 'summary'],
     testEnvironment: 'node',
     moduleNameMapper: {
         '^@/(.*)$': '<rootDir>/src/$1',

--- a/packages/ua-devtools-evm-hardhat/jest.config.js
+++ b/packages/ua-devtools-evm-hardhat/jest.config.js
@@ -1,6 +1,7 @@
 /** @type {import('ts-jest').JestConfigWithTsJest} */
 module.exports = {
     cache: false,
+    reporters: [['github-actions', { silent: false }], 'summary'],
     testEnvironment: 'node',
     moduleNameMapper: {
         '^@/(.*)$': '<rootDir>/src/$1',

--- a/packages/ua-devtools-evm/jest.config.js
+++ b/packages/ua-devtools-evm/jest.config.js
@@ -1,6 +1,7 @@
 /** @type {import('ts-jest').JestConfigWithTsJest} */
 module.exports = {
     cache: false,
+    reporters: [['github-actions', { silent: false }], 'summary'],
     testEnvironment: 'node',
     moduleNameMapper: {
         '^@/(.*)$': '<rootDir>/src/$1',

--- a/packages/ua-devtools/jest.config.js
+++ b/packages/ua-devtools/jest.config.js
@@ -1,6 +1,7 @@
 /** @type {import('ts-jest').JestConfigWithTsJest} */
 module.exports = {
     cache: false,
+    reporters: [['github-actions', { silent: false }], 'summary'],
     testEnvironment: 'node',
     moduleNameMapper: {
         '^@/(.*)$': '<rootDir>/src/$1',

--- a/packages/verify-contract/jest.config.js
+++ b/packages/verify-contract/jest.config.js
@@ -1,6 +1,7 @@
 /** @type {import('ts-jest').JestConfigWithTsJest} */
 module.exports = {
     cache: false,
+    reporters: [['github-actions', { silent: false }], 'summary'],
     testEnvironment: 'node',
     moduleNameMapper: {
         '^@/(.*)$': '<rootDir>/src/$1',

--- a/tests/devtools-evm-hardhat-test/jest.config.js
+++ b/tests/devtools-evm-hardhat-test/jest.config.js
@@ -1,6 +1,7 @@
 /** @type {import('ts-jest').JestConfigWithTsJest} */
 module.exports = {
     cache: false,
+    reporters: [['github-actions', { silent: false }], 'summary'],
     testEnvironment: 'node',
     testTimeout: 150_000,
     setupFilesAfterEnv: ['<rootDir>/jest.setup.js'],

--- a/tests/devtools-evm-test/jest.config.js
+++ b/tests/devtools-evm-test/jest.config.js
@@ -1,6 +1,7 @@
 /** @type {import('ts-jest').JestConfigWithTsJest} */
 module.exports = {
     cache: false,
+    reporters: [['github-actions', { silent: false }], 'summary'],
     testEnvironment: 'node',
     testTimeout: 150_000,
     moduleNameMapper: {

--- a/tests/export-deployments-test/jest.config.js
+++ b/tests/export-deployments-test/jest.config.js
@@ -1,6 +1,7 @@
 /** @type {import('ts-jest').JestConfigWithTsJest} */
 module.exports = {
     cache: false,
+    reporters: [['github-actions', { silent: false }], 'summary'],
     testEnvironment: 'node',
     testTimeout: 300_000,
     setupFilesAfterEnv: ['<rootDir>/jest.setup.js'],

--- a/tests/ua-devtools-evm-hardhat-test/jest.config.js
+++ b/tests/ua-devtools-evm-hardhat-test/jest.config.js
@@ -1,6 +1,7 @@
 /** @type {import('ts-jest').JestConfigWithTsJest} */
 module.exports = {
     cache: false,
+    reporters: [['github-actions', { silent: false }], 'summary'],
     testEnvironment: 'node',
     testTimeout: 300_000,
     setupFilesAfterEnv: ['<rootDir>/jest.setup.js'],

--- a/tests/ua-devtools-evm-hardhat-v1-test/jest.config.js
+++ b/tests/ua-devtools-evm-hardhat-v1-test/jest.config.js
@@ -1,6 +1,7 @@
 /** @type {import('ts-jest').JestConfigWithTsJest} */
 module.exports = {
     cache: false,
+    reporters: [['github-actions', { silent: false }], 'summary'],
     testEnvironment: 'node',
     testTimeout: 300_000,
     setupFilesAfterEnv: ['<rootDir>/jest.setup.js'],


### PR DESCRIPTION
### In this PR

- A side-effect of one of the tasks - adding `github-actions` reporter to `jest` for easier test failure navigation. Read more about [`github-actions` reporter here](https://jestjs.io/docs/configuration#github-actions-reporter)

At some point, we might isolate the default `jest` config to stay a bit DRY and turn it from a `.js` into a `.ts` file (help welcome).