### PR TITLE
🧹 Re-export useful types from toolbox-hardhat; Fix small type & export issues

### DIFF
--- a/.changeset/large-trains-change.md
+++ b/.changeset/large-trains-change.md
@@ -1,0 +1,9 @@
+---
+"@layerzerolabs/ua-devtools-evm-hardhat": patch
+"@layerzerolabs/toolbox-hardhat": patch
+"@layerzerolabs/devtools": patch
+"@layerzerolabs/oapp-example": patch
+"@layerzerolabs/oft-example": patch
+---
+
+Re-export useful types from toolbox-hardhat

--- a/examples/oapp/layerzero.config.ts
+++ b/examples/oapp/layerzero.config.ts
@@ -1,21 +1,23 @@
 import { EndpointId } from '@layerzerolabs/lz-definitions'
 
-const sepoliaContract = {
+import type { OAppOmniGraphHardhat, OmniPointHardhat } from '@layerzerolabs/toolbox-hardhat'
+
+const sepoliaContract: OmniPointHardhat = {
     eid: EndpointId.SEPOLIA_V2_TESTNET,
     contractName: 'MyOApp',
 }
 
-const fujiContract = {
+const fujiContract: OmniPointHardhat = {
     eid: EndpointId.AVALANCHE_V2_TESTNET,
     contractName: 'MyOApp',
 }
 
-const mumbaiContract = {
+const mumbaiContract: OmniPointHardhat = {
     eid: EndpointId.POLYGON_V2_TESTNET,
     contractName: 'MyOApp',
 }
 
-export default {
+const config: OAppOmniGraphHardhat = {
     contracts: [
         {
             contract: fujiContract,
@@ -82,3 +84,5 @@ export default {
         },
     ],
 }
+
+export default config

--- a/examples/oft/layerzero.config.ts
+++ b/examples/oft/layerzero.config.ts
@@ -1,22 +1,23 @@
-// eslint-disable-next-line @typescript-eslint/no-var-requires
 import { EndpointId } from '@layerzerolabs/lz-definitions'
 
-const sepoliaContract = {
+import type { OAppOmniGraphHardhat, OmniPointHardhat } from '@layerzerolabs/toolbox-hardhat'
+
+const sepoliaContract: OmniPointHardhat = {
     eid: EndpointId.SEPOLIA_V2_TESTNET,
     contractName: 'MyOFT',
 }
 
-const fujiContract = {
+const fujiContract: OmniPointHardhat = {
     eid: EndpointId.AVALANCHE_V2_TESTNET,
     contractName: 'MyOFT',
 }
 
-const mumbaiContract = {
+const mumbaiContract: OmniPointHardhat = {
     eid: EndpointId.POLYGON_V2_TESTNET,
     contractName: 'MyOFT',
 }
 
-export default {
+const config: OAppOmniGraphHardhat = {
     contracts: [
         {
             contract: fujiContract,
@@ -32,7 +33,6 @@ export default {
         {
             from: fujiContract,
             to: sepoliaContract,
-            config: {},
         },
         {
             from: fujiContract,
@@ -56,3 +56,5 @@ export default {
         },
     ],
 }
+
+export default config

--- a/packages/devtools/src/types.ts
+++ b/packages/devtools/src/types.ts
@@ -48,7 +48,7 @@ export type EndpointBasedFactory<TValue> = Factory<[eid: EndpointId], TValue>
  * ```
  */
 type GetMandatoryKeys<T> = {
-    [P in keyof T]: T[P] extends Exclude<T[P], NonNullable<unknown> | null> ? never : P
+    [P in keyof T]: T[P] extends Exclude<T[P], NonNullable<unknown> | null> ? never : undefined extends T[P] ? never : P
 }[keyof T]
 
 /**

--- a/packages/devtools/test/omnigraph/types.test.ts
+++ b/packages/devtools/test/omnigraph/types.test.ts
@@ -12,6 +12,10 @@ describe('schema/types', () => {
             const node: OmniNode<unknown> = { point }
         })
 
+        it('should allow undefined config for a union', () => {
+            const node: OmniNode<number | undefined> = { point }
+        })
+
         it('should allow undefined config for undefined TConfig', () => {
             const node: OmniNode<undefined> = { point }
         })
@@ -74,6 +78,10 @@ describe('schema/types', () => {
 
         it('should allow undefined config for undefined TConfig', () => {
             const edge: OmniEdge<undefined> = { vector }
+        })
+
+        it('should allow undefined config for a union', () => {
+            const edge: OmniEdge<number | undefined> = { vector }
         })
 
         it('should not allow undefined config for null TConfig', () => {

--- a/packages/toolbox-hardhat/types/index.d.ts
+++ b/packages/toolbox-hardhat/types/index.d.ts
@@ -3,3 +3,10 @@
 //
 // To fix this, we will create a d.ts file instead of having one created during the build
 import '@layerzerolabs/devtools-evm-hardhat/type-extensions'
+
+// We re-export all the relevant types from devtools
+export type { OmniPointHardhat, OmniEdgeHardhat, OmniDeployment } from '@layerzerolabs/devtools-evm-hardhat'
+export type { OmniPoint, OmniVector, OmniNode, OmniEdge, OmniGraph } from '@layerzerolabs/devtools'
+
+// We also re-export all the relevant types from ua-devtools
+export type { OAppOmniGraphHardhat } from '@layerzerolabs/ua-devtools-evm-hardhat'

--- a/packages/ua-devtools-evm-hardhat/src/index.ts
+++ b/packages/ua-devtools-evm-hardhat/src/index.ts
@@ -1,2 +1,3 @@
 export * from './constants'
 export * from './oapp'
+export * from './ownable'


### PR DESCRIPTION
### In this PR

- Re-export types useful for creating strongly-types configs from `toolbox-hardhat`
- Fix a tiny beauty issue with `WithOptionals` type - if passed a union type, e.g. `string | undefined`, it would consider it as non-optional. This meant that once types were added to the example configs, everything was red since the (actually optional) `config` property was considered non-optional
- Fix a missing export in `ua-devtools-evm-hardhat`