### PR TITLE
🧹 Add default verify url for blast network

### DIFF
--- a/.changeset/nasty-ligers-hunt.md
+++ b/.changeset/nasty-ligers-hunt.md
@@ -1,0 +1,5 @@
+---
+"@layerzerolabs/verify-contract": patch
+---
+
+Added default url for blast network

--- a/packages/verify-contract/src/common/url.ts
+++ b/packages/verify-contract/src/common/url.ts
@@ -76,4 +76,5 @@ const DEFAULT_SCAN_API_URLS: Map<NetworkName, string> = new Map([
     ['fraxtal', 'https://api.fraxscan.com/api'],
     ['mode', 'https://explorer.mode.network/api'],
     ['etherlink', 'https://explorer.etherlink.com/api'],
+    ['blast', 'https://api.blastscan.io/api'],
 ])


### PR DESCRIPTION
aded a default verify contract url for: 
blast