### PR TITLE
🗞️ Complex configs: Add --tag CLI argument for complex multi-config projects with custom wiring [2/N]

### DIFF
--- a/.changeset/light-dolls-dance.md
+++ b/.changeset/light-dolls-dance.md
@@ -1,0 +1,7 @@
+---
+"@layerzerolabs/ua-devtools-evm-hardhat": patch
+"@layerzerolabs/devtools-evm-hardhat": patch
+"@layerzerolabs/toolbox-hardhat": patch
+---
+
+Add tag hardhat task argument

--- a/packages/devtools-evm-hardhat/src/tasks/transactions/subtask.sign-and-send.ts
+++ b/packages/devtools-evm-hardhat/src/tasks/transactions/subtask.sign-and-send.ts
@@ -25,18 +25,22 @@ export interface SignAndSendTaskArgs {
     ci?: boolean
     transactions: OmniTransaction[]
     createSigner: OmniSignerFactory
+    tag?: string
 }
 
 const action: ActionType<SignAndSendTaskArgs> = async ({
     ci,
     transactions,
     createSigner,
+    tag,
 }): Promise<SignAndSendResult> => {
     // We only want to be asking users for input if we are not in interactive mode
     const isInteractive = !ci
 
-    const logger = createLogger()
-    const subtaskLogger = createModuleLogger(SUBTASK_LZ_SIGN_AND_SEND)
+    const logger = tag == null ? createLogger() : createModuleLogger(tag)
+    const subtaskLogger = createModuleLogger(
+        tag == null ? SUBTASK_LZ_SIGN_AND_SEND : `${SUBTASK_LZ_SIGN_AND_SEND}@${tag}`
+    )
 
     // Ask them whether they want to see them
     const previewTransactions = isInteractive
@@ -168,3 +172,10 @@ subtask(SUBTASK_LZ_SIGN_AND_SEND, 'Sign and send a list of transactions using a 
     .addFlag('ci', 'Continuous integration (non-interactive) mode. Will not ask for any input from the user')
     .addParam('transactions', 'List of OmniTransaction objects', undefined, types.any)
     .addParam('createSigner', 'Function that creates a signer for a particular network', undefined, types.fn)
+    .addParam(
+        'tag',
+        'Custom tag to pass to subtasks. Useful for complex projects with multiple custom configurations',
+        undefined,
+        types.string,
+        true
+    )

--- a/packages/ua-devtools-evm-hardhat/src/tasks/oapp/wire/subtask.configure.ts
+++ b/packages/ua-devtools-evm-hardhat/src/tasks/oapp/wire/subtask.configure.ts
@@ -11,14 +11,18 @@ export interface SubtaskConfigureTaskArgs {
     graph: OAppOmniGraph
     configurator?: OAppConfigurator
     oappFactory?: OAppFactory
+    tag?: string
 }
 
 const action: ActionType<SubtaskConfigureTaskArgs> = async ({
     graph,
     configurator = configureOApp,
     oappFactory = createOAppFactory(createConnectedContractFactory()),
+    tag,
 }): Promise<OmniTransaction[]> => {
-    const logger = createModuleLogger(SUBTASK_LZ_OAPP_WIRE_CONFIGURE)
+    const logger = createModuleLogger(
+        tag == null ? SUBTASK_LZ_OAPP_WIRE_CONFIGURE : `${SUBTASK_LZ_OAPP_WIRE_CONFIGURE}@${tag}`
+    )
 
     logger.verbose(`Running with graph:\n\n${printJson(graph)}`)
 
@@ -53,3 +57,10 @@ subtask(SUBTASK_LZ_OAPP_WIRE_CONFIGURE, 'Create a list of OmniTransactions that 
     .addParam('graph', 'Configuration of you OApp of type OAppOmniGraph', undefined, types.any)
     .addParam('configurator', 'Configuration function of type OAppConfigurator', undefined, types.any, true)
     .addParam('oappFactory', 'SDK factory for OApp SDK of type OAppFactory', undefined, types.any, true)
+    .addParam(
+        'tag',
+        'Custom tag to pass to subtasks. Useful for complex projects with multiple custom configurations',
+        undefined,
+        types.string,
+        true
+    )

--- a/packages/ua-devtools-evm-hardhat/src/tasks/ownable/transfer.ownership.ts
+++ b/packages/ua-devtools-evm-hardhat/src/tasks/ownable/transfer.ownership.ts
@@ -30,10 +30,11 @@ interface TaskArgs {
     ci?: boolean
     safe?: boolean
     signer?: string
+    tag?: string
 }
 
 const action: ActionType<TaskArgs> = async (
-    { oappConfig: oappConfigPath, logLevel = 'info', ci = false, safe = false, signer },
+    { oappConfig: oappConfigPath, logLevel = 'info', ci = false, safe = false, signer, tag },
     hre
 ): Promise<SignAndSendResult> => {
     printLogo()
@@ -83,6 +84,7 @@ const action: ActionType<TaskArgs> = async (
         transactions,
         ci,
         createSigner,
+        tag,
     } satisfies SignAndSendTaskArgs)
 
     // Mark the process as unsuccessful if there were any errors (only if it has not yet been marked as such)
@@ -100,3 +102,10 @@ task(TASK_LZ_OWNABLE_TRANSFER_OWNERSHIP, 'Transfer ownable contract ownership', 
     .addFlag('ci', 'Continuous integration (non-interactive) mode. Will not ask for any input from the user')
     .addFlag('safe', 'Use gnosis safe to sign transactions')
     .addParam('signer', 'Index or address of signer', undefined, types.signer, true)
+    .addParam(
+        'tag',
+        'Custom tag to pass to subtasks. Useful for complex projects with multiple custom configurations',
+        undefined,
+        types.string,
+        true
+    )


### PR DESCRIPTION
### In this PR

- Add `--tag` argument to the wire and transfer ownership tasks so that projects that have multiple custom configurations can decide which override to apply based on the `tag` value

### The problem

There is an app that has three custom configurations. These involve overriding the `SUBTASK_LZ_OAPP_WIRE_CONFIGURE` with three different configurations. At the moment, it is impossible to know in which context the configurator is running so the user would need to recreate the wiring task from scratch.

### The solution

Allow users to pass a `tag` that gets passed to the subtasks. These can then `switch` the logic based on this tag.

Although suboptimal in terms of architecture (comparable to having an `IS_STAGING` environment variable in a server configurations), this solution provides enough flexibility to implement complex custom configurations using hardhat tasks.