### PR TITLE
🗞️ Add docker compose spec generation utilities for localnet [4/N]

### DIFF
--- a/.changeset/chilly-glasses-beam.md
+++ b/.changeset/chilly-glasses-beam.md
@@ -1,0 +1,5 @@
+---
+"@layerzerolabs/test-devtools": patch
+---
+
+Add mnemonic arbitrary to test-devtools

--- a/.changeset/perfect-monkeys-cross.md
+++ b/.changeset/perfect-monkeys-cross.md
@@ -1,0 +1,5 @@
+---
+"@layerzerolabs/test-devtools": patch
+---
+
+Add optionalArbitrary

--- a/.changeset/violet-hornets-prove.md
+++ b/.changeset/violet-hornets-prove.md
@@ -1,0 +1,5 @@
+---
+"@layerzerolabs/devtools-evm-hardhat": patch
+---
+
+Add docker compose utilities for simulation

--- a/packages/devtools-evm-hardhat/jest.config.js
+++ b/packages/devtools-evm-hardhat/jest.config.js
@@ -2,11 +2,13 @@
 module.exports = {
     cache: false,
     reporters: [['github-actions', { silent: false }], 'default'],
+    testTimeout: 15_000,
     testEnvironment: 'node',
     moduleNameMapper: {
         '^@/(.*)$': '<rootDir>/src/$1',
     },
     transform: {
         '^.+\\.(t|j)sx?$': '@swc/jest',
+        '^.+\\.conf$': '<rootDir>/jest.transformer.raw.js',
     },
 };

--- a/packages/devtools-evm-hardhat/jest.transformer.raw.js
+++ b/packages/devtools-evm-hardhat/jest.transformer.raw.js
@@ -1,3 +1,6 @@
+// This is a quick, up-to-date version of https://www.npmjs.com/package/jest-raw-loader
+//
+// We need this in order to be able to statically import/embed simulation Dockerfile & nginx.conf
 module.exports = {
     process: (content) => ({ code: `module.exports = ${JSON.stringify(content)}` }),
 };

--- a/packages/devtools-evm-hardhat/jest.transformer.raw.js
+++ b/packages/devtools-evm-hardhat/jest.transformer.raw.js
@@ -1,0 +1,3 @@
+module.exports = {
+    process: (content) => ({ code: `module.exports = ${JSON.stringify(content)}` }),
+};

