### PR TITLE
🪲 Fix tests that use docker compose

### DIFF
--- a/packages/devtools-evm-hardhat/test/simulation/compose.test.ts
+++ b/packages/devtools-evm-hardhat/test/simulation/compose.test.ts
@@ -56,9 +56,10 @@ describe('simulation/compose', () => {
 
             await writeFile(SPEC_FILE_PATH, spec)
 
-            expect(validateSpec().stderr.toString('utf8')).toBe('')
-            expect(validateSpec().status).toBe(0)
+            const result = validateSpec()
 
+            expect(result.stderr.toString('utf8')).toBe('')
+            expect(result.status).toBe(0)
             expect(spec).toMatchSnapshot()
         })
 
@@ -74,8 +75,10 @@ describe('simulation/compose', () => {
 
                     await writeFile(SPEC_FILE_PATH, spec)
 
-                    expect(validateSpec().stderr.toString('utf8')).toBe('')
-                    expect(validateSpec().status).toBe(0)
+                    const result = validateSpec()
+
+                    expect(result.stderr.toString('utf8')).toBe('')
+                    expect(result.status).toBe(0)
                 }),
                 { numRuns: 20 }
             )
@@ -101,8 +104,10 @@ describe('simulation/compose', () => {
 
                     await writeFile(SPEC_FILE_PATH, spec)
 
-                    expect(validateSpec().stderr.toString('utf8')).toBe('')
-                    expect(validateSpec().status).toBe(0)
+                    const result = validateSpec()
+
+                    expect(result.stderr.toString('utf8')).toBe('')
+                    expect(result.status).toBe(0)
                 }),
                 { numRuns: 20 }
             )
@@ -120,8 +125,10 @@ describe('simulation/compose', () => {
 
                     await writeFile(SPEC_FILE_PATH, spec)
 
-                    expect(validateSpec().stderr.toString('utf8')).toBe('')
-                    expect(validateSpec().status).toBe(0)
+                    const result = validateSpec()
+
+                    expect(result.stderr.toString('utf8')).toBe('')
+                    expect(result.status).toBe(0)
                 }),
                 { numRuns: 20 }
             )

--- a/packages/devtools/test/docker/__snapshots__/compose.test.ts.snap
+++ b/packages/devtools/test/docker/__snapshots__/compose.test.ts.snap
@@ -23,5 +23,6 @@ volumes:
 
 exports[`docker/compose serializeDockerComposeSpec should create a valid compose spec if called with no services 1`] = `
 "version: '3.9'
+services: {}
 "
 `;

--- a/packages/devtools/test/docker/compose.test.ts
+++ b/packages/devtools/test/docker/compose.test.ts
@@ -17,6 +17,7 @@ describe('docker/compose', () => {
         it('should create a valid compose spec if called with no services', async () => {
             const spec = serializeDockerComposeSpec({
                 version: '3.9',
+                services: {},
             })
 
             await writeFile(SPEC_FILE_PATH, spec)

--- a/packages/devtools/test/docker/compose.test.ts
+++ b/packages/devtools/test/docker/compose.test.ts
@@ -7,7 +7,8 @@ describe('docker/compose', () => {
     describe('serializeDockerComposeSpec', () => {
         const SPEC_FILE_PATH = join(__dirname, 'docker-compose.yaml')
 
-        const validateSpec = () => spawnSync('docker', ['compose', '-f', SPEC_FILE_PATH, 'config'])
+        const validateSpec = () =>
+            spawnSync('docker', ['--log-level', 'ERROR', 'compose', '-f', SPEC_FILE_PATH, 'config'])
 
         afterEach(async () => {
             await rm(SPEC_FILE_PATH, { force: true })
@@ -20,8 +21,10 @@ describe('docker/compose', () => {
 
             await writeFile(SPEC_FILE_PATH, spec)
 
-            expect(validateSpec().status).toBe(0)
+            const result = validateSpec()
 
+            expect(result.stderr.toString('utf8')).toBe('')
+            expect(result.status).toBe(0)
             expect(spec).toMatchSnapshot()
         })
 
@@ -52,8 +55,10 @@ describe('docker/compose', () => {
 
             await writeFile(SPEC_FILE_PATH, spec)
 
-            expect(validateSpec().status).toBe(0)
+            const result = validateSpec()
 
+            expect(result.stderr.toString('utf8')).toBe('')
+            expect(result.status).toBe(0)
             expect(spec).toMatchSnapshot()
         })
     })


### PR DESCRIPTION
### In this PR

- In our `Dockerfile`, we always install the newest version of `docker`. In the recent update, the logic for `docker compose config` has changed and no longer supports a compose file with no services. The test has been updated to include an empty `services` object
- Small speedup for other compose tests - the validation logic is only ran once
- More assertions for the compose tests to see the details of an error from `stderr` if something goes wrong, instead of just the error code