### PR TITLE
🗞️ Configuration functions

### DIFF
--- a/.changeset/selfish-ways-explode.md
+++ b/.changeset/selfish-ways-explode.md
@@ -1,0 +1,5 @@
+---
+"@layerzerolabs/io-devtools": patch
+---
+
+Add the ability to define configs as functions

--- a/packages/io-devtools/test/config/__snapshots__/loading.test.ts.snap
+++ b/packages/io-devtools/test/config/__snapshots__/loading.test.ts.snap
@@ -2,18 +2,34 @@
 
 exports[`config/loading createConfigLoader should reject if the file cannot be imported 1`] = `[Error: Unable to read config file './myconfig.ts': No way]`;
 
-exports[`config/loading createConfigLoader should reject if the file contents do not match the schema 1`] = `
+exports[`config/loading createConfigLoader should reject if the path is not a file 1`] = `[Error: Unable to read config file './myconfig.ts'. Check that the file exists and is readable to your terminal user]`;
+
+exports[`config/loading createConfigLoader should reject if the path is not readable 1`] = `[Error: Unable to read config file './myconfig.ts'. Check that the file exists and is readable to your terminal user]`;
+
+exports[`config/loading createConfigLoader when config file exports a config should reject if the file contents do not match the schema 1`] = `
 [Error: Config from file './myconfig.ts' is malformed. Please fix the following errors:
 
 Property 'good': Required]
 `;
 
-exports[`config/loading createConfigLoader should reject if the path is not a file 1`] = `[Error: Unable to read config file './myconfig.ts'. Check that the file exists and is readable to your terminal user]`;
-
-exports[`config/loading createConfigLoader should reject if the path is not readable 1`] = `[Error: Unable to read config file './myconfig.ts'. Check that the file exists and is readable to your terminal user]`;
-
-exports[`config/loading createConfigLoader should resolve if the file contents match the schema 1`] = `
+exports[`config/loading createConfigLoader when config file exports a config should resolve if the file contents match the schema 1`] = `
 {
   "good": "config",
 }
+`;
+
+exports[`config/loading createConfigLoader when config file exports a function when it is a synchronous function should reject if the function returns an invalid config 1`] = `
+[Error: Config from file './myconfig.ts' is malformed. Please fix the following errors:
+
+Property 'good': Required]
+`;
+
+exports[`config/loading createConfigLoader when config file exports a function when it is a synchronous function should reject if the function throws an error 1`] = `[Error: Got an exception while executing config funtion from file './myconfig.ts': Error: Oh not again]`;
+
+exports[`config/loading createConfigLoader when config file exports a function when it is an asynchronous function should reject if the function rejects 1`] = `[Error: Got an exception while executing config funtion from file './myconfig.ts': Error: Y u do dis]`;
+
+exports[`config/loading createConfigLoader when config file exports a function when it is an asynchronous function should reject if the function resolves with an invalid config 1`] = `
+[Error: Config from file './myconfig.ts' is malformed. Please fix the following errors:
+
+Property 'good': Required]
 `;


### PR DESCRIPTION
### In this PR

- To allow more flexibility when defining configs, we will accept the `layerzero.config.ts` / `layerzero.config.js` to export a function (synchronous or asynchronous) that, when executed, will return the config itself. This allows users to query any information before constructing the config (e.g. on-chain information)

This is very useful when it comes to custom configs - we can now query for information that we'd otherwise need to get and hardcode (e.g. contract addresses).

```typescript
// layerzero.config.ts
import hre from 'hardhat';

// We'll need a per-network HardhatRuntimeEnvironment to access its deployments
const getEnvironment = createGetHreByEid(hre)

export default async () => {
  // We'll create a fantom HardhatRuntimeEnvironment
  const fantomEnvironment = await getEnvironment('fantom-mainnet')
  // Instead of hardcoding the DVN address, we can just pull it from the deployments
  const layerZeroDVN = fantomEnvironment.deployments.get('DVN')
  
  // Now we return the actual config
  return {
    contracts: [/* ... */],
    connections: [{
      /* ... */
      config: {
        sendConfig: {
          ulnConfig: {
            requiredDVNs: [layerZeroDVN.address]
          }
        }
      }
    }]
  }
}
```