### PR TITLE
🧹 Add default verify urls for fraxtal and mode

### DIFF
--- a/.changeset/pretty-houses-pay.md
+++ b/.changeset/pretty-houses-pay.md
@@ -1,0 +1,5 @@
+---
+"@layerzerolabs/verify-contract": patch
+---
+
+Added default scan urls for fraxtal and mode

--- a/packages/verify-contract/src/common/url.ts
+++ b/packages/verify-contract/src/common/url.ts
@@ -73,4 +73,6 @@ const DEFAULT_SCAN_API_URLS: Map<NetworkName, string> = new Map([
     ['mantle', 'https://explorer.mantle.xyz/api'],
     ['metis', 'https://api.routescan.io/v2/network/mainnet/evm/1088/etherscan'],
     ['scroll', 'https://api.scrollscan.com/api'],
+    ['fraxtal', 'https://api.fraxscan.com/api'],
+    ['mode', 'https://explorer.mode.network/api'],
 ])


### PR DESCRIPTION
Add default scan-apis for:
mode
fraxtal