--- a/packages/devtools-evm-hardhat/src/simulation/assets/Dockerfile.conf
+++ b/packages/devtools-evm-hardhat/src/simulation/assets/Dockerfile.conf
@@ -1,0 +1,51 @@
+ARG FOUNDRY_VERSION=nightly-156cb1396b7076c6f9cb56f3719f8c90f7f52064
+ARG ALPINE_VERSION=3.18
+
+#   .-.-.   .-.-.   .-.-.   .-.-.   .-.-.   .-.-.   .-.-.   .-.-
+#  / / \ \ / / \ \ / / \ \ / / \ \ / / \ \ / / \ \ / / \ \ / / \
+# `-'   `-`-'   `-`-'   `-`-'   `-`-'   `-`-'   `-`-'   `-`-'
+#
+#             Image that gives us the foundry tools
+#
+#   .-.-.   .-.-.   .-.-.   .-.-.   .-.-.   .-.-.   .-.-.   .-.-
+#  / / \ \ / / \ \ / / \ \ / / \ \ / / \ \ / / \ \ / / \ \ / / \
+# `-'   `-`-'   `-`-'   `-`-'   `-`-'   `-`-'   `-`-'   `-`-'
+FROM ghcr.io/foundry-rs/foundry:$FOUNDRY_VERSION AS foundry
+
+#   .-.-.   .-.-.   .-.-.   .-.-.   .-.-.   .-.-.   .-.-.   .-.-
+#  / / \ \ / / \ \ / / \ \ / / \ \ / / \ \ / / \ \ / / \ \ / / \
+# `-'   `-`-'   `-`-'   `-`-'   `-`-'   `-`-'   `-`-'   `-`-'
+#
+#               Image that starts an EVM node
+#
+#   .-.-.   .-.-.   .-.-.   .-.-.   .-.-.   .-.-.   .-.-.   .-.-
+#  / / \ \ / / \ \ / / \ \ / / \ \ / / \ \ / / \ \ / / \ \ / / \
+# `-'   `-`-'   `-`-'   `-`-'   `-`-'   `-`-'   `-`-'   `-`-'
+FROM alpine:$ALPINE_VERSION AS node-evm
+
+STOPSIGNAL SIGINT
+
+# We will provide a default healthcheck (that assumes that the netowrk is running on the default port 8545)
+HEALTHCHECK --timeout=2s --interval=2s --retries=20 CMD cast block --rpc-url http://localhost:8545/ latest
+
+# Get anvil
+COPY --from=foundry /usr/local/bin/anvil /usr/local/bin/anvil
+
+# Get cast for healthcheck
+COPY --from=foundry /usr/local/bin/cast /usr/local/bin/cast
+
+#   .-.-.   .-.-.   .-.-.   .-.-.   .-.-.   .-.-.   .-.-.   .-.-
+#  / / \ \ / / \ \ / / \ \ / / \ \ / / \ \ / / \ \ / / \ \ / / \
+# `-'   `-`-'   `-`-'   `-`-'   `-`-'   `-`-'   `-`-'   `-`-'
+#
+#           Image that starts an nginx proxy server
+#
+#   .-.-.   .-.-.   .-.-.   .-.-.   .-.-.   .-.-.   .-.-.   .-.-
+#  / / \ \ / / \ \ / / \ \ / / \ \ / / \ \ / / \ \ / / \ \ / / \
+# `-'   `-`-'   `-`-'   `-`-'   `-`-'   `-`-'   `-`-'   `-`-'
+FROM nginx:alpine$ALPINE_VERSION AS proxy-evm
+
+COPY ./nginx.conf /etc/nginx/nginx.conf
+
+HEALTHCHECK --timeout=2s --interval=2s --retries=20 CMD curl -f http://0.0.0.0:8545/health-check
+

--- a/packages/devtools-evm-hardhat/src/simulation/assets/index.ts
+++ b/packages/devtools-evm-hardhat/src/simulation/assets/index.ts
@@ -1,0 +1,7 @@
+// Even though it would be nice to just call this file Dockerfile instead of Dockerfile.conf,
+// esbuild (or tsup) have issues with specifying loaders for files without extensions.
+//
+// And since we already have a file with .conf extension,
+// we add the same extension to the Dockerfile to use the same d.ts file and the same loader
+export { default as dockerfile } from './Dockerfile.conf'
+export { default as nginxConf } from './nginx.conf'

