### PR TITLE
🗞️ OwnableMixin + OApp = 🆒 [1/N]

### DIFF
--- a/.changeset/new-lies-buy.md
+++ b/.changeset/new-lies-buy.md
@@ -1,0 +1,8 @@
+---
+"@layerzerolabs/ua-devtools-evm-hardhat-test": patch
+"@layerzerolabs/ua-devtools-evm": patch
+"@layerzerolabs/ua-devtools": patch
+"@layerzerolabs/devtools": patch
+---
+
+Add ownable functionality to OApp

--- a/packages/devtools/src/omnigraph/types.ts
+++ b/packages/devtools/src/omnigraph/types.ts
@@ -1,5 +1,5 @@
 import type { EndpointId } from '@layerzerolabs/lz-definitions'
-import type { OmniAddress, WithOptionals } from '@/types'
+import type { Factory, OmniAddress, WithOptionals } from '@/types'
 
 /**
  * OmniPoint identifies a point in omniverse, an omnichain universe.
@@ -69,3 +69,11 @@ export type WithEid<TValue> = TValue & { eid: EndpointId }
 export interface IOmniSDK {
     point: OmniPoint
 }
+
+/**
+ * Base factory for all SDK factories
+ */
+export type OmniSDKFactory<TOmniSDK extends IOmniSDK = IOmniSDK, TOmniPoint = OmniPoint> = Factory<
+    [TOmniPoint],
+    TOmniSDK
+>

--- a/packages/ua-devtools-evm/src/index.ts
+++ b/packages/ua-devtools-evm/src/index.ts
@@ -1,2 +1,3 @@
 export * from './lzapp'
 export * from './oapp'
+export * from './ownable'

--- a/packages/ua-devtools-evm/src/oapp/sdk.ts
+++ b/packages/ua-devtools-evm/src/oapp/sdk.ts
@@ -16,6 +16,7 @@ import type { EndpointV2Factory, IEndpointV2 } from '@layerzerolabs/protocol-dev
 import { OmniSDK } from '@layerzerolabs/devtools-evm'
 import { printJson } from '@layerzerolabs/io-devtools'
 import { mapError } from '@layerzerolabs/devtools'
