### PR TITLE
🪲 Fix wrong cwd in publish action

### DIFF
--- a/.github/workflows/reusable-publish.yaml
+++ b/.github/workflows/reusable-publish.yaml
@@ -63,6 +63,7 @@ jobs:
       - name: Publish packages / create version bump PRs
         uses: changesets/action@v1
         with:
+          cwd: ${GITHUB_WORKSPACE}
           version: pnpm release:version
           publish: pnpm release:publish
           title: "🚀 Version packages"


### PR DESCRIPTION
### In this PR

- Debugging the `changesets/action` - at the moment it was complaining about [the current directory not being a git repo](https://github.com/LayerZero-Labs/devtools/actions/runs/8527494307/job/23360046644). 