### PR TITLE
🗞️ Bits and pieces of types and configuration for localnet [3/N]

### DIFF
--- a/.changeset/witty-toes-compare.md
+++ b/.changeset/witty-toes-compare.md
@@ -1,0 +1,7 @@
+---
+"@layerzerolabs/devtools-evm-hardhat": patch
+"@layerzerolabs/devtools-evm": patch
+"@layerzerolabs/devtools": patch
+---
+
+Add types for simulation

--- a/packages/devtools-evm-hardhat/src/simulation/types.ts
+++ b/packages/devtools-evm-hardhat/src/simulation/types.ts
@@ -1,0 +1,44 @@
+import { AnvilOptions } from '@layerzerolabs/devtools-evm'
+
+export interface SimulationUserConfig {
+    /**
+     * Simulation works by creating local forks of networks specified
+     * in hardhat config. These networks are containerized and not accessible
+     * from the developer machine - instead, a simple proxy server
+     * listening on this port proxies requests to the individual networks.
+     *
+     * For example, a hardhat configuration with networks `fuji` and `mainnet`
+     * will result in two forks being created. These networks will then be accessible
+     * on `http://localhost:<port>/fuji` and `http://localhost:<port>/mainnet`
+     *
+     * @default 8545
+     */
+    port?: number
+
+    /**
+     * Simulation task stores its artifacts on the local filesystem.
+     *
+     * To customize the path, set this property to a relative or absolute path
+     * (relative path will be resolved against the root path of your hardhat project)
+     *
+     * @default .layerzero
+     */
+    directory?: string
+
+    /**
+     * Anvil overrides for the underlying EVM nodes.
+     */
+    anvil?: SimulationAnvilUserConfig
+}
+
+export interface SimulationConfig {
+    port: number
+    directory: string
+    anvil: SimulationAnvilConfig
+}
+
+export type SimulationAnvilConfig = AnvilOptions & {
+    mnemonic: NonNullable<AnvilOptions['mnemonic']>
+}
+
+export type SimulationAnvilUserConfig = Omit<AnvilOptions, 'host' | 'port' | 'state' | 'forkUrl'>

--- a/packages/devtools-evm-hardhat/src/simulation/types.ts
+++ b/packages/devtools-evm-hardhat/src/simulation/types.ts
@@ -31,14 +31,33 @@ export interface SimulationUserConfig {
     anvil?: SimulationAnvilUserConfig
 }
 
+/**
+ * Resolved simulation config
+ */
 export interface SimulationConfig {
     port: number
     directory: string
     anvil: SimulationAnvilConfig
 }
 
+/**
+ * Resolved simulation config for anvil.
+ *
+ * This config is created by taking the user config
+ * and applying defaults.
+ */
 export type SimulationAnvilConfig = AnvilOptions & {
     mnemonic: NonNullable<AnvilOptions['mnemonic']>
 }
 
+/**
+ * User facing simulation config for anvil.
+ *
+ * This config cannot override several system attributes for anvil
+ * (since it would not really make sense seeing that anvil is being run in containers):
+ *
+ * - host & port: this would break the docker port bindings
+ * - state: state is kept within the container and is not accessible from the outside
+ * - forkUrl: this is set based on the hardhat config and points to the hardhat network url
+ */
 export type SimulationAnvilUserConfig = Omit<AnvilOptions, 'host' | 'port' | 'state' | 'forkUrl'>

--- a/packages/devtools-evm-hardhat/src/type-extensions.ts
+++ b/packages/devtools-evm-hardhat/src/type-extensions.ts
@@ -1,6 +1,7 @@
 import 'hardhat/types/config'
 import { EndpointId } from '@layerzerolabs/lz-definitions'
 import { ConnectSafeConfigWithSafeAddress } from '@safe-global/protocol-kit'
+import { SimulationUserConfig } from '@/simulation/types'
 
 declare module 'hardhat/types/config' {
     interface HardhatNetworkUserConfig {
@@ -102,5 +103,19 @@ declare module 'hardhat/types/config' {
          * @default ['@layerzerolabs/lz-evm-sdk-v2','@layerzerolabs/test-devtools-evm-hardhat']
          */
         artifactSourcePackages?: string[]
+
+        /**
+         * Configuration of features that are not considered stable yet
+         */
+        experimental?: {
+            /**
+             * Configuration for omnichain simulation
+             *
+             * Omnichain simulation allows developers to easily setup
+             * local environment forked from live networks without
+             * having to adjust the `hardhat.config.ts` file
+             */
+            simulation?: SimulationUserConfig
+        }
     }
 }

--- a/packages/devtools-evm/src/simulation/anvil.ts
+++ b/packages/devtools-evm/src/simulation/anvil.ts
@@ -28,6 +28,12 @@ export interface AnvilOptions {
     //
 
     blockTime?: number
+
+    //
+    // State
+    //
+
+    state?: string
 }
 
 /**
@@ -37,7 +43,15 @@ export interface AnvilOptions {
  * @param {AnvilOptions} options
  * @returns {string[]} `anvil` CLI arguments
  */
-export const createAnvilCliOptions = ({ host, port, mnemonic, forkUrl, blockTime, count }: AnvilOptions): string[] =>
+export const createAnvilCliOptions = ({
+    host,
+    port,
+    mnemonic,
+    forkUrl,
+    blockTime,
+    count,
+    state,
+}: AnvilOptions): string[] =>
     pipe(
         [
             pipe(
@@ -63,6 +77,10 @@ export const createAnvilCliOptions = ({ host, port, mnemonic, forkUrl, blockTime
             pipe(
                 O.fromNullable(blockTime),
                 O.map((blockTime) => ['--block-time', String(blockTime)])
+            ),
+            pipe(
+                O.fromNullable(state),
+                O.map((state) => ['--state', state])
             ),
         ],
         A.compact,

--- a/packages/devtools/src/docker/types.ts
+++ b/packages/devtools/src/docker/types.ts
@@ -89,6 +89,8 @@ export interface ComposeSpecService {
     healthcheck?: ComposeSpecServiceHealthcheck
 }
 
+export type ComposeSpecServices = Record<string, ComposeSpecService>
+
 export interface ComposeSpecVolumeDefinition {
     name?: string
     driver?: string
@@ -98,10 +100,12 @@ export interface ComposeSpecVolumeDefinition {
 
 export type ComposeSpecVolume = null | ComposeSpecVolumeDefinition
 
+export type ComposeSpecVolumes = Record<string, ComposeSpecVolume>
+
 export interface ComposeSpec {
     version: ComposeSpecVersion
-    services?: Record<string, ComposeSpecService>
-    volumes?: Record<string, ComposeSpecVolume>
+    services?: ComposeSpecServices
+    volumes?: ComposeSpecVolumes
 }
 
 export type ListOrDict = Record<string, string | number | boolean | null> | string[]


### PR DESCRIPTION
### In this PR 

- Adding types for configuring the localnet (a.k.a. _simulation_ as suggested by @kushdave95)
- Adding `state` option to `AnvilOptions`
- Adding names for some of the compose types to be a bit DRY

This PR exists only to reduce the size of the ones to come, there's a lot of code related to generation of the `docker-compose.yaml` files for simulations so every file that can be split off that chunk is a good file.