### PR TITLE
🗞️ Pass additional properties through OAppNodeConfigSchema; Allow null

### DIFF
--- a/.changeset/nervous-rockets-sneeze.md
+++ b/.changeset/nervous-rockets-sneeze.md
@@ -1,0 +1,8 @@
+---
+"@layerzerolabs/ua-devtools": patch
+"@layerzerolabs/toolbox-hardhat": patch
+"@layerzerolabs/ua-devtools-evm": patch
+"@layerzerolabs/ua-devtools-evm-hardhat": patch
+---
+
+Pass additional OApp node configuration properties through schema; Make properties nullable & optional

--- a/packages/ua-devtools/package.json
+++ b/packages/ua-devtools/package.json
@@ -27,7 +27,8 @@
     "clean": "rm -rf dist",
     "dev": "$npm_execpath tsup --watch",
     "lint": "$npm_execpath eslint '**/*.{js,ts,json}'",
-    "lint:fix": "eslint --fix '**/*.{js,ts,json}'"
+    "lint:fix": "eslint --fix '**/*.{js,ts,json}'",
+    "test": "jest --ci"
   },
   "devDependencies": {
     "@layerzerolabs/devtools": "~0.3.4",

--- a/packages/ua-devtools/src/oapp/schema.ts
+++ b/packages/ua-devtools/src/oapp/schema.ts
@@ -71,8 +71,10 @@ export const OAppEnforcedOptionsSchema = z.array(OAppEnforcedOptionConfigSchema)
 >
 
 export const OAppNodeConfigSchema = OwnableNodeConfigSchema.extend({
-    delegate: AddressSchema.optional(),
-}) satisfies z.ZodSchema<OAppNodeConfig, z.ZodTypeDef, unknown>
+    delegate: AddressSchema.nullish(),
+})
+    // We'll pass all unknown properties through without validating them
+    .passthrough() satisfies z.ZodSchema<OAppNodeConfig, z.ZodTypeDef, unknown>
 
 export const OAppEdgeConfigSchema = z
     .object({
@@ -83,5 +85,6 @@ export const OAppEdgeConfigSchema = z
         receiveConfig: OAppReceiveConfigSchema,
         enforcedOptions: OAppEnforcedOptionsSchema,
     })
+    // We'll pass all unknown properties through without validating them
     .passthrough()
     .partial() satisfies z.ZodSchema<OAppEdgeConfig, z.ZodTypeDef, unknown>

--- a/packages/ua-devtools/src/ownable/schema.ts
+++ b/packages/ua-devtools/src/ownable/schema.ts
@@ -1,6 +1,9 @@
 import { AddressSchema } from '@layerzerolabs/devtools'
 import { z } from 'zod'
 
-export const OwnableNodeConfigSchema = z.object({
-    owner: AddressSchema.optional(),
-})
+export const OwnableNodeConfigSchema = z
+    .object({
+        owner: AddressSchema.nullish(),
+    })
+    // We'll pass all unknown properties through without validating them
+    .passthrough()

--- a/packages/ua-devtools/src/ownable/types.ts
+++ b/packages/ua-devtools/src/ownable/types.ts
@@ -7,7 +7,7 @@ export interface IOwnable {
 }
 
 export interface OwnableNodeConfig {
-    owner?: OmniAddress
+    owner?: OmniAddress | null
 }
 
 export type OwnableOmniGraph = OmniGraph<OwnableNodeConfig | undefined>

--- a/packages/ua-devtools/test/oapp/schema.test.ts
+++ b/packages/ua-devtools/test/oapp/schema.test.ts
@@ -1,0 +1,32 @@
+import type { OAppNodeConfig } from '@/oapp/types'
+import fc from 'fast-check'
+import { evmAddressArbitrary, nullableArbitrary } from '@layerzerolabs/test-devtools'
+import { OAppNodeConfigSchema } from '@/oapp/schema'
+
+describe('oapp/schema', () => {
+    describe('OAppNodeConfigSchema', () => {
+        const oappNodeConfigArbitrary: fc.Arbitrary<OAppNodeConfig> = fc.record({
+            owner: nullableArbitrary(evmAddressArbitrary),
+            delegate: nullableArbitrary(evmAddressArbitrary),
+        })
+
+        it('should succeed with a valid config', () => {
+            fc.assert(
+                fc.property(oappNodeConfigArbitrary, (config) => {
+                    expect(OAppNodeConfigSchema.parse(config)).toEqual(config)
+                })
+            )
+        })
+
+        it('should pass any additional properties through', () => {
+            fc.assert(
+                fc.property(oappNodeConfigArbitrary, fc.object(), (config, extraProperties) => {
+                    expect(OAppNodeConfigSchema.parse({ ...extraProperties, ...config })).toEqual({
+                        ...extraProperties,
+                        ...config,
+                    })
+                })
+            )
+        })
+    })
+})


### PR DESCRIPTION
### In this PR

- Allow any additional `OAppNodeConfig` properties through the schema. This allows for custom, albeit unchecked, configurations to be used with the default schema
- Allow `null` as well as `undefined` for `owner` and `delegate` properties