### PR TITLE
🗞️ Add --safe and --signer CLI arguments to the wire task

### DIFF
--- a/.changeset/forty-panthers-breathe.md
+++ b/.changeset/forty-panthers-breathe.md
@@ -1,0 +1,8 @@
+---
+"@layerzerolabs/ua-devtools-evm-hardhat-test": patch
+"@layerzerolabs/ua-devtools-evm-hardhat": patch
+"@layerzerolabs/devtools-evm-hardhat": patch
+"@layerzerolabs/devtools-evm": patch
+---
+
+Add the ability to choose gnosis safe for transaction signing; add the ability to pick signer index/address

--- a/packages/devtools-evm-hardhat/src/tasks/transactions/subtask.sign-and-send.ts
+++ b/packages/devtools-evm-hardhat/src/tasks/transactions/subtask.sign-and-send.ts
@@ -1,7 +1,6 @@
 import { types } from '@/cli'
 import { SUBTASK_LZ_SIGN_AND_SEND } from '@/constants'
 import { formatOmniTransaction } from '@/transactions/format'
-import { createGnosisSignerFactory, createSignerFactory } from '@/transactions/signer'
 import {
     type OmniSignerFactory,
     type OmniTransaction,
@@ -25,16 +24,13 @@ import type { ActionType } from 'hardhat/types'
 export interface SignAndSendTaskArgs {
     ci?: boolean
     transactions: OmniTransaction[]
-    useSafe?: boolean
-    createSigner?: OmniSignerFactory
+    createSigner: OmniSignerFactory
 }
 
 const action: ActionType<SignAndSendTaskArgs> = async ({
     ci,
     transactions,
-    useSafe = false,
-    // useSafe will override createSigner using Gnosis factory
-    createSigner = useSafe ? createGnosisSignerFactory() : createSignerFactory(),
+    createSigner,
 }): Promise<SignAndSendResult> => {
     // We only want to be asking users for input if we are not in interactive mode
     const isInteractive = !ci
@@ -171,5 +167,4 @@ const action: ActionType<SignAndSendTaskArgs> = async ({
 subtask(SUBTASK_LZ_SIGN_AND_SEND, 'Sign and send a list of transactions using a local signer', action)
     .addFlag('ci', 'Continuous integration (non-interactive) mode. Will not ask for any input from the user')
     .addParam('transactions', 'List of OmniTransaction objects', undefined, types.any)
-    .addParam('createSigner', 'Function that creates a signer for a particular network', undefined, types.any, true)
-    .addParam('useSafe', 'Use Gnosis Safe for signing.  Overrides createSigner.', false, types.boolean, true)
+    .addParam('createSigner', 'Function that creates a signer for a particular network', undefined, types.fn)

--- a/packages/devtools-evm-hardhat/test/cli.test.ts
+++ b/packages/devtools-evm-hardhat/test/cli.test.ts
@@ -1,0 +1,35 @@
+import { signer } from '@/cli'
+import { evmAddressArbitrary } from '@layerzerolabs/test-devtools'
+import fc from 'fast-check'
+
+describe('cli', () => {
+    describe('signer', () => {
+        it('should throw if invalid address is passed', () => {
+            expect(() => signer.parse('signer', 'wat')).toThrow()
+        })
+
+        it('should throw if negative index is passed', () => {
+            fc.assert(
+                fc.property(fc.integer({ max: -1 }), (index) => {
+                    expect(() => signer.parse('signer', String(index))).toThrow()
+                })
+            )
+        })
+
+        it('should return the address if valid address is passed', () => {
+            fc.assert(
+                fc.property(evmAddressArbitrary, (address) => {
+                    expect(signer.parse('signer', address)).toBe(address)
+                })
+            )
+        })
+
+        it('should return the index if non-negative index is passed', () => {
+            fc.assert(
+                fc.property(fc.integer({ min: 0 }), (index) => {
+                    expect(signer.parse('signer', String(index))).toBe(index)
+                })
+            )
+        })
+    })
+})

--- a/packages/devtools-evm/src/address.ts
+++ b/packages/devtools-evm/src/address.ts
@@ -1,5 +1,5 @@
 import type { OmniAddress } from '@layerzerolabs/devtools'
-import { getAddress } from '@ethersproject/address'
+import { getAddress, isAddress } from '@ethersproject/address'
 import { AddressZero } from '@ethersproject/constants'
 
 /**
@@ -19,3 +19,11 @@ export const makeZeroAddress = (address?: OmniAddress | null | undefined): strin
  * @returns {OmniAddress}
  */
 export const addChecksum = (address: OmniAddress): OmniAddress => getAddress(address)
+
+/**
+ * Re-export of `isAddress` from `@ethersporject/address`
+ *
+ * @param {OmniAddress} address
+ * @returns {boolean}
+ */
+export const isEVMAddress = isAddress

--- a/tests/ua-devtools-evm-hardhat-test/test/task/oapp/wire.test.ts
+++ b/tests/ua-devtools-evm-hardhat-test/test/task/oapp/wire.test.ts
@@ -6,6 +6,11 @@ import { deployOApp } from '../../__utils__/oapp'
 import { cwd } from 'process'
 import { JsonRpcSigner } from '@ethersproject/providers'
 import { deployAndSetupDefaultEndpointV2 } from '../../__utils__/endpointV2'
+import {
+    createGnosisSignerFactory,
+    createSignerFactory,
+    SUBTASK_LZ_SIGN_AND_SEND,
+} from '@layerzerolabs/devtools-evm-hardhat'
 
 jest.mock('@layerzerolabs/io-devtools', () => {
     const original = jest.requireActual('@layerzerolabs/io-devtools')
@@ -16,7 +21,20 @@ jest.mock('@layerzerolabs/io-devtools', () => {
     }
 })
 
+jest.mock('@layerzerolabs/devtools-evm-hardhat', () => {
+    const original = jest.requireActual('@layerzerolabs/devtools-evm-hardhat')
+
+    return {
+        ...original,
+        createGnosisSignerFactory: jest.fn(original.createGnosisSignerFactory),
+        createSignerFactory: jest.fn(original.createSignerFactory),
+    }
+})
+
+const hreRunSpy = jest.spyOn(hre, 'run')
 const promptToContinueMock = promptToContinue as jest.Mock
+const createGnosisSignerFactoryMock = createGnosisSignerFactory as jest.Mock
+const createSignerFactoryMock = createSignerFactory as jest.Mock
 
 describe(`task ${TASK_LZ_OAPP_WIRE}`, () => {
     // Helper matcher object that checks for OmniPoint objects
@@ -40,6 +58,9 @@ describe(`task ${TASK_LZ_OAPP_WIRE}`, () => {
 
     beforeEach(async () => {
         promptToContinueMock.mockReset()
+        createGnosisSignerFactoryMock.mockClear()
+        createSignerFactoryMock.mockClear()
+        hreRunSpy.mockClear()
     })
 
     describe('with invalid configs', () => {
@@ -185,6 +206,123 @@ describe(`task ${TASK_LZ_OAPP_WIRE}`, () => {
 
             expect(successful).toEqual([expectTransactionWithReceipt, expectTransactionWithReceipt])
             expect(errors).toEqual([])
+        })
+
+        it('should use gnosis safe signer if --safe flag is passed', async () => {
+            const oappConfig = configPathFixture('valid.config.connected.js')
+
+            promptToContinueMock
+                .mockResolvedValueOnce(false) // We don't want to see the list
+                .mockResolvedValueOnce(true) // We want to continue
+
+            await hre.run(TASK_LZ_OAPP_WIRE, { oappConfig, safe: true })
+
+            expect(createGnosisSignerFactory).toHaveBeenCalledOnce()
+
+            // Get the created gnosis signer factory
+            const createSigner = createGnosisSignerFactoryMock.mock.results[0]?.value
+            expect(typeof createSigner).toBe('function')
+
+            // Now we check that the sign and send subtask has been called with the correct signer factory
+            expect(hreRunSpy).toHaveBeenCalledWith(
+                SUBTASK_LZ_SIGN_AND_SEND,
+                {
+                    transactions: expect.any(Array),
+                    ci: false,
+                    createSigner,
+                },
+                {},
+                undefined
+            )
+        })
+
+        it('should use gnosis safe signer with index if --safe flag and --signer are passed', async () => {
+            const oappConfig = configPathFixture('valid.config.connected.js')
+            const [signer] = await hre.getUnnamedAccounts()
+
+            promptToContinueMock
+                .mockResolvedValueOnce(false) // We don't want to see the list
+                .mockResolvedValueOnce(true) // We want to continue
+
+            await hre.run(TASK_LZ_OAPP_WIRE, { oappConfig, safe: true, signer })
+
+            expect(createGnosisSignerFactory).toHaveBeenCalledOnce()
+            expect(createGnosisSignerFactory).toHaveBeenCalledWith(signer)
+
+            // Get the created gnosis signer factory
+            const createSigner = createGnosisSignerFactoryMock.mock.results[0]?.value
+            expect(typeof createSigner).toBe('function')
+
+            // Now we check that the sign and send subtask has been called with the correct signer factory
+            expect(hreRunSpy).toHaveBeenCalledWith(
+                SUBTASK_LZ_SIGN_AND_SEND,
+                {
+                    transactions: expect.any(Array),
+                    ci: false,
+                    createSigner,
+                },
+                {},
+                undefined
+            )
+        })
+
+        it('should use signer index if --signer is passed', async () => {
+            const oappConfig = configPathFixture('valid.config.connected.js')
+
+            promptToContinueMock
+                .mockResolvedValueOnce(false) // We don't want to see the list
+                .mockResolvedValueOnce(true) // We want to continue
+
+            await hre.run(TASK_LZ_OAPP_WIRE, { oappConfig, signer: 0 })
+
+            expect(createSignerFactory).toHaveBeenCalledOnce()
+            expect(createSignerFactory).toHaveBeenCalledWith(0)
+
+            // Get the created signer factory
+            const createSigner = createSignerFactoryMock.mock.results[0]?.value
+            expect(typeof createSigner).toBe('function')
+
+            // Now we check that the sign and send subtask has been called with the correct signer factory
+            expect(hreRunSpy).toHaveBeenCalledWith(
+                SUBTASK_LZ_SIGN_AND_SEND,
+                {
+                    transactions: expect.any(Array),
+                    ci: false,
+                    createSigner,
+                },
+                {},
+                undefined
+            )
+        })
+
+        it('should use signer address if --signer is passed', async () => {
+            const oappConfig = configPathFixture('valid.config.connected.js')
+            const [signer] = await hre.getUnnamedAccounts()
+
+            promptToContinueMock
+                .mockResolvedValueOnce(false) // We don't want to see the list
+                .mockResolvedValueOnce(true) // We want to continue
+
+            await hre.run(TASK_LZ_OAPP_WIRE, { oappConfig, signer })
+
+            expect(createSignerFactory).toHaveBeenCalledOnce()
+            expect(createSignerFactory).toHaveBeenCalledWith(signer)
+
+            // Get the created signer factory
+            const createSigner = createSignerFactoryMock.mock.results[0]?.value
+            expect(typeof createSigner).toBe('function')
+
+            // Now we check that the sign and send subtask has been called with the correct signer factory
+            expect(hreRunSpy).toHaveBeenCalledWith(
+                SUBTASK_LZ_SIGN_AND_SEND,
+                {
+                    transactions: expect.any(Array),
+                    ci: false,
+                    createSigner,
+                },
+                {},
+                undefined
+            )
         })
 
         describe('if a transaction fails', () => {


### PR DESCRIPTION
### In this PR

- Add `--safe` CLI argument for signing transactions with gnosis safe
- Add `--signer` CLI argument for selecting the index or address of a signer