### PR TITLE
🪲 Don't use printRecord in SDKs

### DIFF
--- a/.changeset/wet-buckets-flash.md
+++ b/.changeset/wet-buckets-flash.md
@@ -1,0 +1,5 @@
+---
+"@layerzerolabs/protocol-devtools-evm": patch
+---
+
+Don't use printRecord for transaction descriptions

--- a/packages/protocol-devtools-evm/src/dvn/sdk.ts
+++ b/packages/protocol-devtools-evm/src/dvn/sdk.ts
@@ -2,7 +2,7 @@ import type { EndpointId } from '@layerzerolabs/lz-definitions'
 import type { IDVN, DVNDstConfig } from '@layerzerolabs/protocol-devtools'
 import { formatEid, type OmniTransaction } from '@layerzerolabs/devtools'
 import { OmniSDK } from '@layerzerolabs/devtools-evm'
-import { printRecord } from '@layerzerolabs/io-devtools'
+import { printJson } from '@layerzerolabs/io-devtools'
 import { DVNDstConfigSchema } from './schema'
 
 export class DVN extends OmniSDK implements IDVN {
@@ -30,7 +30,7 @@ export class DVN extends OmniSDK implements IDVN {
 
         return {
             ...this.createTransaction(data),
-            description: `Setting dstConfig for ${formatEid(eid)}: ${printRecord(value)}`,
+            description: `Setting dstConfig for ${formatEid(eid)}: ${printJson(value)}`,
         }
     }
 }

--- a/packages/protocol-devtools-evm/src/executor/sdk.ts
+++ b/packages/protocol-devtools-evm/src/executor/sdk.ts
@@ -2,7 +2,7 @@ import type { EndpointId } from '@layerzerolabs/lz-definitions'
 import type { IExecutor, ExecutorDstConfig } from '@layerzerolabs/protocol-devtools'
 import { formatEid, type OmniTransaction } from '@layerzerolabs/devtools'
 import { OmniSDK } from '@layerzerolabs/devtools-evm'
-import { printRecord } from '@layerzerolabs/io-devtools'
+import { printJson } from '@layerzerolabs/io-devtools'
 import { ExecutorDstConfigSchema } from './schema'
 
 export class Executor extends OmniSDK implements IExecutor {
@@ -31,7 +31,7 @@ export class Executor extends OmniSDK implements IExecutor {
 
         return {
             ...this.createTransaction(data),
-            description: `Setting dstConfig for ${formatEid(eid)}: ${printRecord(value)}`,
+            description: `Setting dstConfig for ${formatEid(eid)}: ${printJson(value)}`,
         }
     }
 }

--- a/packages/protocol-devtools-evm/src/priceFeed/sdk.ts
+++ b/packages/protocol-devtools-evm/src/priceFeed/sdk.ts
@@ -2,7 +2,7 @@ import type { EndpointId } from '@layerzerolabs/lz-definitions'
 import type { IPriceFeed, PriceData } from '@layerzerolabs/protocol-devtools'
 import { formatEid, type OmniTransaction } from '@layerzerolabs/devtools'
 import { OmniSDK } from '@layerzerolabs/devtools-evm'
-import { printRecord } from '@layerzerolabs/io-devtools'
+import { printJson } from '@layerzerolabs/io-devtools'
 import { PriceDataSchema } from './schema'
 
 export class PriceFeed extends OmniSDK implements IPriceFeed {
@@ -28,7 +28,7 @@ export class PriceFeed extends OmniSDK implements IPriceFeed {
 
         return {
             ...this.createTransaction(data),
-            description: `Setting price for ${formatEid(eid)}: ${printRecord(priceData)}`,
+            description: `Setting price for ${formatEid(eid)}: ${printJson(priceData)}`,
         }
     }
 }

--- a/packages/protocol-devtools-evm/src/uln302/sdk.ts
+++ b/packages/protocol-devtools-evm/src/uln302/sdk.ts
@@ -14,7 +14,7 @@ import {
 } from '@layerzerolabs/devtools'
 import { Uln302ExecutorConfigSchema, Uln302UlnConfigSchema } from './schema'
 import assert from 'assert'
-import { printJson, printRecord } from '@layerzerolabs/io-devtools'
+import { printJson } from '@layerzerolabs/io-devtools'
 import { isZero } from '@layerzerolabs/devtools'
 import { OmniSDK, addChecksum, makeZeroAddress } from '@layerzerolabs/devtools-evm'
 
@@ -167,7 +167,7 @@ export class Uln302 extends OmniSDK implements IUln302 {
 
         return {
             ...this.createTransaction(data),
-            description: `Setting default ULN config for ${formatEid(eid)}: ${printRecord(serializedConfig)}`,
+            description: `Setting default ULN config for ${formatEid(eid)}: ${printJson(serializedConfig)}`,
         }
     }
 


### PR DESCRIPTION
### In this PR

- Replace `printRecord` with `printJson` when adding descriptions to transactions. `printRecord` is meant to be used directly with stdout and it's not suitable for serialization. Also it's much slower than `printJson`, slowing down some of the tests to about 2 minutes