### PR TITLE
🧹 Add prune script to wipe everything

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "lint:fix": "$npm_execpath turbo run lint:fix",
     "logs": "docker compose logs -f",
     "prepare": "husky install",
+    "prune": "git clean -dfX",
     "registry:logs": "docker compose -f docker-compose.registry.yaml logs -f",
     "registry:publish": "docker compose -f docker-compose.registry.yaml run --build --rm $DOCKER_COMPOSE_ARGS publish",
     "registry:start": "docker compose -f docker-compose.registry.yaml up npm-registry --wait $DOCKER_COMPOSE_ARGS",


### PR DESCRIPTION
### In this PR

- To easily wipe all ignored files (builds, artifacts, caches, `node_modules`, everything) we add a `prune` command. This is an addition to the exiting `clean` commands that don't touch `node_modules` (and need to be kept in sync with the package settings so that they truly clean everything)