### PR TITLE
🪲 Fix publish action, the saga continues

### DIFF
--- a/.github/workflows/actions/setup-environment/action.yaml
+++ b/.github/workflows/actions/setup-environment/action.yaml
@@ -3,16 +3,6 @@ description: Setup node & package manager, checkout code
 runs:
   using: "composite"
   steps:
-    # Workaround for dubious ownership problem inside a containerized workflow
-    #
-    # See https://github.com/actions/runner-images/issues/6775
-    #
-    # A possible solution to investigate is to use the 1001 user
-    # https://github.com/actions/runner/issues/2033#issuecomment-1598547465
-    - name: Transfer file ownership to the root user
-      shell: bash
-      run: chown -R root .
-
     - uses: pnpm/action-setup@v2
       name: Install pnpm
       with:

--- a/.github/workflows/actions/setup-environment/action.yaml
+++ b/.github/workflows/actions/setup-environment/action.yaml
@@ -9,9 +9,9 @@ runs:
     #
     # A possible solution to investigate is to use the 1001 user
     # https://github.com/actions/runner/issues/2033#issuecomment-1598547465
-    - name: Mark workspace directory as safe
+    - name: Transfer file ownership to the root user
       shell: bash
-      run: git config --global --add safe.directory ${GITHUB_WORKSPACE}
+      run: chown -R root .
 
     - uses: pnpm/action-setup@v2
       name: Install pnpm

--- a/.github/workflows/reusable-publish.yaml
+++ b/.github/workflows/reusable-publish.yaml
@@ -63,7 +63,6 @@ jobs:
       - name: Publish packages / create version bump PRs
         uses: changesets/action@v1
         with:
-          cwd: ${GITHUB_WORKSPACE}
           version: pnpm release:version
           publish: pnpm release:publish
           title: "🚀 Version packages"
@@ -75,10 +74,10 @@ jobs:
           # Since we want to make sure it uses our .npmrc we'll just point it
           # to our workspace root (which, in a workflow that uses a container, is put under __w directory)
           #
-          # Here we need to use the ${GITHUB_WORKSPACE} environment variable instead
-          # of the context value ${{ github.workspace }}
+          # Here we need to use the ${{ env.GITHUB_WORKSPACE }} environment variable instead
+          # of the github context value ${{ github.workspace }}
           #
           # See more here https://github.com/actions/runner/issues/2058
-          HOME: ${GITHUB_WORKSPACE}
+          HOME: ${{ env.GITHUB_WORKSPACE }}
           GITHUB_TOKEN: ${{ secrets.LAYERZERO_BOT_GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN_PUBLISHER }}

--- a/.github/workflows/reusable-publish.yaml
+++ b/.github/workflows/reusable-publish.yaml
@@ -33,6 +33,16 @@ jobs:
           submodules: "true"
           token: ${{ secrets.LAYERZERO_BOT_GITHUB_TOKEN }}
 
+      # Workaround for dubious ownership problem inside a containerized workflow
+      #
+      # See https://github.com/actions/runner-images/issues/6775
+      #
+      # A possible solution to investigate is to use the 1001 user
+      # https://github.com/actions/runner/issues/2033#issuecomment-1598547465
+      - name: Transfer file ownership to the root user
+        shell: bash
+        run: chown -R root .
+
       - name: Setup environment
         uses: ./.github/workflows/actions/setup-environment
 


### PR DESCRIPTION
### In this PR

- Instead of setting the safe directory, transfer ownership of the workspace directory to the root user (that's the user running the action)
- Fix a problem where environment variables are not expanded when passed as values for `env`

I am not proud but well that's about how much time I have to fix this.