### PR TITLE
🧹 Use prebuilt base image in github actions [2/N]

### DIFF
--- a/.github/workflows/actions/setup-environment/action.yaml
+++ b/.github/workflows/actions/setup-environment/action.yaml
@@ -8,12 +8,3 @@ runs:
       with:
         version: 8
         run_install: false
-
-    - name: Setup Node.js
-      uses: actions/setup-node@v4
-      with:
-        node-version-file: ".nvmrc"
-        cache: "pnpm"
-
-    - name: Setup Foundry
-      uses: foundry-rs/foundry-toolchain@v1

--- a/.github/workflows/reusable-publish.yaml
+++ b/.github/workflows/reusable-publish.yaml
@@ -21,6 +21,11 @@ jobs:
   publish:
     name: Publish
     runs-on: ubuntu-latest
+
+    # We'll run the job on the prebuilt base image
+    container:
+      image: ghcr.io/layerzero-labs/devtools-dev-base:main
+
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4

--- a/.github/workflows/reusable-test.yaml
+++ b/.github/workflows/reusable-test.yaml
@@ -70,9 +70,6 @@ jobs:
       - name: Setup environment
         uses: ./.github/workflows/actions/setup-environment
 
-      - name: Install dependencies
-        uses: ./.github/workflows/actions/install-dependencies
-
       - name: Setup build cache
         uses: ./.github/workflows/actions/setup-build-cache
 
@@ -110,10 +107,6 @@ jobs:
       contents: read
       packages: read
 
-    # We'll run the job on the prebuilt base image
-    container:
-      image: ghcr.io/layerzero-labs/devtools-dev-base:main
-
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
@@ -123,14 +116,19 @@ jobs:
       - name: Setup environment
         uses: ./.github/workflows/actions/setup-environment
 
-      - name: Install dependencies
-        uses: ./.github/workflows/actions/install-dependencies
+      # There is a small bug in docker compose that will cause 401 if we don't pull the base image manually
+      #
+      # See more here https://github.com/docker/compose-cli/issues/1545
+      - name: Authenticate to GHCR
+        run: echo ${{ secrets.GITHUB_TOKEN }} | docker login ghcr.io -u ${{ github.actor }} --password-stdin
 
       - name: Test
         run: pnpm test:user
         env:
           LAYERZERO_EXAMPLES_REPOSITORY_URL: https://github.com/${{ github.repository }}.git
           LAYERZERO_EXAMPLES_REPOSITORY_REF: ${{ github.ref }}
+          # We'll use the prebuilt base image
+          DEVTOOLS_BASE_IMAGE: ghcr.io/layerzero-labs/devtools-dev-base:main
 
       # We'll collect the docker compose logs from all containers on failure
       - name: Collect docker logs on failure

--- a/.github/workflows/reusable-test.yaml
+++ b/.github/workflows/reusable-test.yaml
@@ -79,8 +79,8 @@ jobs:
       # There is a small bug in docker compose that will cause 401 if we don't pull the base image manually
       #
       # See more here https://github.com/docker/compose-cli/issues/1545
-      - name: Pull base image
-        run: docker pull ghcr.io/layerzero-labs/devtools-dev-base:main
+      - name: Authenticate to GHCR
+        run: echo ${{ secrets.GITHUB_TOKEN }} | docker login ghcr.io -u ${{ github.actor }} --password-stdin
 
       - name: Test
         run: pnpm test:ci

--- a/.github/workflows/reusable-test.yaml
+++ b/.github/workflows/reusable-test.yaml
@@ -76,11 +76,11 @@ jobs:
       - name: Setup build cache
         uses: ./.github/workflows/actions/setup-build-cache
 
-      # # There is a small bug in docker compose that will cause 401 if we don't pull the base image manually
-      # #
-      # # See more here https://github.com/docker/compose-cli/issues/1545
-      # - name: Pull base image
-      #   run: docker pull ghcr.io/layerzero-labs/devtools-dev-base:main
+      # There is a small bug in docker compose that will cause 401 if we don't pull the base image manually
+      #
+      # See more here https://github.com/docker/compose-cli/issues/1545
+      - name: Pull base image
+        run: docker pull ghcr.io/layerzero-labs/devtools-dev-base:main
 
       - name: Test
         run: pnpm test:ci

--- a/.github/workflows/reusable-test.yaml
+++ b/.github/workflows/reusable-test.yaml
@@ -67,6 +67,12 @@ jobs:
       - name: Setup build cache
         uses: ./.github/workflows/actions/setup-build-cache
 
+      # There is a small bug in docker compose that will cause 401 if we don't pull the base image manually
+      #
+      # See more here https://github.com/docker/compose-cli/issues/1545
+      - name: Pull base image
+        run: docker pull ghcr.io/layerzero-labs/devtools-dev-base:main
+
       - name: Test
         run: pnpm test:ci
         env:

--- a/.github/workflows/reusable-test.yaml
+++ b/.github/workflows/reusable-test.yaml
@@ -22,6 +22,10 @@ jobs:
     name: Build & Lint
     runs-on: ubuntu-latest
 
