### PR TITLE
🗞️ OwnableMixin + OApp = 🆒 [2/N]

### DIFF
--- a/.changeset/tiny-seahorses-suffer.md
+++ b/.changeset/tiny-seahorses-suffer.md
@@ -1,0 +1,7 @@
+---
+"@layerzerolabs/ua-devtools-evm-hardhat": patch
+"@layerzerolabs/protocol-devtools": patch
+"@layerzerolabs/ua-devtools": patch
+---
+
+Clean up OApp & Ownable types; Add OAppNodeSchema

--- a/packages/protocol-devtools/src/dvn/types.ts
+++ b/packages/protocol-devtools/src/dvn/types.ts
@@ -1,4 +1,4 @@
-import type { Factory, IOmniSDK, OmniGraph, OmniPoint, OmniTransaction } from '@layerzerolabs/devtools'
+import type { IOmniSDK, OmniGraph, OmniPoint, OmniSDKFactory, OmniTransaction } from '@layerzerolabs/devtools'
 import type { EndpointId } from '@layerzerolabs/lz-definitions'
 
 export interface IDVN extends IOmniSDK {
@@ -18,4 +18,4 @@ export interface DVNEdgeConfig {
 
 export type DVNOmniGraph = OmniGraph<unknown, DVNEdgeConfig>
 
-export type DVNFactory<TDVN extends IDVN = IDVN, TOmniPoint = OmniPoint> = Factory<[TOmniPoint], TDVN>
+export type DVNFactory<TDVN extends IDVN = IDVN, TOmniPoint = OmniPoint> = OmniSDKFactory<TDVN, TOmniPoint>

--- a/packages/protocol-devtools/src/endpointv2/types.ts
+++ b/packages/protocol-devtools/src/endpointv2/types.ts
@@ -1,12 +1,12 @@
 import type {
     OmniAddress,
-    Factory,
     OmniGraph,
     OmniPoint,
     OmniTransaction,
     IOmniSDK,
     Bytes32,
     PossiblyBytes,
+    OmniSDKFactory,
 } from '@layerzerolabs/devtools'
 import type { EndpointId } from '@layerzerolabs/lz-definitions'
 import type { IUln302, Uln302ExecutorConfig, Uln302UlnConfig, Uln302UlnUserConfig } from '@/uln302/types'
@@ -214,7 +214,7 @@ export interface EndpointV2EdgeConfig {
 
 export type EndpointV2OmniGraph = OmniGraph<unknown, EndpointV2EdgeConfig>
 
-export type EndpointV2Factory<TEndpointV2 extends IEndpointV2 = IEndpointV2, TOmniPoint = OmniPoint> = Factory<
-    [TOmniPoint],
-    TEndpointV2
+export type EndpointV2Factory<TEndpointV2 extends IEndpointV2 = IEndpointV2, TOmniPoint = OmniPoint> = OmniSDKFactory<
+    TEndpointV2,
+    TOmniPoint
 >

--- a/packages/protocol-devtools/src/executor/types.ts
+++ b/packages/protocol-devtools/src/executor/types.ts
@@ -1,4 +1,4 @@
-import type { Factory, IOmniSDK, OmniGraph, OmniPoint, OmniTransaction } from '@layerzerolabs/devtools'
+import type { IOmniSDK, OmniGraph, OmniPoint, OmniSDKFactory, OmniTransaction } from '@layerzerolabs/devtools'
 import type { EndpointId } from '@layerzerolabs/lz-definitions'
 
 export interface IExecutor extends IOmniSDK {
@@ -19,7 +19,7 @@ export interface ExecutorEdgeConfig {
 
 export type ExecutorOmniGraph = OmniGraph<unknown, ExecutorEdgeConfig>
 
-export type ExecutorFactory<TExecutor extends IExecutor = IExecutor, TOmniPoint = OmniPoint> = Factory<
-    [TOmniPoint],
-    TExecutor
+export type ExecutorFactory<TExecutor extends IExecutor = IExecutor, TOmniPoint = OmniPoint> = OmniSDKFactory<
+    TExecutor,
+    TOmniPoint
 >

--- a/packages/protocol-devtools/src/priceFeed/types.ts
+++ b/packages/protocol-devtools/src/priceFeed/types.ts
@@ -1,4 +1,4 @@
-import type { Factory, IOmniSDK, OmniGraph, OmniPoint, OmniTransaction } from '@layerzerolabs/devtools'
+import type { IOmniSDK, OmniGraph, OmniPoint, OmniSDKFactory, OmniTransaction } from '@layerzerolabs/devtools'
 import type { EndpointId } from '@layerzerolabs/lz-definitions'
 
 export interface IPriceFeed extends IOmniSDK {
@@ -18,7 +18,7 @@ export interface PriceFeedEdgeConfig {
 
 export type PriceFeedOmniGraph = OmniGraph<unknown, PriceFeedEdgeConfig>
 
-export type PriceFeedFactory<TPriceFeed extends IPriceFeed = IPriceFeed, TOmniPoint = OmniPoint> = Factory<
-    [TOmniPoint],
-    TPriceFeed
+export type PriceFeedFactory<TPriceFeed extends IPriceFeed = IPriceFeed, TOmniPoint = OmniPoint> = OmniSDKFactory<
+    TPriceFeed,
+    TOmniPoint
 >

--- a/packages/protocol-devtools/src/uln302/types.ts
+++ b/packages/protocol-devtools/src/uln302/types.ts
@@ -1,4 +1,11 @@
-import type { OmniAddress, OmniGraph, Factory, OmniTransaction, IOmniSDK, OmniPoint } from '@layerzerolabs/devtools'
+import type {
+    OmniAddress,
+    OmniGraph,
+    OmniTransaction,
+    IOmniSDK,
+    OmniPoint,
+    OmniSDKFactory,
+} from '@layerzerolabs/devtools'
 import type { EndpointId } from '@layerzerolabs/lz-definitions'
 
 export interface IUln302 extends IOmniSDK {
@@ -115,4 +122,7 @@ export interface Uln302NodeConfig {
 
 export type Uln302OmniGraph = OmniGraph<Uln302NodeConfig, unknown>
 
-export type Uln302Factory<TUln302 extends IUln302 = IUln302, TOmniPoint = OmniPoint> = Factory<[TOmniPoint], TUln302>
+export type Uln302Factory<TUln302 extends IUln302 = IUln302, TOmniPoint = OmniPoint> = OmniSDKFactory<
+    TUln302,
+    TOmniPoint
+>

--- a/packages/ua-devtools-evm-hardhat/src/oapp/schema.ts
+++ b/packages/ua-devtools-evm-hardhat/src/oapp/schema.ts
@@ -5,7 +5,7 @@ import {
 } from '@layerzerolabs/devtools-evm-hardhat'
 import { z } from 'zod'
 import type { OAppOmniGraphHardhat } from './types'
-import { OAppEdgeConfigSchema } from '@layerzerolabs/ua-devtools'
+import { OAppEdgeConfigSchema, OAppNodeConfigSchema } from '@layerzerolabs/ua-devtools'
 
 /**
  * Validation schema for OApp configs in hardhat environment.
@@ -14,6 +14,6 @@ import { OAppEdgeConfigSchema } from '@layerzerolabs/ua-devtools'
  * the user input.
  */
 export const OAppOmniGraphHardhatSchema = createOmniGraphHardhatSchema(
-    createOmniNodeHardhatSchema(z.unknown()),
+    createOmniNodeHardhatSchema(OAppNodeConfigSchema.optional()),
     createOmniEdgeHardhatSchema(OAppEdgeConfigSchema.optional())
 ) satisfies z.ZodSchema<OAppOmniGraphHardhat>

--- a/packages/ua-devtools-evm-hardhat/src/oapp/types.ts
+++ b/packages/ua-devtools-evm-hardhat/src/oapp/types.ts
@@ -1,4 +1,4 @@
-import { OmniGraphHardhat } from '@layerzerolabs/devtools-evm-hardhat'
-import { OAppEdgeConfig } from '@layerzerolabs/ua-devtools'
+import type { OmniGraphHardhat } from '@layerzerolabs/devtools-evm-hardhat'
+import type { OAppEdgeConfig, OAppNodeConfig } from '@layerzerolabs/ua-devtools'
 
-export type OAppOmniGraphHardhat = OmniGraphHardhat<unknown, OAppEdgeConfig | undefined>
+export type OAppOmniGraphHardhat = OmniGraphHardhat<OAppNodeConfig | undefined, OAppEdgeConfig | undefined>

--- a/packages/ua-devtools/src/lzapp/types.ts
+++ b/packages/ua-devtools/src/lzapp/types.ts
@@ -1,4 +1,11 @@
-import type { Factory, IOmniSDK, OmniAddress, OmniGraph, OmniPoint, OmniTransaction } from '@layerzerolabs/devtools'
+import type {
+    IOmniSDK,
+    OmniAddress,
+    OmniGraph,
+    OmniPoint,
+    OmniSDKFactory,
+    OmniTransaction,
+} from '@layerzerolabs/devtools'
 import type { EndpointId } from '@layerzerolabs/lz-definitions'
 
 export interface ILzApp extends IOmniSDK {
@@ -9,4 +16,4 @@ export interface ILzApp extends IOmniSDK {
 
 export type LzAppOmniGraph = OmniGraph<unknown, unknown>
 
-export type LzAppFactory<TLzApp extends ILzApp = ILzApp, TOmniPoint = OmniPoint> = Factory<[TOmniPoint], TLzApp>
+export type LzAppFactory<TLzApp extends ILzApp = ILzApp, TOmniPoint = OmniPoint> = OmniSDKFactory<TLzApp, TOmniPoint>

--- a/packages/ua-devtools/src/oapp/schema.ts
+++ b/packages/ua-devtools/src/oapp/schema.ts
@@ -8,11 +8,13 @@ import {
     ExecutorOrderedExecutionOption,
     OAppEdgeConfig,
     OAppEnforcedOption,
+    OAppNodeConfig,
     OAppReceiveConfig,
     OAppReceiveLibraryConfig,
     OAppSendConfig,
 } from './types'
 import { ExecutorOptionType } from '@layerzerolabs/lz-v2-utilities'
+import { OwnableNodeConfigSchema } from '@/ownable/schema'
 
 export const OAppReceiveLibraryConfigSchema = z.object({
     gracePeriod: UIntBigIntSchema,
@@ -68,6 +70,8 @@ export const OAppEnforcedOptionsSchema = z.array(OAppEnforcedOptionConfigSchema)
     unknown
 >
 
+export const OAppNodeConfigSchema = OwnableNodeConfigSchema satisfies z.ZodSchema<OAppNodeConfig, z.ZodTypeDef, unknown>
+
 export const OAppEdgeConfigSchema = z
     .object({
         sendLibrary: AddressSchema,
@@ -77,4 +81,5 @@ export const OAppEdgeConfigSchema = z
         receiveConfig: OAppReceiveConfigSchema,
         enforcedOptions: OAppEnforcedOptionsSchema,
     })
+    .passthrough()
     .partial() satisfies z.ZodSchema<OAppEdgeConfig, z.ZodTypeDef, unknown>

--- a/packages/ua-devtools/src/oapp/types.ts
+++ b/packages/ua-devtools/src/oapp/types.ts
@@ -2,17 +2,17 @@ import type { EndpointId } from '@layerzerolabs/lz-definitions'
 import type { IEndpointV2, Timeout, Uln302ExecutorConfig, Uln302UlnUserConfig } from '@layerzerolabs/protocol-devtools'
 import type {
     Bytes,
-    Factory,
     IOmniSDK,
     OmniAddress,
     OmniGraph,
     OmniPoint,
+    OmniSDKFactory,
     OmniTransaction,
     OmniVector,
     PossiblyBigInt,
 } from '@layerzerolabs/devtools'
 import { ExecutorOptionType } from '@layerzerolabs/lz-v2-utilities'
-import type { IOwnable } from '@/ownable/types'
+import type { IOwnable, OwnableNodeConfig } from '@/ownable/types'
 
 export interface IOApp extends IOmniSDK, IOwnable {
     getEndpointSDK(): Promise<IEndpointV2>
@@ -36,6 +36,8 @@ export interface OAppSendConfig {
 export interface OAppReceiveConfig {
     ulnConfig?: Uln302UlnUserConfig
 }
+
+export type OAppNodeConfig = OwnableNodeConfig
 
 export interface OAppEdgeConfig {
     sendLibrary?: string
@@ -102,6 +104,6 @@ export interface OAppEnforcedOptions {
     enforcedOptions: EncodedOption[]
 }
 
-export type OAppOmniGraph = OmniGraph<unknown, OAppEdgeConfig | undefined>
+export type OAppOmniGraph = OmniGraph<OAppNodeConfig | undefined, OAppEdgeConfig | undefined>
 
-export type OAppFactory<TOApp extends IOApp = IOApp, TOmniPoint = OmniPoint> = Factory<[TOmniPoint], TOApp>
+export type OAppFactory<TOApp extends IOApp = IOApp, TOmniPoint = OmniPoint> = OmniSDKFactory<TOApp, TOmniPoint>


### PR DESCRIPTION
### In this PR

- Type cleanup - reuse `OmniSDKFactory` for all the SDK factories out there
- Add `OAppNodeConfig` - since `OApp` is now ownable, its graph can contain ownership config. We will most probably not configure ownership as part of the wire task (TBD @TRileySchwarz) and keep it as a separate step to match the typical development workflow