### PR TITLE
🗞️ Adjust simulation config logic for anvil [7/N]

### DIFF
--- a/.changeset/dull-bananas-kiss.md
+++ b/.changeset/dull-bananas-kiss.md
@@ -1,0 +1,5 @@
+---
+"@layerzerolabs/devtools-evm-hardhat": patch
+---
+
+Adjust simulation config logic for anvil

--- a/packages/devtools-evm-hardhat/test/simulation/config.test.ts
+++ b/packages/devtools-evm-hardhat/test/simulation/config.test.ts
@@ -10,11 +10,13 @@ import { resolve } from 'path'
 
 describe('simulation/config', () => {
     describe('resolveSimulationConfig()', () => {
-        it('should resolve with defaults without no properties', () => {
+        it('should resolve with defaults when called with no properties', () => {
             expect(resolveSimulationConfig({}, hre.config)).toEqual({
                 port: 8545,
                 directory: resolve(hre.config.paths.root, '.layerzero'),
                 anvil: {
+                    host: '0.0.0.0',
+                    port: 8545,
                     mnemonic: 'test test test test test test test test test test test junk',
                 },
             })
@@ -27,6 +29,8 @@ describe('simulation/config', () => {
                         port,
                         directory: resolve(hre.config.paths.root, directory),
                         anvil: {
+                            host: '0.0.0.0',
+                            port: 8545,
                             mnemonic,
                         },
                     })
@@ -69,14 +73,20 @@ describe('simulation/config', () => {
                 networkA: {
                     forkUrl: networkA.url,
                     mnemonic: simulationConfig.anvil.mnemonic,
+                    host: '0.0.0.0',
+                    port: 8545,
                 },
                 networkB: {
                     forkUrl: networkB.url,
                     mnemonic: simulationConfig.anvil.mnemonic,
+                    host: '0.0.0.0',
+                    port: 8545,
                 },
                 networkC: {
                     forkUrl: networkC.url,
                     mnemonic: simulationConfig.anvil.mnemonic,
+                    host: '0.0.0.0',
+                    port: 8545,
                 },
             })
         })
@@ -114,20 +124,67 @@ describe('simulation/config', () => {
                 })
             ).toStrictEqual({
                 networkA: {
+                    ...networkA,
                     url: `http://localhost:${simulationConfig.port}/networkA`,
                     accounts: {
+                        count: 10,
+                        initialIndex: 0,
+                        passphrase: '',
+                        path: "m/44'/60'/0'/0/",
                         mnemonic: simulationConfig.anvil.mnemonic,
                     },
                 },
                 networkB: {
+                    ...networkB,
                     url: `http://localhost:${simulationConfig.port}/networkB`,
                     accounts: {
+                        count: 10,
+                        initialIndex: 0,
+                        passphrase: '',
+                        path: "m/44'/60'/0'/0/",
                         mnemonic: simulationConfig.anvil.mnemonic,
                     },
                 },
                 networkC: {
+                    ...networkC,
                     url: `http://localhost:${simulationConfig.port}/networkC`,
                     accounts: {
+                        count: 10,
+                        initialIndex: 0,
+                        passphrase: '',
+                        path: "m/44'/60'/0'/0/",
+                        mnemonic: simulationConfig.anvil.mnemonic,
+                    },
+                },
+            })
+        })
+
+        it('should respect anvil accounts options', () => {
+            const localhost = hre.config.networks.localhost
+            const networkA = { ...localhost, url: 'http://network.a' }
+            const simulationConfig = resolveSimulationConfig(
+                {
+                    anvil: {
+                        count: 20,
+                        derivationPath: "m/44'/60'/0'/16/",
+                    },
+                },
+                hre.config
+            )
+
+            expect(
+                getHardhatNetworkOverrides(simulationConfig, {
+                    networkA,
+                })
+            ).toStrictEqual({
+                networkA: {
+                    ...networkA,
+                    url: `http://localhost:${simulationConfig.port}/networkA`,
+                    accounts: {
+                        count: simulationConfig.anvil.count,
+                        initialIndex: 0,
+                        passphrase: '',
+                        path: simulationConfig.anvil.derivationPath,
                         mnemonic: simulationConfig.anvil.mnemonic,
                     },
                 },


### PR DESCRIPTION
### In this PR

- Adjusting the simulation config for `anvil` 
  - Pointing `anvil` to `0.0.0.0:8545` since it's running in a docker container
  - Making `getHardhatNetworkOverrides` return a full, resolved hardhat network config. The original intention was to store the output of this function in an e.g. `.json` file and merge it with `hardhat.config.ts` at runtime. This meant that it could not contain any sensitive information since a user mistake (like accidentally pushing this file to a public repository) would lead to the loss of private data. The new idea is to call this function at runtime, without storing anything on the filesystem. The output of this function will be used to update the network configuration in hardhat without any intermediate steps.