### PR TITLE
🧹 Add new urls in verify-contract for mantle, metis, and scroll

### DIFF
--- a/.changeset/eight-worms-yawn.md
+++ b/.changeset/eight-worms-yawn.md
@@ -1,0 +1,5 @@
+---
+"@layerzerolabs/verify-contract": patch
+---
+
+Updated urls for metis, mantle, scroll

--- a/packages/verify-contract/src/common/url.ts
+++ b/packages/verify-contract/src/common/url.ts
@@ -70,4 +70,7 @@ const DEFAULT_SCAN_API_URLS: Map<NetworkName, string> = new Map([
     ['zkconsensys-mainnet', 'https://api.lineascan.build/api'],
     ['moonbeam', 'https://api-moonbeam.moonscan.io/api'],
     ['moonbeam-testnet', 'https://api-moonbase.moonscan.io/api'],
+    ['mantle', 'https://explorer.mantle.xyz/api'],
+    ['metis', 'https://api.routescan.io/v2/network/mainnet/evm/1088/etherscan'],
+    ['scroll', 'https://api.scrollscan.com/api'],
 ])


### PR DESCRIPTION
Update the default url mappings for:
metis
mantle
scroll