### PR TITLE
🗞️ Add opt-in parallel configuration execution

### DIFF
--- a/.changeset/early-moose-talk.md
+++ b/.changeset/early-moose-talk.md
@@ -1,0 +1,7 @@
+---
+"@layerzerolabs/ua-devtools-evm-hardhat-v1-test": patch
+"@layerzerolabs/ua-devtools-evm-hardhat-test": patch
+"@layerzerolabs/ua-devtools": patch
+---
+
+Add feature-flagged parallel configuration execution

--- a/.changeset/thirty-maps-train.md
+++ b/.changeset/thirty-maps-train.md
@@ -1,0 +1,5 @@
+---
+"@layerzerolabs/ua-devtools": patch
+---
+
+Use parallel execution when configuring OApp

--- a/packages/ua-devtools/src/lzapp/config.ts
+++ b/packages/ua-devtools/src/lzapp/config.ts
@@ -1,20 +1,28 @@
-import { flattenTransactions, formatOmniVector, parallel, type OmniTransaction } from '@layerzerolabs/devtools'
+import {
+    flattenTransactions,
+    formatOmniVector,
+    parallel,
+    type OmniTransaction,
+    sequence,
+} from '@layerzerolabs/devtools'
 import { LzAppFactory, LzAppOmniGraph } from './types'
 import { createModuleLogger, printBoolean } from '@layerzerolabs/io-devtools'
 
 export type LzAppConfigurator = (graph: LzAppOmniGraph, createSdk: LzAppFactory) => Promise<OmniTransaction[]>
 
-export const configureLzApp: LzAppConfigurator = async (graph: LzAppOmniGraph, createSdk: LzAppFactory) =>
-    flattenTransactions(
-        // For now we keep the parallel execution as an opt-in feature flag
-        // before we have a retry logic fully in place for the SDKs
-        //
-        // This is to avoid 429 too many requests errors from the RPCs
-        process.env.LZ_ENABLE_EXPERIMENTAL_PARALLEL_EXECUTION
-            ? (createModuleLogger('LzApp').warn(`You are using experimental parallel configuration`),
-              await parallel([() => configureLzAppTrustedRemotes(graph, createSdk)]))
-            : [await configureLzAppTrustedRemotes(graph, createSdk)]
-    )
+export const configureLzApp: LzAppConfigurator = async (graph: LzAppOmniGraph, createSdk: LzAppFactory) => {
+    const logger = createModuleLogger('LzApp')
+    const tasks = [() => configureLzAppTrustedRemotes(graph, createSdk)]
+    // For now we keep the parallel execution as an opt-in feature flag
+    // before we have a retry logic fully in place for the SDKs
+    //
+    // This is to avoid 429 too many requests errors from the RPCs
+    const applicative = process.env.LZ_ENABLE_EXPERIMENTAL_PARALLEL_EXECUTION
+        ? (logger.warn(`You are using experimental parallel configuration`), parallel)
+        : sequence
+
+    return flattenTransactions(await applicative(tasks))
+}
 
 export const configureLzAppTrustedRemotes: LzAppConfigurator = async (graph, createSdk) => {
     const logger = createModuleLogger('LzApp')

--- a/packages/ua-devtools/src/oapp/config.ts
+++ b/packages/ua-devtools/src/oapp/config.ts
@@ -5,6 +5,7 @@ import {
     isDeepEqual,
     OmniAddress,
     OmniPointMap,
+    parallel,
     type OmniTransaction,
 } from '@layerzerolabs/devtools'
 import { OAppEnforcedOption, OAppEnforcedOptionParam, OAppFactory, OAppOmniGraph } from './types'
@@ -16,15 +17,17 @@ import { ExecutorOptionType, Options } from '@layerzerolabs/lz-v2-utilities'
 export type OAppConfigurator = (graph: OAppOmniGraph, createSdk: OAppFactory) => Promise<OmniTransaction[]>
 
 export const configureOApp: OAppConfigurator = async (graph: OAppOmniGraph, createSdk: OAppFactory) =>
-    flattenTransactions([
-        await configureOAppPeers(graph, createSdk),
-        await configureSendLibraries(graph, createSdk),
-        await configureReceiveLibraries(graph, createSdk),
-        await configureReceiveLibraryTimeouts(graph, createSdk),
-        await configureSendConfig(graph, createSdk),
-        await configureReceiveConfig(graph, createSdk),
-        await configureEnforcedOptions(graph, createSdk),
-    ])
+    flattenTransactions(
+        await parallel([
+            () => configureOAppPeers(graph, createSdk),
+            () => configureSendLibraries(graph, createSdk),
+            () => configureReceiveLibraries(graph, createSdk),
+            () => configureReceiveLibraryTimeouts(graph, createSdk),
+            () => configureSendConfig(graph, createSdk),
+            () => configureReceiveConfig(graph, createSdk),
+            () => configureEnforcedOptions(graph, createSdk),
+        ])
+    )
 
 export const configureOAppPeers: OAppConfigurator = async (graph, createSdk) => {
     const logger = createModuleLogger('OApp')

--- a/tests/ua-devtools-evm-hardhat-v1-test/test/lzapp/config.test.ts
+++ b/tests/ua-devtools-evm-hardhat-v1-test/test/lzapp/config.test.ts
@@ -69,5 +69,42 @@ describe('lzapp/config', () => {
                 await avaxLzAppSdk.setTrustedRemote(ethLzAppPoint.eid, ethLzAppPoint.address),
             ])
         })
+
+        it('should return all setPeer transactions in parallel mode', async () => {
+            const graph: LzAppOmniGraph = {
+                contracts: [
+                    {
+                        point: ethLzAppPoint,
+                    },
+                    {
+                        point: avaxLzAppPoint,
+                    },
+                ],
+                connections: [
+                    {
+                        vector: { from: ethLzAppPoint, to: avaxLzAppPoint },
+                        config: undefined,
+                    },
+                    {
+                        vector: { from: avaxLzAppPoint, to: ethLzAppPoint },
+                        config: undefined,
+                    },
+                ],
+            }
+
+            process.env.LZ_ENABLE_EXPERIMENTAL_PARALLEL_EXECUTION = '1'
+
+            // This is the LzApp config that we want to use against our contracts
+            transactions = await configureLzApp(graph, lzappSdkFactory)
+
+            expect(transactions).toEqual([
+                await ethLzAppSdk.setTrustedRemote(avaxLzAppPoint.eid, avaxLzAppPoint.address),
+                await avaxLzAppSdk.setTrustedRemote(ethLzAppPoint.eid, ethLzAppPoint.address),
+            ])
+        })
+    })
+
+    afterEach(() => {
+        process.env.LZ_ENABLE_EXPERIMENTAL_PARALLEL_EXECUTION = undefined
     })
 })


### PR DESCRIPTION
### In this PR

- Add feature-flagged parallel execution capability to OApp / LzApp configuration. This is enabled by setting `LZ_ENABLE_EXPERIMENTAL_PARALLEL_EXECUTION` environment variable to a truth value (e.g. `'1'` or `'true'` or `'ohboi'`). The reason this has been feature flagged is the fact that when using public RPCs, we might get rate-limited and without a proper retry logic in place for SDKs, this might make our tool unusable.
- We might decide later to pull this one level up and allow the `LzAppConfigurator` and `OAppConfigurator` to accept an applicative (`parallel` or `sequence`)