+    permissions:
+      contents: read
+      packages: read
+
     # We'll run the job on the prebuilt base image
     container:
       image: ghcr.io/layerzero-labs/devtools-dev-base:main
@@ -52,6 +56,11 @@ jobs:
   test:
     name: Test
     runs-on: ubuntu-latest-4xlarge
+
+    permissions:
+      contents: read
+      packages: read
+
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
@@ -67,11 +76,11 @@ jobs:
       - name: Setup build cache
         uses: ./.github/workflows/actions/setup-build-cache
 
-      # There is a small bug in docker compose that will cause 401 if we don't pull the base image manually
-      #
-      # See more here https://github.com/docker/compose-cli/issues/1545
-      - name: Pull base image
-        run: docker pull ghcr.io/layerzero-labs/devtools-dev-base:main
+      # # There is a small bug in docker compose that will cause 401 if we don't pull the base image manually
+      # #
+      # # See more here https://github.com/docker/compose-cli/issues/1545
+      # - name: Pull base image
+      #   run: docker pull ghcr.io/layerzero-labs/devtools-dev-base:main
 
       - name: Test
         run: pnpm test:ci
@@ -96,6 +105,10 @@ jobs:
   test-user:
     name: User test
     runs-on: ubuntu-latest-4xlarge
+
+    permissions:
+      contents: read
+      packages: read
 
     # We'll run the job on the prebuilt base image
     container:

--- a/.github/workflows/reusable-test.yaml
+++ b/.github/workflows/reusable-test.yaml
@@ -21,6 +21,11 @@ jobs:
   build:
     name: Build & Lint
     runs-on: ubuntu-latest
+
+    # We'll run the job on the prebuilt base image
+    container:
+      image: ghcr.io/layerzero-labs/devtools-dev-base:main
+
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
@@ -64,6 +69,9 @@ jobs:
 
       - name: Test
         run: pnpm test:ci
+        env:
+          # We'll use the prebuilt base image
+          DEVTOOLS_BASE_IMAGE: ghcr.io/layerzero-labs/devtools-dev-base:main
 
       # We'll collect the docker compose logs from all containers on failure
       - name: Collect docker logs on failure
@@ -82,6 +90,11 @@ jobs:
   test-user:
     name: User test
     runs-on: ubuntu-latest-4xlarge
+
+    # We'll run the job on the prebuilt base image
+    container:
+      image: ghcr.io/layerzero-labs/devtools-dev-base:main
+
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,20 @@
 # so the code will still work on node 18.16.0
 ARG NODE_VERSION=20.10.0
 
+# We will allow consumers to override the default base image
+# 
+# This will allow CI environments to supply the prebuilt base image
+# while not breaking the flow for local development
+# 
+# Local development does not by default have access to GHCR and would require
+# an additonal step (docker login). While this step is easy, it is still nicer 
+# to provide a transiton period during which the local flow remains unchanged 
+# and the base image is built locally
+# 
+# The CI environment will use base images from https://github.com/LayerZero-Labs/devtools/pkgs/container/devtools-dev-base
+# e.g. ghcr.io/layerzero-labs/devtools-dev-base:main
+ARG BASE_IMAGE=base
+
 #   .-.-.   .-.-.   .-.-.   .-.-.   .-.-.   .-.-.   .-.-.   .-.-
 #  / / \ \ / / \ \ / / \ \ / / \ \ / / \ \ / / \ \ / / \ \ / / \
 # `-'   `-`-'   `-`-'   `-`-'   `-`-'   `-`-'   `-`-'   `-`-'
@@ -69,7 +83,7 @@ RUN docker compose version
 #   .-.-.   .-.-.   .-.-.   .-.-.   .-.-.   .-.-.   .-.-.   .-.-
 #  / / \ \ / / \ \ / / \ \ / / \ \ / / \ \ / / \ \ / / \ \ / / \
 # `-'   `-`-'   `-`-'   `-`-'   `-`-'   `-`-'   `-`-'   `-`-'
-FROM base as development
+FROM $BASE_IMAGE as development
 
 ENV NPM_CONFIG_STORE_DIR=/pnpm
 ENV NPM_CONFIG_PACKAGE_IMPORT_METHOD=copy

--- a/docker-compose.templates.yaml
+++ b/docker-compose.templates.yaml
@@ -17,6 +17,13 @@ services:
   project:
     build:
       context: .
+      target: development
+      args:
+        # We'll provide a way to override the base image
+        # build argument using an environment variable
+        #
+        # This will allow Ci environments to override the base image easily
+        BASE_IMAGE: ${DEVTOOLS_BASE_IMAGE:-base}
     # We'll provide a single testing MNEMONIC for the project so that the test EVM nodes
     # account are in sync with the hardhat accounts
     environment:


### PR DESCRIPTION
### In this PR

- As the next step towards faster pipelines, we'll use the base docker image published to GHCR as the base for our CI runs. Since we don't want to introduce breaking changes to our local workflows, we'll add it as an opt-in feature - we'll allow the base image to be specified as a build argument and we'll allow that to be in turn specified using an environment variable