### PR TITLE
🧹 Better logging and errors [1/N]

### DIFF
--- a/.changeset/brown-ducks-poke.md
+++ b/.changeset/brown-ducks-poke.md
@@ -1,0 +1,5 @@
+---
+"@layerzerolabs/devtools": patch
+---
+
+Add tapError utility to simplify async error logging

--- a/.changeset/happy-cars-glow.md
+++ b/.changeset/happy-cars-glow.md
@@ -1,0 +1,5 @@
+---
+"@layerzerolabs/devtools": patch
+---
+
+Add mapError utility

--- a/packages/devtools-evm/src/omnigraph/sdk.ts
+++ b/packages/devtools-evm/src/omnigraph/sdk.ts
@@ -49,6 +49,13 @@ export abstract class OmniSDK implements IOmniSDK {
         )
     ) {}
 
+    /**
+     * Human radable label for this SDK
+     */
+    get label(): string {
+        return formatOmniContract(this.contract)
+    }
+
     get point(): OmniPoint {
         return omniContractToPoint(this.contract)
     }

--- a/packages/devtools/src/common/promise.ts
+++ b/packages/devtools/src/common/promise.ts
@@ -36,8 +36,34 @@ export const sequence = async <T>(tasks: Task<T>[]): Promise<T[]> => {
 export const parallel = async <T>(tasks: Task<T>[]): Promise<T[]> => await Promise.all(tasks.map((task) => task()))
 
 /**
+ * Maps the errors coming from a task. Errors thrown from the `toError`
+ * callback will not be caught.
+ *
+ * ```
+ * const functionThatMightThrow = () => sdk.getSomeAttribute()
+ *
+ * const result = await mapError(functionThatMightThrow, (error) => new Error(`Error produced: ${error}`))
+ * ```
+ *
+ * @template T
+ * @template E
+ * @param {(error: unknown) => E} toError Error mapping function
+ */
+export const mapError = async <T, E = unknown>(task: Task<T>, toError: (error: unknown) => E): Promise<Awaited<T>> => {
+    try {
+        return await task()
+    } catch (error: unknown) {
+        throw toError(error)
+    }
+}
+
+/**
  * Intercepts any errors coming from a task. The return value
- * of this call will be the return value of the task.
+ * of this call will be the return value of the task
+ * and the rejected value will be the original erorr.
+ *
+ * Any errors or rejections from the `onError` callback will be caught
+ * and the original error will be rethrown.
  *
  * ```
  * const functionThatMightThrow = () => sdk.getSomeAttribute()

--- a/packages/devtools/test/common/promise.test.ts
+++ b/packages/devtools/test/common/promise.test.ts
@@ -1,7 +1,14 @@
 /// <reference types="jest-extended" />
 
 import fc from 'fast-check'
-import { createSimpleRetryStrategy, createRetryFactory, first, firstFactory, sequence } from '@/common/promise'
+import {
+    createSimpleRetryStrategy,
+    createRetryFactory,
+    first,
+    firstFactory,
+    sequence,
+    tapError,
+} from '@/common/promise'
 
 describe('common/promise', () => {
     const valueArbitrary = fc.anything()
@@ -187,6 +194,88 @@ describe('common/promise', () => {
 
                     expect(successful).toHaveBeenCalledTimes(1)
                     expect(successful).toHaveBeenCalledWith(...args)
+                })
+            )
+        })
+    })
+
+    describe('tapError', () => {
+        it('should resolve with the return value of a synchronous task', async () => {
+            await fc.assert(
+                fc.asyncProperty(valueArbitrary, async (value) => {
+                    const task = jest.fn().mockReturnValue(value)
+                    const handleError = jest.fn()
+
+                    await expect(tapError(task, handleError)).resolves.toBe(value)
+                    expect(handleError).not.toHaveBeenCalled()
+                })
+            )
+        })
+
+        it('should resolve with the resolution value of an asynchronous task', async () => {
+            await fc.assert(
+                fc.asyncProperty(valueArbitrary, async (value) => {
+                    const task = jest.fn().mockResolvedValue(value)
+                    const handleError = jest.fn()
+
+                    await expect(tapError(task, handleError)).resolves.toBe(value)
+                    expect(handleError).not.toHaveBeenCalled()
+                })
+            )
+        })
+
+        it('should reject and call the onError callback if a synchronous task throws', async () => {
+            await fc.assert(
+                fc.asyncProperty(valueArbitrary, async (error) => {
+                    const task = jest.fn().mockImplementation(() => {
+                        throw error
+                    })
+                    const handleError = jest.fn()
+
+                    await expect(tapError(task, handleError)).rejects.toBe(error)
+                    expect(handleError).toHaveBeenCalledOnce()
+                    expect(handleError).toHaveBeenCalledExactlyOnceWith(error)
+                })
+            )
+        })
+
+        it('should reject and call the onError callback if an asynchronous task rejects', async () => {
+            await fc.assert(
+                fc.asyncProperty(valueArbitrary, async (error) => {
+                    const task = jest.fn().mockRejectedValue(error)
+                    const handleError = jest.fn()
+
+                    await expect(tapError(task, handleError)).rejects.toBe(error)
+                    expect(handleError).toHaveBeenCalledOnce()
+                    expect(handleError).toHaveBeenCalledExactlyOnceWith(error)
+                })
+            )
+        })
+
+        it('should reject with the original error if the onError callback throws', async () => {
+            await fc.assert(
+                fc.asyncProperty(valueArbitrary, valueArbitrary, async (error, anotherError) => {
+                    const task = jest.fn().mockRejectedValue(error)
+                    const handleError = jest.fn().mockImplementation(() => {
+                        throw anotherError
+                    })
+
+                    await expect(tapError(task, handleError)).rejects.toBe(error)
+                    expect(handleError).toHaveBeenCalledOnce()
+                    expect(handleError).toHaveBeenCalledExactlyOnceWith(error)
+                })
+            )
+        })
+
+        it('should reject with the original error if the onError callback rejects', async () => {
+            await fc.assert(
+                fc.asyncProperty(valueArbitrary, valueArbitrary, async (error, anotherError) => {
+                    const task = jest.fn().mockRejectedValue(error)
+                    const handleError = jest.fn().mockRejectedValue(anotherError)
+
+                    await expect(tapError(task, handleError)).rejects.toBe(error)
+                    expect(handleError).toHaveBeenCalledOnce()
+                    expect(handleError).toHaveBeenCalledExactlyOnceWith(error)
                 })
             )
         })

--- a/packages/devtools/test/common/promise.test.ts
+++ b/packages/devtools/test/common/promise.test.ts
@@ -246,7 +246,7 @@ describe('common/promise', () => {
                     const task = jest.fn().mockRejectedValue(error)
                     const handleError = jest.fn().mockReturnValue(mappedError)
 
-                    await expect(tapError(task, handleError)).rejects.toBe(mappedError)
+                    await expect(mapError(task, handleError)).rejects.toBe(mappedError)
                     expect(handleError).toHaveBeenCalledOnce()
                     expect(handleError).toHaveBeenCalledExactlyOnceWith(error)
                 })


### PR DESCRIPTION
### In this PR

- Improve logging for the `OApp` SDK - wrap the original errors with more descriptive ones
- Add `tapError` (for error logging) and `mapError` (for error mapping) functions to `devtools`