+import { OwnableMixin } from '@/ownable/mixin'
 
 export class OApp extends OmniSDK implements IOApp {
     constructor(
@@ -23,6 +24,42 @@ export class OApp extends OmniSDK implements IOApp {
         protected readonly endpointV2Factory: EndpointV2Factory
     ) {
         super(contract)
+    }
+
+    getOwner(): Promise<string> {
+        // TODO This is a quick and dirty way of applying OwnableMixin
+        //
+        // The proper solution involves :
+        // - Option A: Using class decorators
+        // - Option B: Using dynamic classes
+        //
+        // TypeScript support for these is still lacking and the resulting code would slow
+        // down the development at this point
+        return OwnableMixin.getOwner.call(this)
+    }
+
+    hasOwner(address: string): Promise<boolean> {
+        // TODO This is a quick and dirty way of applying OwnableMixin
+        //
+        // The proper solution involves :
+        // - Option A: Using class decorators
+        // - Option B: Using dynamic classes
+        //
+        // TypeScript support for these is still lacking and the resulting code would slow
+        // down the development at this point
+        return OwnableMixin.hasOwner.call(this, address)
+    }
+
+    setOwner(address: string): Promise<OmniTransaction> {
+        // TODO This is a quick and dirty way of applying OwnableMixin
+        //
+        // The proper solution involves :
+        // - Option A: Using class decorators
+        // - Option B: Using dynamic classes
+        //
+        // TypeScript support for these is still lacking and the resulting code would slow
+        // down the development at this point
+        return OwnableMixin.setOwner.call(this, address)
     }
 
     async getEndpointSDK(): Promise<IEndpointV2> {

--- a/packages/ua-devtools-evm/src/ownable/factory.ts
+++ b/packages/ua-devtools-evm/src/ownable/factory.ts
@@ -1,0 +1,15 @@
+import pMemoize from 'p-memoize'
+import type { OwnableFactory } from '@layerzerolabs/ua-devtools'
+import { OwnableMixin } from './mixin'
+import { IOwnable } from '@layerzerolabs/ua-devtools'
+import { OmniSDK } from '@layerzerolabs/devtools-evm'
+import { OmniSDKFactory } from '@layerzerolabs/devtools'
+
+/**
+ * Syntactic sugar that adds IOwnable functionality to an instance of OmniSDK
+ *
+ * @param {OmniSDKFactory<OApp>} sdkFactory
+ * @returns {OwnableFactory<OApp & IOwnable>}
+ */
+export const createOwnableFactory = (sdkFactory: OmniSDKFactory<OmniSDK>): OwnableFactory<OmniSDK & IOwnable> =>
+    pMemoize(async (point) => Object.assign(await sdkFactory(point), OwnableMixin))

--- a/packages/ua-devtools-evm/src/ownable/index.ts
+++ b/packages/ua-devtools-evm/src/ownable/index.ts
@@ -1,0 +1,2 @@
+export * from './factory'
+export * from './mixin'

--- a/packages/ua-devtools-evm/src/ownable/mixin.ts
+++ b/packages/ua-devtools-evm/src/ownable/mixin.ts
@@ -1,0 +1,31 @@
+import { OmniAddress, OmniTransaction, areBytes32Equal, mapError } from '@layerzerolabs/devtools'
+import { OmniSDK } from '@layerzerolabs/devtools-evm'
+import type { IOwnable } from '@layerzerolabs/ua-devtools'
+
+export const OwnableMixin: IOwnable = {
+    async getOwner(this: OmniSDK): Promise<OmniAddress> {
+        this.logger.debug(`Getting owner`)
+
+        const owner = await mapError(
+            async () => this.contract.contract.owner(),
+            (error) => new Error(`Failed to get owner for OApp ${this.label}: ${error}`)
+        )
+
+        return this.logger.debug(`Got owner: ${owner}`), owner
+    },
+    async hasOwner(this: OmniSDK, address: OmniAddress): Promise<boolean> {
+        this.logger.debug(`Checking whether owner is ${address}`)
+
+        return areBytes32Equal(await OwnableMixin.getOwner.apply(this), address)
+    },
+    async setOwner(this: OmniSDK, address: OmniAddress): Promise<OmniTransaction> {
+        this.logger.debug(`Setting owner to address ${address}`)
+
+        const data = this.contract.contract.interface.encodeFunctionData('transferOwnership', [address])
+
+        return {
+            ...this.createTransaction(data),
+            description: `Setting owner to address ${address}`,
+        }
+    },
+}

--- a/packages/ua-devtools-evm/test/ownable/mixin.test.ts
+++ b/packages/ua-devtools-evm/test/ownable/mixin.test.ts
@@ -1,0 +1,96 @@
+import fc from 'fast-check'
+import { endpointArbitrary, evmAddressArbitrary } from '@layerzerolabs/test-devtools'
+import { Contract } from '@ethersproject/contracts'
+import { OApp } from '@/oapp/sdk'
+import { OmniContract } from '@layerzerolabs/devtools-evm'
+import { OwnableMixin } from '@/ownable/mixin'
+import { areBytes32Equal } from '@layerzerolabs/devtools'
+
+describe('ownable/mixin', () => {
+    const jestFunctionArbitrary = fc.anything().map(() => jest.fn())
+
+    const oappOmniContractArbitrary = fc.record({
+        address: evmAddressArbitrary,
+        owner: jestFunctionArbitrary,
+        interface: fc.record({
+            encodeFunctionData: jestFunctionArbitrary,
+        }),
+    }) as fc.Arbitrary<unknown> as fc.Arbitrary<Contract>
+
+    const omniContractArbitrary: fc.Arbitrary<OmniContract> = fc.record({
+        eid: endpointArbitrary,
+        contract: oappOmniContractArbitrary,
+    })
+
+    const EndpointV2Factory = jest.fn().mockRejectedValue('No endpoint')
+
+    describe('getOwner', () => {
+        it('should call owner on the contract', async () => {
+            await fc.assert(
+                fc.asyncProperty(omniContractArbitrary, evmAddressArbitrary, async (omniContract, owner) => {
+                    omniContract.contract.owner.mockResolvedValue(owner)
+
+                    const sdk = new OApp(omniContract, EndpointV2Factory)
+                    const ownable = Object.assign(sdk, OwnableMixin)
+
+                    expect(await ownable.getOwner()).toBe(owner)
+                    expect(omniContract.contract.owner).toHaveBeenCalledTimes(1)
+                })
+            )
+        })
+    })
+
+    describe('hasOwner', () => {
+        it('should return true if the owner addresses match', async () => {
+            await fc.assert(
+                fc.asyncProperty(omniContractArbitrary, evmAddressArbitrary, async (omniContract, owner) => {
+                    omniContract.contract.owner.mockResolvedValue(owner)
+
+                    const sdk = new OApp(omniContract, EndpointV2Factory)
+                    const ownable = Object.assign(sdk, OwnableMixin)
+
+                    expect(await ownable.hasOwner(owner)).toBeTruthy()
+                })
+            )
+        })
+
+        it('should return false if the owner addresses do not match', async () => {
+            await fc.assert(
+                fc.asyncProperty(
+                    omniContractArbitrary,
+                    evmAddressArbitrary,
+                    evmAddressArbitrary,
+                    async (omniContract, owner, user) => {
+                        fc.pre(!areBytes32Equal(owner, user))
+
+                        omniContract.contract.owner.mockResolvedValue(owner)
+
+                        const sdk = new OApp(omniContract, EndpointV2Factory)
+                        const ownable = Object.assign(sdk, OwnableMixin)
+
+                        expect(await ownable.hasOwner(user)).toBeFalsy()
+                    }
+                )
+            )
+        })
+    })
+
+    describe('setOwner', () => {
+        it('should encode data for a transferOwnership call', async () => {
+            await fc.assert(
+                fc.asyncProperty(omniContractArbitrary, evmAddressArbitrary, async (omniContract, owner) => {
+                    const sdk = new OApp(omniContract, EndpointV2Factory)
+                    const ownable = Object.assign(sdk, OwnableMixin)
+                    const encodeFunctionData = omniContract.contract.interface.encodeFunctionData as jest.Mock
+
+                    encodeFunctionData.mockClear()
+
+                    await ownable.setOwner(owner)
+
+                    expect(encodeFunctionData).toHaveBeenCalledTimes(1)
+                    expect(encodeFunctionData).toHaveBeenCalledWith('transferOwnership', [owner])
+                })
+            )
+        })
+    })
+})

--- a/packages/ua-devtools/src/index.ts
+++ b/packages/ua-devtools/src/index.ts
@@ -1,2 +1,3 @@
 export * from './lzapp'
 export * from './oapp'
+export * from './ownable'

--- a/packages/ua-devtools/src/oapp/types.ts
+++ b/packages/ua-devtools/src/oapp/types.ts
@@ -12,8 +12,9 @@ import type {
     PossiblyBigInt,
 } from '@layerzerolabs/devtools'
 import { ExecutorOptionType } from '@layerzerolabs/lz-v2-utilities'
+import type { IOwnable } from '@/ownable/types'
 
-export interface IOApp extends IOmniSDK {
+export interface IOApp extends IOmniSDK, IOwnable {
     getEndpointSDK(): Promise<IEndpointV2>
     getPeer(eid: EndpointId): Promise<OmniAddress | undefined>
     hasPeer(eid: EndpointId, address: OmniAddress | null | undefined): Promise<boolean>

--- a/packages/ua-devtools/src/ownable/config.ts
+++ b/packages/ua-devtools/src/ownable/config.ts
@@ -1,0 +1,34 @@
+import { createModuleLogger } from '@layerzerolabs/io-devtools'
+import type { OwnableFactory, OwnableOmniGraph } from './types'
+import { flattenTransactions, formatOmniPoint, type OmniTransaction } from '@layerzerolabs/devtools'
+
+export type OwnableConfigurator = (graph: OwnableOmniGraph, createSdk: OwnableFactory) => Promise<OmniTransaction[]>
+
+export const configureOwnable: OwnableConfigurator = async (graph, createSdk) => {
+    const logger = createModuleLogger('Ownable')
+
+    return flattenTransactions(
+        await Promise.all(
+            graph.contracts.map(async ({ point, config }) => {
+                const formattedPoint = formatOmniPoint(point)
+
+                if (config?.owner == null) {
+                    return logger.verbose(`No owner specified for ${formattedPoint}`), undefined
+                }
+
+                logger.verbose(`Checking whether the owner of ${formattedPoint} is ${config.owner}`)
+
+                const sdk = await createSdk(point)
+                const hasOwner = await sdk.hasOwner(config.owner)
+                if (hasOwner) {
+                    return logger.verbose(`The owner of ${formattedPoint} already is ${config.owner}`), undefined
+                }
+
+                return (
+                    logger.verbose(`Setting the owner of ${formattedPoint} to ${config.owner}`),
+                    sdk.setOwner(config.owner)
+                )
+            })
+        )
+    )
+}

--- a/packages/ua-devtools/src/ownable/index.ts
+++ b/packages/ua-devtools/src/ownable/index.ts
@@ -1,0 +1,3 @@
+export * from './config'
+export * from './schema'
+export * from './types'

--- a/packages/ua-devtools/src/ownable/schema.ts
+++ b/packages/ua-devtools/src/ownable/schema.ts
@@ -1,0 +1,6 @@
+import { AddressSchema } from '@layerzerolabs/devtools'
+import { z } from 'zod'
+
+export const OwnableNodeConfigSchema = z.object({
+    owner: AddressSchema.optional(),
+})

--- a/packages/ua-devtools/src/ownable/types.ts
+++ b/packages/ua-devtools/src/ownable/types.ts
@@ -1,0 +1,18 @@
+import type { Factory, OmniAddress, OmniGraph, OmniPoint, OmniTransaction } from '@layerzerolabs/devtools'
+
+export interface IOwnable {
+    getOwner(): Promise<OmniAddress>
+    hasOwner(address: OmniAddress): Promise<boolean>
+    setOwner(address: OmniAddress): Promise<OmniTransaction>
+}
+
+export interface OwnableNodeConfig {
+    owner?: OmniAddress
+}
+
+export type OwnableOmniGraph = OmniGraph<OwnableNodeConfig | undefined>
+
+export type OwnableFactory<TOwnable extends IOwnable = IOwnable, TOmniPoint = OmniPoint> = Factory<
+    [TOmniPoint],
+    TOwnable
+>

--- a/tests/ua-devtools-evm-hardhat-test/test/ownable/config.test.ts
+++ b/tests/ua-devtools-evm-hardhat-test/test/ownable/config.test.ts
@@ -1,6 +1,5 @@
 import 'hardhat'
 import { EndpointId } from '@layerzerolabs/lz-definitions'
-import { deployOApp } from '../__utils__/oapp'
 import {
     createConnectedContractFactory,
     createSignerFactory,
@@ -9,8 +8,8 @@ import {
 import { createOAppFactory, createOwnableFactory } from '@layerzerolabs/ua-devtools-evm'
 import { configureOwnable, IOwnable, OwnableFactory, OwnableOmniGraph } from '@layerzerolabs/ua-devtools'
 import { OmniContract, omniContractToPoint } from '@layerzerolabs/devtools-evm'
-import { deployAndSetupDefaultEndpointV2 } from '../__utils__/endpointV2'
 import { createSignAndSend, OmniPoint } from '@layerzerolabs/devtools'
+import { deployContract, setupDefaultEndpointV2 } from '@layerzerolabs/test-setup-devtools-evm-hardhat'
 
 describe('ownable/config', () => {
     const ethPointHardhat = { eid: EndpointId.ETHEREUM_V2_MAINNET, contractName: 'DefaultOApp' }
@@ -28,12 +27,13 @@ describe('ownable/config', () => {
     let avaxOwnableSdk: IOwnable
 
     beforeAll(async () => {
-        await deployAndSetupDefaultEndpointV2()
+        await deployContract('EndpointV2')
+        await setupDefaultEndpointV2()
     })
 
     // This is the OApp config that we want to use against our contracts
     beforeEach(async () => {
-        await deployOApp()
+        await deployContract('OApp')
 
         contractFactory = createConnectedContractFactory()
         ownableFactory = createOwnableFactory(createOAppFactory(contractFactory))

--- a/tests/ua-devtools-evm-hardhat-test/test/ownable/config.test.ts
+++ b/tests/ua-devtools-evm-hardhat-test/test/ownable/config.test.ts
@@ -1,0 +1,175 @@
+import 'hardhat'
+import { EndpointId } from '@layerzerolabs/lz-definitions'
+import { deployOApp } from '../__utils__/oapp'
+import {
+    createConnectedContractFactory,
+    createSignerFactory,
+    OmniContractFactoryHardhat,
+} from '@layerzerolabs/devtools-evm-hardhat'
+import { createOAppFactory, createOwnableFactory } from '@layerzerolabs/ua-devtools-evm'
+import { configureOwnable, IOwnable, OwnableFactory, OwnableOmniGraph } from '@layerzerolabs/ua-devtools'
+import { OmniContract, omniContractToPoint } from '@layerzerolabs/devtools-evm'
+import { deployAndSetupDefaultEndpointV2 } from '../__utils__/endpointV2'
+import { createSignAndSend, OmniPoint } from '@layerzerolabs/devtools'
+
+describe('ownable/config', () => {
+    const ethPointHardhat = { eid: EndpointId.ETHEREUM_V2_MAINNET, contractName: 'DefaultOApp' }
+    const avaxPointHardhat = { eid: EndpointId.AVALANCHE_V2_MAINNET, contractName: 'DefaultOApp' }
+
+    let contractFactory: OmniContractFactoryHardhat
+    let ownableFactory: OwnableFactory
+
+    let ethContract: OmniContract
+    let ethPoint: OmniPoint
+    let ethOwnableSdk: IOwnable
+
+    let avaxContract: OmniContract
+    let avaxPoint: OmniPoint
+    let avaxOwnableSdk: IOwnable
+
+    beforeAll(async () => {
+        await deployAndSetupDefaultEndpointV2()
+    })
+
+    // This is the OApp config that we want to use against our contracts
+    beforeEach(async () => {
+        await deployOApp()
+
+        contractFactory = createConnectedContractFactory()
+        ownableFactory = createOwnableFactory(createOAppFactory(contractFactory))
+
+        ethContract = await contractFactory(ethPointHardhat)
+        avaxContract = await contractFactory(avaxPointHardhat)
+
+        ethPoint = omniContractToPoint(ethContract)
+        ethOwnableSdk = await ownableFactory(ethPoint)
+
+        avaxPoint = omniContractToPoint(avaxContract)
+        avaxOwnableSdk = await ownableFactory(avaxPoint)
+    })
+
+    describe('configureOwnable', () => {
+        it('should not return any transactions if configs are undefined', async () => {
+            const graph: OwnableOmniGraph = {
+                contracts: [
+                    {
+                        point: avaxPoint,
+                        config: undefined,
+                    },
+                    {
+                        point: ethPoint,
+                        config: undefined,
+                    },
+                ],
+                connections: [],
+            }
+
+            expect(await configureOwnable(graph, ownableFactory)).toEqual([])
+        })
+
+        it('should not return any transactions if owners are undefined', async () => {
+            const graph: OwnableOmniGraph = {
+                contracts: [
+                    {
+                        point: avaxPoint,
+                        config: {
+                            owner: undefined,
+                        },
+                    },
+                    {
+                        point: ethPoint,
+                        config: {
+                            owner: undefined,
+                        },
+                    },
+                ],
+                connections: [],
+            }
+
+            expect(await configureOwnable(graph, ownableFactory)).toEqual([])
+        })
+
+        it('should return all transferOwnerhip transactions if owners are specified', async () => {
+            const graph: OwnableOmniGraph = {
+                contracts: [
+                    {
+                        point: avaxPoint,
+                        config: {
+                            // We'll make them an interlocked couple, living in perpetual state of codependence
+                            owner: ethPoint.address,
+                        },
+                    },
+                    {
+                        point: ethPoint,
+                        config: {
+                            // We'll make them an interlocked couple, living in perpetual state of codependence
+                            owner: avaxPoint.address,
+                        },
+                    },
+                ],
+                connections: [],
+            }
+
+            expect(await configureOwnable(graph, ownableFactory)).toEqual([
+                await avaxOwnableSdk.setOwner(ethPoint.address),
+                await ethOwnableSdk.setOwner(avaxPoint.address),
+            ])
+        })
+
+        it('should not set owners that have already been set', async () => {
+            const graph: OwnableOmniGraph = {
+                contracts: [
+                    {
+                        point: avaxPoint,
+                        config: {
+                            // We'll make them an interlocked couple, living in perpetual state of codependence
+                            owner: ethPoint.address,
+                        },
+                    },
+                    {
+                        point: ethPoint,
+                        config: {
+                            // We'll make them an interlocked couple, living in perpetual state of codependence
+                            owner: avaxPoint.address,
+                        },
+                    },
+                ],
+                connections: [],
+            }
+
+            const signAndSend = createSignAndSend(createSignerFactory())
+            await signAndSend([await avaxOwnableSdk.setOwner(ethPoint.address)])
+
+            expect(await configureOwnable(graph, ownableFactory)).toEqual([
+                await ethOwnableSdk.setOwner(avaxPoint.address),
+            ])
+        })
+
+        it('should not produce any transactions if ran again', async () => {
+            const graph: OwnableOmniGraph = {
+                contracts: [
+                    {
+                        point: avaxPoint,
+                        config: {
+                            // We'll make them an interlocked couple, living in perpetual state of codependence
+                            owner: ethPoint.address,
+                        },
+                    },
+                    {
+                        point: ethPoint,
+                        config: {
+                            // We'll make them an interlocked couple, living in perpetual state of codependence
+                            owner: avaxPoint.address,
+                        },
+                    },
+                ],
+                connections: [],
+            }
+
+            const signAndSend = createSignAndSend(createSignerFactory())
+            await signAndSend(await configureOwnable(graph, ownableFactory))
+
+            expect(await configureOwnable(graph, ownableFactory)).toEqual([])
+        })
+    })
+})


### PR DESCRIPTION
### In this PR

- Adding `OwnableMixin`, a collection of methods that can be mixed in to a class instance / class prototype to add `Ownable` SDk functionality
- Adding `createOwnableFactory` to wrap an arbitrary `OmniSDK` with `OwnableMixin`
- Adding `configureOwnable` function to configure ownership

At this point, the amount of very convoluted code that makes TypeScript happy about mixins does not justify the extra three literal methods on `OApp` that proxy the calls to `OwnableMixin`. Less repetitive solutions can be achieved with class decorators but the support is still experimental and could break TypeScript for lots of client projects - see here https://www.typescriptlang.org/docs/handbook/mixins.html.

On the other hand, having `OwnableMixin` out of the `OApp` prototype chain allows us to mixt it in with any SDK, not just `OApp` ones.