### PR TITLE
🧹  Add etherlink scan url to verify-contract package

### DIFF
--- a/.changeset/tall-turtles-thank.md
+++ b/.changeset/tall-turtles-thank.md
@@ -1,0 +1,5 @@
+---
+"@layerzerolabs/verify-contract": patch
+---
+
+Add the default verify-contract url for etherlink

--- a/packages/verify-contract/src/common/url.ts
+++ b/packages/verify-contract/src/common/url.ts
@@ -75,4 +75,5 @@ const DEFAULT_SCAN_API_URLS: Map<NetworkName, string> = new Map([
     ['scroll', 'https://api.scrollscan.com/api'],
     ['fraxtal', 'https://api.fraxscan.com/api'],
     ['mode', 'https://explorer.mode.network/api'],
+    ['etherlink', 'https://explorer.etherlink.com/api'],
 ])


### PR DESCRIPTION
Add a default scan api for:
etherlink