### PR TITLE
🧹 Take RPC URLs from environment in examples

### DIFF
--- a/.changeset/fair-cars-tie.md
+++ b/.changeset/fair-cars-tie.md
@@ -1,0 +1,6 @@
+---
+"@layerzerolabs/oapp-example": patch
+"@layerzerolabs/oft-example": patch
+---
+
+Take RPC URLs from the environment in the examples

--- a/examples/oapp/hardhat.config.ts
+++ b/examples/oapp/hardhat.config.ts
@@ -51,17 +51,17 @@ const config: HardhatUserConfig = {
     networks: {
         sepolia: {
             eid: EndpointId.SEPOLIA_V2_TESTNET,
-            url: 'https://rpc.sepolia.org/',
+            url: process.env.RPC_URL_SEPOLIA || 'https://rpc.sepolia.org/',
             accounts,
         },
         fuji: {
             eid: EndpointId.AVALANCHE_V2_TESTNET,
-            url: 'https://rpc.ankr.com/avalanche_fuji',
+            url: process.env.RPC_URL_FUJI || 'https://rpc.ankr.com/avalanche_fuji',
             accounts,
         },
         mumbai: {
             eid: EndpointId.POLYGON_V2_TESTNET,
-            url: 'https://rpc.ankr.com/polygon_mumbai',
+            url: process.env.RPC_URL_MUMBAI || 'https://rpc.ankr.com/polygon_mumbai',
             accounts,
         },
     },

--- a/examples/oft/hardhat.config.ts
+++ b/examples/oft/hardhat.config.ts
@@ -51,17 +51,17 @@ const config: HardhatUserConfig = {
     networks: {
         sepolia: {
             eid: EndpointId.SEPOLIA_V2_TESTNET,
-            url: 'https://rpc.sepolia.org/',
+            url: process.env.RPC_URL_SEPOLIA || 'https://rpc.sepolia.org/',
             accounts,
         },
         fuji: {
             eid: EndpointId.AVALANCHE_V2_TESTNET,
-            url: 'https://rpc.ankr.com/avalanche_fuji',
+            url: process.env.RPC_URL_FUJI || 'https://rpc.ankr.com/avalanche_fuji',
             accounts,
         },
         mumbai: {
             eid: EndpointId.POLYGON_V2_TESTNET,
-            url: 'https://rpc.ankr.com/polygon_mumbai',
+            url: process.env.RPC_URL_MUMBAI || 'https://rpc.ankr.com/polygon_mumbai',
             accounts,
         },
     },


### PR DESCRIPTION
### In this PR

- Take RPC URLs from the environment in our examples and provide defaults only if they don't exist

This is introduced to improve the testing of the examples themselves. If we want to introduce any E2E tests for the examples, we need good-quality RPCs that will not cause any flakiness. At the same time, we want to keep the examples usable out of the box for the users.

The solution for this is to be able to inject private RPCs while testing with the CI/CD pipeline using environment variables. Users can still default to the predefined RPCs (or modify their hardhat configs to their liking).

This PR will play an important role when testing the simulation flow - this flow requires forkable RPCs and as such cannot be tested on our local hardhat nodes.