### PR TITLE
🪲 Fix multiplatform docker build

### DIFF
--- a/.github/workflows/reusable-publish-docker.yaml
+++ b/.github/workflows/reusable-publish-docker.yaml
@@ -22,12 +22,6 @@ jobs:
     name: Build base docker image
     runs-on: ubuntu-latest
 
-    strategy:
-      matrix:
-        platform:
-          - linux/amd64
-          - linux/arm64
-
     permissions:
       contents: read
       packages: write
@@ -62,7 +56,7 @@ jobs:
         with:
           provenance: false
           context: .
-          platforms: ${{ matrix.platform }}
+          platforms: linux/amd64,linux/arm64
           push: true
           target: base
           tags: ${{ steps.meta.outputs.tags }}


### PR DESCRIPTION
### In this PR

- Removing the matrix strategy from docker build. Turns out that the `docker/build-push-action` does not play nice with parallel builds and the last job to complete will always override any previous build artifacts. In order to keep the job parallel, we'd need to make it much more complex as [per the documentation](https://docs.docker.com/build/ci/github-actions/multi-platform/) - [issue here](https://github.com/docker/build-push-action/issues/1051). Since this job does not have impact on our pipeline duration, we simply build them in series and keep things simple