--- a/packages/devtools-evm-hardhat/src/simulation/assets/nginx.conf
+++ b/packages/devtools-evm-hardhat/src/simulation/assets/nginx.conf
@@ -2,10 +2,10 @@ events {}
 
 http {
   # We will modify the log  format to include the target_network
-  log_format unique '$remote_addr - $remote_user [$time_local] '
-                    '"$request" $status $body_bytes_sent '
-                    '"$http_referer" "$http_user_agent" '
-                    'Network: "$target_network"';
+  log_format proxied '$remote_addr - $remote_user [$time_local] '
+                     '"$request" $status $body_bytes_sent '
+                     '"$http_referer" "$http_user_agent" '
+                     'Network: "$target_network"';
 
   server {
     # This proxy server will listen on port 8545
@@ -35,8 +35,8 @@ http {
     # 
     # # http://localhost/fuji/some/url -> http://fuji:8545/
     location / {
-      # Set the log format to be our custom log format
-      access_log /var/log/nginx/access.log unique;
+      # Set the log format to be our custom 'proxied' log format
+      access_log /var/log/nginx/access.log proxied;
 
       resolver 127.0.0.11;
       autoindex off;

--- a/packages/devtools-evm-hardhat/src/simulation/assets/nginx.conf
+++ b/packages/devtools-evm-hardhat/src/simulation/assets/nginx.conf
@@ -25,7 +25,7 @@ http {
     }
 
     # In this section we'll proxy all the requests to this server
-    # to the respectative network nodes
+    # to the respective network nodes
     # 
     # The requests are proxied based on the first path segment:
     # 

--- a/packages/devtools-evm-hardhat/src/simulation/assets/nginx.conf
+++ b/packages/devtools-evm-hardhat/src/simulation/assets/nginx.conf
@@ -1,0 +1,56 @@
+events {}
+
+http {
+  # We will modify the log  format to include the target_network
+  log_format unique '$remote_addr - $remote_user [$time_local] '
+                    '"$request" $status $body_bytes_sent '
+                    '"$http_referer" "$http_user_agent" '
+                    'Network: "$target_network"';
+
+  server {
+    # This proxy server will listen on port 8545
+    # 
+    # Even though it's not ideal to have this hardcoded, this port
+    # will be remapped to a desired host port using docker compose,
+    # the only issue this hardcoding brings is the fact that this port
+    # needs to match the container port in the compose spec
+    listen 8545;
+    listen [::]:8545;
+
+    # We will add a simple endpoint for healthcheck
+    location /health-check {
+      access_log	off;
+      error_log	off;
+      return 200 'ok';
+    }
+
+    # In this section we'll proxy all the requests to this server
+    # to the respectative network nodes
+    # 
+    # The requests are proxied based on the first path segment:
+    # 
+    # http://localhost/fuji -> http://fuji:8545/
+    # 
+    # For now the remaining path segments are not being preserved:
+    # 
+    # # http://localhost/fuji/some/url -> http://fuji:8545/
+    location / {
+      # Set the log format to be our custom log format
+      access_log /var/log/nginx/access.log unique;
+
+      resolver 127.0.0.11;
+      autoindex off;
+
+      # This variable will hold the name of the network to proxy to
+      set $target_network '';
+
+      # Extract the first path segment from the request URI
+      if ($request_uri ~* ^/(?<target_network>[^/]+)(/.*)?$) {
+        set $target_network $1;
+      }
+
+      # Proxy the request to the appropriate network
+      proxy_pass http://$target_network:8545/;
+    }
+  }
+}

--- a/packages/devtools-evm-hardhat/src/simulation/compose.ts
+++ b/packages/devtools-evm-hardhat/src/simulation/compose.ts
@@ -50,7 +50,7 @@ export const createEvmNodeProxyServiceSpec = (
     ports: [`${port}:8545`],
     depends_on: pipe(
         networkServices,
-        // This service will depends on the RPCs to be healthy
+        // This service will depend on the RPCs to be healthy
         // so we'll take the networkServices object and replace
         // the values with service_healthy condition
         RR.map(() => ({

--- a/packages/devtools-evm-hardhat/src/simulation/compose.ts
+++ b/packages/devtools-evm-hardhat/src/simulation/compose.ts
@@ -1,0 +1,93 @@
+import { pipe } from 'fp-ts/lib/function'
+import * as RR from 'fp-ts/ReadonlyRecord'
+import type { ComposeSpec, ComposeSpecService } from '@layerzerolabs/devtools'
+import { type AnvilOptions, createAnvilCliOptions } from '@layerzerolabs/devtools-evm'
+import type { ComposeSpecServices } from '@layerzerolabs/devtools'
+import type { SimulationConfig } from './types'
+
+/**
+ * Creates a docker compose service specification for an anvil-based EVM node
+ *
+ * @param {AnvilOptions} anvilOptions
+ * @returns {ComposeSpecService}
+ */
+export const createEvmNodeServiceSpec = (anvilOptions: AnvilOptions): ComposeSpecService => ({
+    // This service references a Dockerfile that is copied
+    // next to the resulting docker-compose.yaml
+    //
+    // The source for this Dockerfile is located in src/simulation/assets/Dockerfile.conf
+    build: {
+        dockerfile: 'Dockerfile',
+        target: 'node-evm',
+    },
+    command: ['anvil', ...createAnvilCliOptions(anvilOptions)],
+})
+
+/**
+ * Creates a docker compose service specification for an nginx-based proxy service
+ * that proxies requests to underlying EVM nodes (or their RPC URLs to be mor precise)
+ *
+ * @param {number} port
+ * @param {ComposeSpecServices} networkServices
+ * @returns {ComposeSpecService}
+ */
+export const createEvmNodeProxyServiceSpec = (
+    port: number,
+    networkServices: ComposeSpecServices
+): ComposeSpecService => ({
+    // This service references a Dockerfile that is copied
+    // next to the resulting docker-compose.yaml
+    //
+    // The source for this Dockerfile is located in src/simulation/assets/Dockerfile.conf
+    build: {
+        dockerfile: 'Dockerfile',
+        target: 'proxy-evm',
+    },
+    // This service will expose its internal 8545 port to a host port
+    //
+    // The internal 8545 port is hardcoded both here and in the nginx.conf file,
+    // the source for which is located in src/simulation/assets/nginx.conf
+    ports: [`${port}:8545`],
+    depends_on: pipe(
+        networkServices,
+        // This service will depends on the RPCs to be healthy
+        // so we'll take the networkServices object and replace
+        // the values with service_healthy condition
+        RR.map(() => ({
+            condition: 'service_healthy',
+        }))
+    ),
+})
+
+/**
+ * Creates a docker compose spec with a set of anvil-based EVM nodes
+ * and a single proxy server that proxies requests to these nodes.
+ *
+ * @param {SimulationConfig} config
+ * @param {Record<string, AnvilOptions>} networks
+ * @returns {ComposeSpec}
+ */
+export const createSimulationComposeSpec = (
+    config: SimulationConfig,
+    networks: Record<string, AnvilOptions>
+): ComposeSpec => ({
+    version: '3.9',
+    services: pipe(
+        networks,
+        // First we turn the networks into docker compose specs for EVM nodes
+        RR.map(createEvmNodeServiceSpec),
+        (networkServiceSpecs) =>
+            // Then we add the RPC proxy server
+            //
+            // There is a small edge case here that we can address
+            // if it ever comes up: if a network is called 'rpc', this compose file
+            // will not work.
+            //
+            // The fix for this is to prefix all networks with something like network-xxx
+            // but we can do that if ever this usecase comes up
+            pipe(
+                networkServiceSpecs,
+                RR.upsertAt('rpc', createEvmNodeProxyServiceSpec(config.port, networkServiceSpecs))
+            )
+    ),
+})

--- a/packages/devtools-evm-hardhat/src/simulation/index.ts
+++ b/packages/devtools-evm-hardhat/src/simulation/index.ts
@@ -1,2 +1,3 @@
+export * from './compose'
 export * from './config'
 export * from './types'

--- a/packages/devtools-evm-hardhat/test/simulation/__snapshots__/compose.test.ts.snap
+++ b/packages/devtools-evm-hardhat/test/simulation/__snapshots__/compose.test.ts.snap
@@ -1,0 +1,13 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`simulation/compose createEvmNodeServiceSpec() should work when there are no anvil options 1`] = `
+"version: '3.9'
+services:
+  anvil:
+    build:
+      dockerfile: Dockerfile
+      target: node-evm
+    command:
+      - anvil
+"
+`;

--- a/packages/devtools-evm-hardhat/test/simulation/compose.test.ts
+++ b/packages/devtools-evm-hardhat/test/simulation/compose.test.ts
@@ -1,0 +1,138 @@
+import hre from 'hardhat'
+import { resolveSimulationConfig } from '@/simulation'
+import {
+    createEvmNodeProxyServiceSpec,
+    createEvmNodeServiceSpec,
+    createSimulationComposeSpec,
+} from '@/simulation/compose'
+import { serializeDockerComposeSpec } from '@layerzerolabs/devtools'
+import { AnvilOptions } from '@layerzerolabs/devtools-evm'
+import { optionalArbitrary } from '@layerzerolabs/test-devtools'
+import { spawnSync } from 'child_process'
+import fc from 'fast-check'
+import { rm, writeFile } from 'fs/promises'
+import { join } from 'path'
+
+describe('simulation/compose', () => {
+    // The available docker port range
+    const portArbitrary = fc.integer({ min: 1, max: 65535 })
+
+    const anvilOptionsArbitrary: fc.Arbitrary<AnvilOptions> = fc.record({
+        host: optionalArbitrary(fc.ipV4()),
+        port: optionalArbitrary(portArbitrary),
+        count: optionalArbitrary(fc.integer()),
+        mnemonic: optionalArbitrary(fc.string()),
+        state: optionalArbitrary(fc.string()),
+        blockTime: optionalArbitrary(fc.integer()),
+        forkUrl: optionalArbitrary(fc.webUrl()),
+    })
+
+    const SPEC_FILE_PATH = join(__dirname, 'docker-compose.yaml')
+
+    const validateSpec = () => spawnSync('docker', ['compose', '-f', SPEC_FILE_PATH, 'config'])
+
+    afterEach(async () => {
+        await rm(SPEC_FILE_PATH, { force: true })
+    })
+
+    describe('createEvmNodeServiceSpec()', () => {
+        it('should work when there are no anvil options', async () => {
+            const spec = serializeDockerComposeSpec({
+                version: '3.9',
+                services: {
+                    anvil: createEvmNodeServiceSpec({}),
+                },
+            })
+
+            await writeFile(SPEC_FILE_PATH, spec)
+
+            expect(validateSpec().status).toBe(0)
+
+            expect(spec).toMatchSnapshot()
+        })
+
+        it('should work with anvil options', async () => {
+            await fc.assert(
+                fc.asyncProperty(anvilOptionsArbitrary, async (anvilOptions) => {
+                    const spec = serializeDockerComposeSpec({
+                        version: '3.9',
+                        services: {
+                            anvil: createEvmNodeServiceSpec(anvilOptions),
+                        },
+                    })
+
+                    await writeFile(SPEC_FILE_PATH, spec)
+
+                    expect(validateSpec().status).toBe(0)
+                }),
+                { numRuns: 20 }
+            )
+        })
+    })
+
+    describe('createEvmNodeProxyServiceSpec()', () => {
+        // We are aware of shortcomings of the simulation spec generation process:
+        //
+        // - whitespace service names will generate invalid compose files. This should not be a problem in a real hardhat project
+        // - network named rpc will collide with the RPC proxy container defined in the spec
+        //
+        // Because of this we'll filter down on the possibilities when it comes to service names
+        const serviceNameArbitrary = fc
+            .string({ minLength: 1 })
+            .map((name) => name.replaceAll(/[^a-zA-Z]/g, '_'))
+            .filter((name) => name !== 'rpc')
+
+        const servicesArbitrary = fc.dictionary(
+            serviceNameArbitrary,
+            anvilOptionsArbitrary.map(createEvmNodeServiceSpec)
+        )
+
+        it('should work with anvil services', async () => {
+            await fc.assert(
+                fc.asyncProperty(portArbitrary, servicesArbitrary, async (port, services) => {
+                    const spec = serializeDockerComposeSpec({
+                        version: '3.9',
+                        services: {
+                            ...services,
+                            rpc: createEvmNodeProxyServiceSpec(port, services),
+                        },
+                    })
+
+                    await writeFile(SPEC_FILE_PATH, spec)
+
+                    expect(validateSpec().status).toBe(0)
+                }),
+                { numRuns: 20 }
+            )
+        })
+    })
+
+    describe('createSimulationComposeSpec()', () => {
+        // We are aware of shortcomings of the simulation spec generation process:
+        //
+        // - whitespace service names will generate invalid compose files. This should not be a problem in a real hardhat project
+        // - network named rpc will collide with the RPC proxy container defined in the spec
+        //
+        // Because of this we'll filter down on the possibilities when it comes to service names
+        const serviceNameArbitrary = fc
+            .string({ minLength: 1 })
+            .map((name) => name.replaceAll(/[^a-zA-Z]/g, '_'))
+            .filter((name) => name !== 'rpc')
+
+        const anvilOptionsRecordArbitrary = fc.dictionary(serviceNameArbitrary, anvilOptionsArbitrary)
+
+        it('should work goddammit', async () => {
+            await fc.assert(
+                fc.asyncProperty(portArbitrary, anvilOptionsRecordArbitrary, async (port, anvilOptions) => {
+                    const simulationConfig = resolveSimulationConfig({ port }, hre.config)
+                    const spec = serializeDockerComposeSpec(createSimulationComposeSpec(simulationConfig, anvilOptions))
+
+                    await writeFile(SPEC_FILE_PATH, spec)
+
+                    expect(validateSpec().status).toBe(0)
+                }),
+                { numRuns: 20 }
+            )
+        })
+    })
+})

--- a/packages/devtools-evm-hardhat/test/simulation/config.test.ts
+++ b/packages/devtools-evm-hardhat/test/simulation/config.test.ts
@@ -1,4 +1,8 @@
-import { getAnvilOptionsFromHardhatNetworks, getHardhatNetworkOverrides, resolveSimulationConfig } from '@/simulation'
+import {
+    getAnvilOptionsFromHardhatNetworks,
+    getHardhatNetworkOverrides,
+    resolveSimulationConfig,
+} from '@/simulation/config'
 import fc from 'fast-check'
 import hre from 'hardhat'
 import { resolve } from 'path'

--- a/packages/devtools-evm-hardhat/test/simulation/config.test.ts
+++ b/packages/devtools-evm-hardhat/test/simulation/config.test.ts
@@ -3,6 +3,7 @@ import {
     getHardhatNetworkOverrides,
     resolveSimulationConfig,
 } from '@/simulation/config'
+import { mnemonicArbitrary } from '@layerzerolabs/test-devtools'
 import fc from 'fast-check'
 import hre from 'hardhat'
 import { resolve } from 'path'
@@ -21,7 +22,7 @@ describe('simulation/config', () => {
 
         it('should not override user values if provided', () => {
             fc.assert(
-                fc.property(fc.integer(), fc.string(), fc.string(), (port, directory, mnemonic) => {
+                fc.property(fc.integer(), fc.string(), mnemonicArbitrary, (port, directory, mnemonic) => {
                     expect(resolveSimulationConfig({ port, directory, anvil: { mnemonic } }, hre.config)).toEqual({
                         port,
                         directory: resolve(hre.config.paths.root, directory),

--- a/packages/devtools-evm-hardhat/tsconfig.json
+++ b/packages/devtools-evm-hardhat/tsconfig.json
@@ -8,5 +8,6 @@
     "paths": {
       "@/*": ["./src/*"]
     }
-  }
+  },
+  "files": ["./types/conf.d.ts"]
 }

--- a/packages/devtools-evm-hardhat/tsup.config.ts
+++ b/packages/devtools-evm-hardhat/tsup.config.ts
@@ -10,5 +10,8 @@ export default defineConfig([
         splitting: false,
         treeshake: true,
         format: ['esm', 'cjs'],
+        loader: {
+            '.conf': 'text',
+        },
     },
 ])

--- a/packages/devtools-evm-hardhat/types/conf.d.ts
+++ b/packages/devtools-evm-hardhat/types/conf.d.ts
@@ -1,0 +1,5 @@
+declare module '*.conf' {
+    declare const content: string
+
+    export default content
+}

--- a/packages/test-devtools/package.json
+++ b/packages/test-devtools/package.json
@@ -29,6 +29,9 @@
     "lint": "$npm_execpath eslint '**/*.{js,ts,json}'",
     "lint:fix": "eslint --fix '**/*.{js,ts,json}'"
   },
+  "dependencies": {
+    "@scure/bip39": "~1.2.2"
+  },
   "devDependencies": {
     "@layerzerolabs/lz-definitions": "~2.1.15",
     "fast-check": "^3.15.1",

--- a/packages/test-devtools/src/arbitraries.ts
+++ b/packages/test-devtools/src/arbitraries.ts
@@ -4,7 +4,11 @@ import { ENDPOINT_IDS } from './constants'
 
 export const nullishArbitrary = fc.constantFrom(null, undefined)
 
+export const undefinedArbitrary = fc.constantFrom(undefined)
+
 export const nullableArbitrary = <T>(a: fc.Arbitrary<T>) => fc.oneof(a, nullishArbitrary)
+
+export const optionalArbitrary = <T>(a: fc.Arbitrary<T>) => fc.oneof(a, undefinedArbitrary)
 
 export const addressArbitrary = fc.string()
 

--- a/packages/test-devtools/src/arbitraries.ts
+++ b/packages/test-devtools/src/arbitraries.ts
@@ -1,6 +1,7 @@
 import fc from 'fast-check'
 import { EndpointId, Stage } from '@layerzerolabs/lz-definitions'
-import { ENDPOINT_IDS } from './constants'
+import { BIP39_WORDLIST, ENDPOINT_IDS } from './constants'
+import { entropyToMnemonic } from '@scure/bip39'
 
 export const nullishArbitrary = fc.constantFrom(null, undefined)
 
@@ -19,6 +20,10 @@ export const evmBytes32Arbitrary = fc.hexaString({ minLength: 64, maxLength: 64 
 export const endpointArbitrary: fc.Arbitrary<EndpointId> = fc.constantFrom(...ENDPOINT_IDS)
 
 export const stageArbitrary: fc.Arbitrary<Stage> = fc.constantFrom(Stage.MAINNET, Stage.TESTNET, Stage.SANDBOX)
+
+export const mnemonicArbitrary: fc.Arbitrary<string> = fc
+    .uint8Array({ minLength: 16, maxLength: 16 })
+    .map((entropy) => entropyToMnemonic(entropy, BIP39_WORDLIST))
 
 export const pointArbitrary = fc.record({
     eid: endpointArbitrary,

--- a/packages/test-devtools/src/constants.ts
+++ b/packages/test-devtools/src/constants.ts
@@ -1,3 +1,6 @@
 import { EndpointId } from '@layerzerolabs/lz-definitions'
+import { wordlist } from '@scure/bip39/wordlists/english'
 
 export const ENDPOINT_IDS = Object.values(EndpointId).filter((value): value is EndpointId => typeof value === 'number')
+
+export const BIP39_WORDLIST: string[] = wordlist

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -987,6 +987,10 @@ importers:
         version: 3.22.4
 
   packages/test-devtools:
+    dependencies:
+      '@scure/bip39':
+        specifier: ~1.2.2
+        version: 1.2.2
     devDependencies:
       '@layerzerolabs/lz-definitions':
         specifier: ~2.1.15


### PR DESCRIPTION
### In this PR

- Adding utilities & assets required to create a compose spec consisting of anvil-based EVM nodes & an nginx-based RPC proxy
- The proxy is added to avoid exposing N networking ports from the forked nodes - instead, these stay internal to the compose stack and the client needs to use the proxy to get to them
- In order to avoid copying files, the `Dockerfile` and `nginx.conf` file are imported as strings to the code itself using `raw`/`text` loaders. This required a `raw` loader for `jest` (instead of installing a package [with three outdated lines of code](https://github.com/keplersj/jest-raw-loader/blob/master/index.js) I just added a local version of the transformer - `jest.transformer.raw.js`) and a `text` loader for `esbuild`. In addition to this a type definition was required so that TypeScript is not freaking out over importing unknown file types
- Two additional arbitrariness for fuzzy testing were added to make generating optional types easier
- One new arbitrary for generating mnemonics