### PR TITLE
🧹 Remove unused build tsconfigs

### DIFF
--- a/packages/devtools-evm-hardhat/package.json
+++ b/packages/devtools-evm-hardhat/package.json
@@ -34,7 +34,7 @@
     "type-extensions"
   ],
   "scripts": {
-    "prebuild": "$npm_execpath tsc --noEmit -p tsconfig.build.json",
+    "prebuild": "$npm_execpath tsc --noEmit",
     "build": "$npm_execpath tsup",
     "clean": "rm -rf dist",
     "dev": "$npm_execpath tsup --watch",

--- a/packages/devtools-evm-hardhat/tsconfig.build.json
+++ b/packages/devtools-evm-hardhat/tsconfig.build.json
@@ -1,4 +1,0 @@
-{
-  "extends": "./tsconfig.json",
-  "exclude": ["node_modules", "dist", "test"]
-}

--- a/packages/devtools-evm/package.json
+++ b/packages/devtools-evm/package.json
@@ -27,7 +27,7 @@
     "./dist/index.*"
   ],
   "scripts": {
-    "prebuild": "$npm_execpath tsc --noEmit -p tsconfig.build.json",
+    "prebuild": "$npm_execpath tsc --noEmit",
     "build": "$npm_execpath tsup",
     "clean": "rm -rf dist",
     "dev": "$npm_execpath tsup --watch",

--- a/packages/devtools-evm/tsconfig.build.json
+++ b/packages/devtools-evm/tsconfig.build.json
@@ -1,4 +1,0 @@
-{
-  "extends": "./tsconfig.json",
-  "exclude": ["node_modules", "dist", "test"]
-}

--- a/packages/protocol-devtools-evm/package.json
+++ b/packages/protocol-devtools-evm/package.json
@@ -27,7 +27,7 @@
     "./dist/index.*"
   ],
   "scripts": {
-    "prebuild": "$npm_execpath tsc --noEmit -p tsconfig.build.json",
+    "prebuild": "$npm_execpath tsc --noEmit",
     "build": "$npm_execpath tsup",
     "clean": "rm -rf dist",
     "dev": "$npm_execpath tsup --watch",

--- a/packages/protocol-devtools-evm/tsconfig.build.json
+++ b/packages/protocol-devtools-evm/tsconfig.build.json
@@ -1,4 +1,0 @@
-{
-  "extends": "./tsconfig.json",
-  "exclude": ["node_modules", "dist", "test"]
-}


### PR DESCRIPTION
### In this PR

- Removing `tsconfig.build.json` files that were previously used to filter build output from packages and did not get deleted. These are no longer necessary as `tsup` will only build the source files specified in `tsup.config.ts`