### PR TITLE
🪲 Fix failing main publish action

### DIFF
--- a/.github/workflows/actions/setup-environment/action.yaml
+++ b/.github/workflows/actions/setup-environment/action.yaml
@@ -3,6 +3,16 @@ description: Setup node & package manager, checkout code
 runs:
   using: "composite"
   steps:
+    # Workaround for dubious ownership problem inside a containerized workflow
+    #
+    # See https://github.com/actions/runner-images/issues/6775
+    #
+    # A possible solution to investigate is to use the 1001 user
+    # https://github.com/actions/runner/issues/2033#issuecomment-1598547465
+    - name: Mark workspace directory as safe
+      shell: bash
+      run: git config --global --add safe.directory ${GITHUB_WORKSPACE}
+
     - uses: pnpm/action-setup@v2
       name: Install pnpm
       with:

--- a/.github/workflows/reusable-publish.yaml
+++ b/.github/workflows/reusable-publish.yaml
@@ -72,7 +72,12 @@ jobs:
           # in HOME folder and if it doesn't find one there it will create one
           #
           # Since we want to make sure it uses our .npmrc we'll just point it
-          # to our workspace root (which, in our container, is the /app directory)
-          HOME: /app
+          # to our workspace root (which, in a workflow that uses a container, is put under __w directory)
+          #
+          # Here we need to use the ${GITHUB_WORKSPACE} environment variable instead
+          # of the context value ${{ github.workspace }}
+          #
+          # See more here https://github.com/actions/runner/issues/2058
+          HOME: ${GITHUB_WORKSPACE}
           GITHUB_TOKEN: ${{ secrets.LAYERZERO_BOT_GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN_PUBLISHER }}


### PR DESCRIPTION
### In this PR

- Fixing the `HOME` directory for a containerized action (it's always `/__w/<repository name>/<repository name>` as asked [here](https://github.com/actions/runner/discussions/1332)
  - Here we need to use `$GITHUB_WORKSPACE` environment variable instead of the `${{ github.workspace }}` context - see [here](https://github.com/actions/runner/issues/2058)
- Fixing problems with _dubious ownership_ as described [here](https://github.com/actions/runner-images/issues/6775)
  - A possible solution is to change the docker user as described [here](https://github.com/actions/runner/issues/2033#issuecomment-1598547465) but this, as seen when debugging, will still not change the owner of files coming from checkout action