### PR TITLE
🧹 Custom configuration: Pass configLoader to config validator [1/N]

### DIFF
--- a/packages/ua-devtools-evm-hardhat/src/tasks/oapp/config.get.ts
+++ b/packages/ua-devtools-evm-hardhat/src/tasks/oapp/config.get.ts
@@ -1,12 +1,13 @@
 import { ActionType } from 'hardhat/types'
 import { task } from 'hardhat/config'
-import { createLogger, printCrossTable } from '@layerzerolabs/io-devtools'
+import { createConfigLoader, createLogger, printCrossTable } from '@layerzerolabs/io-devtools'
 import { getReceiveConfig, getSendConfig, validateAndTransformOappConfig } from '@/utils/taskHelpers'
 import { TASK_LZ_OAPP_CONFIG_GET } from '@/constants/tasks'
 import assert from 'assert'
 import { setDefaultLogLevel } from '@layerzerolabs/io-devtools'
 import { OAppOmniGraph } from '@layerzerolabs/ua-devtools'
 import { getNetworkNameForEid, types } from '@layerzerolabs/devtools-evm-hardhat'
+import { OAppOmniGraphHardhatSchema } from '@/oapp'
 
 interface TaskArgs {
     logLevel?: string
@@ -20,7 +21,11 @@ const action: ActionType<TaskArgs> = async ({ logLevel = 'info', oappConfig }) =
     const networks: string[] = []
     const addresses: string[] = []
     const logger = createLogger()
-    const graph: OAppOmniGraph = await validateAndTransformOappConfig(oappConfig, logger)
+    const graph: OAppOmniGraph = await validateAndTransformOappConfig(
+        oappConfig,
+        createConfigLoader(OAppOmniGraphHardhatSchema),
+        logger
+    )
     graph.contracts.forEach((contract) => {
         networks.push(getNetworkNameForEid(contract.point.eid))
         addresses.push(contract.point.address)

--- a/packages/ua-devtools-evm-hardhat/src/tasks/oapp/enforced.opts.get.ts
+++ b/packages/ua-devtools-evm-hardhat/src/tasks/oapp/enforced.opts.get.ts
@@ -1,6 +1,12 @@
 import { ActionType } from 'hardhat/types'
 import { task } from 'hardhat/config'
-import { createLogger, printCrossTable, printRecord, setDefaultLogLevel } from '@layerzerolabs/io-devtools'
+import {
+    createConfigLoader,
+    createLogger,
+    printCrossTable,
+    printRecord,
+    setDefaultLogLevel,
+} from '@layerzerolabs/io-devtools'
 import { TASK_LZ_OAPP_ENFORCED_OPTS_GET } from '@/constants/tasks'
 import { printLogo } from '@layerzerolabs/io-devtools/swag'
 import { EncodedOption, OAppOmniGraph } from '@layerzerolabs/ua-devtools'
@@ -11,6 +17,7 @@ import { validateAndTransformOappConfig } from '@/utils/taskHelpers'
 import { getNetworkNameForEid } from '@layerzerolabs/devtools-evm-hardhat'
 import { areVectorsEqual, isZero } from '@layerzerolabs/devtools'
 import { Options } from '@layerzerolabs/lz-v2-utilities'
+import { OAppOmniGraphHardhatSchema } from '@/oapp/schema'
 
 interface TaskArgs {
     oappConfig: string
@@ -25,7 +32,11 @@ const action: ActionType<TaskArgs> = async ({ oappConfig: oappConfigPath, logLev
 
     // And we'll create a logger for ourselves
     const logger = createLogger()
-    const graph: OAppOmniGraph = await validateAndTransformOappConfig(oappConfigPath, logger)
+    const graph: OAppOmniGraph = await validateAndTransformOappConfig(
+        oappConfigPath,
+        createConfigLoader(OAppOmniGraphHardhatSchema),
+        logger
+    )
 
     // need points for OApp Enforced Option Matrix
     const points = graph.contracts

--- a/packages/ua-devtools-evm-hardhat/src/tasks/oapp/peers.get.ts
+++ b/packages/ua-devtools-evm-hardhat/src/tasks/oapp/peers.get.ts
@@ -1,6 +1,12 @@
 import { ActionType } from 'hardhat/types'
 import { task } from 'hardhat/config'
-import { createLogger, printBoolean, printCrossTable, setDefaultLogLevel } from '@layerzerolabs/io-devtools'
+import {
+    createConfigLoader,
+    createLogger,
+    printBoolean,
+    printCrossTable,
+    setDefaultLogLevel,
+} from '@layerzerolabs/io-devtools'
 import { TASK_LZ_OAPP_PEERS_GET } from '@/constants/tasks'
 import { printLogo } from '@layerzerolabs/io-devtools/swag'
 import { OAppOmniGraph } from '@layerzerolabs/ua-devtools'
@@ -10,6 +16,7 @@ import { checkOAppPeers } from '@layerzerolabs/ua-devtools'
 import { validateAndTransformOappConfig } from '@/utils/taskHelpers'
 import { getNetworkNameForEid } from '@layerzerolabs/devtools-evm-hardhat'
 import { areVectorsEqual } from '@layerzerolabs/devtools'
+import { OAppOmniGraphHardhatSchema } from '@/oapp/schema'
 
 interface TaskArgs {
     oappConfig: string
@@ -24,7 +31,11 @@ const action: ActionType<TaskArgs> = async ({ oappConfig: oappConfigPath, logLev
 
     // And we'll create a logger for ourselves
     const logger = createLogger()
-    const graph: OAppOmniGraph = await validateAndTransformOappConfig(oappConfigPath, logger)
+    const graph: OAppOmniGraph = await validateAndTransformOappConfig(
+        oappConfigPath,
+        createConfigLoader(OAppOmniGraphHardhatSchema),
+        logger
+    )
 
     // need points for OApp Peer Matrix
     const points = graph.contracts

--- a/packages/ua-devtools-evm-hardhat/src/tasks/oapp/wire/index.ts
+++ b/packages/ua-devtools-evm-hardhat/src/tasks/oapp/wire/index.ts
@@ -1,7 +1,13 @@
 import { task } from 'hardhat/config'
 import type { ActionType } from 'hardhat/types'
 import { SUBTASK_LZ_OAPP_WIRE_CONFIGURE, TASK_LZ_OAPP_WIRE } from '@/constants/tasks'
-import { createLogger, setDefaultLogLevel, printJson, pluralizeNoun } from '@layerzerolabs/io-devtools'
+import {
+    createLogger,
+    setDefaultLogLevel,
+    printJson,
+    pluralizeNoun,
+    createConfigLoader,
+} from '@layerzerolabs/io-devtools'
 import { OAppOmniGraph } from '@layerzerolabs/ua-devtools'
 import {
     types,
@@ -17,6 +23,7 @@ import type { SubtaskConfigureTaskArgs } from './subtask.configure'
 import type { SignAndSendTaskArgs } from '@layerzerolabs/devtools-evm-hardhat/tasks'
 
 import './subtask.configure'
+import { OAppOmniGraphHardhatSchema } from '@/oapp/schema'
 
 interface TaskArgs {
     oappConfig: string
@@ -37,7 +44,11 @@ const action: ActionType<TaskArgs> = async (
 
     // And we'll create a logger for ourselves
     const logger = createLogger()
-    const graph: OAppOmniGraph = await validateAndTransformOappConfig(oappConfigPath, logger)
+    const graph: OAppOmniGraph = await validateAndTransformOappConfig(
+        oappConfigPath,
+        createConfigLoader(OAppOmniGraphHardhatSchema),
+        logger
+    )
 
     // At this point we are ready to create the list of transactions
     logger.verbose(`Creating a list of wiring transactions`)


### PR DESCRIPTION
### In this PR

- Changing the API of `validateAndTransformOappConfig` so that the config loader is passed as an argument. Config loader is responsible for turning a path to a config file into a strongly typed config, based on the schema it uses.

This is the first step towards making custom configurations easier to accomplish (or more precisely, easier to represent in TypeScript). It creates a bit of extra code on the consumer side that in return allows for more flexibility - custom loader can be created for custom config schemas.

In the first use case, this will be used to add ownership transfer functionality for which we'll use a custom schema and an SDK mixin.