### PR TITLE
🧹 Helper types for custom configurations

### DIFF
--- a/.changeset/eight-ravens-fetch.md
+++ b/.changeset/eight-ravens-fetch.md
@@ -1,0 +1,7 @@
+---
+"@layerzerolabs/devtools-evm-hardhat": patch
+"@layerzerolabs/toolbox-hardhat": patch
+"@layerzerolabs/ua-devtools-evm-hardhat": patch
+---
+
+Add InferOmniGraph helper type

--- a/.changeset/red-seals-rule.md
+++ b/.changeset/red-seals-rule.md
@@ -1,0 +1,5 @@
+---
+"@layerzerolabs/devtools": patch
+---
+
+Add helper signer types

--- a/.changeset/three-spoons-occur.md
+++ b/.changeset/three-spoons-occur.md
@@ -1,0 +1,16 @@
+---
+"@layerzerolabs/ua-devtools-evm-hardhat-test": patch
+"@layerzerolabs/devtools-evm-hardhat": patch
+"@layerzerolabs/protocol-devtools": patch
+"@layerzerolabs/ua-devtools": patch
+"@layerzerolabs/devtools": patch
+"@layerzerolabs/devtools-evm": patch
+"@layerzerolabs/omnicounter-devtools": patch
+"@layerzerolabs/omnicounter-devtools-evm": patch
+"@layerzerolabs/protocol-devtools-evm": patch
+"@layerzerolabs/toolbox-hardhat": patch
+"@layerzerolabs/ua-devtools-evm": patch
+"@layerzerolabs/ua-devtools-evm-hardhat": patch
+---
+
+Add Configurator helper type

--- a/packages/devtools-evm-hardhat/src/omnigraph/types.ts
+++ b/packages/devtools-evm-hardhat/src/omnigraph/types.ts
@@ -51,6 +51,19 @@ export interface OmniGraphHardhat<TNodeConfig = unknown, TEdgeConfig = unknown> 
     connections: OmniEdgeHardhat<TEdgeConfig>[]
 }
 
+/**
+ * Helper type to convert OmniGraphHardhat to OmniGraph
+ *
+ * ```
+ * type MyOmniGraphHardhat = OmniGraphHardhat<MyNodeConfig, MyEdgeConfig>
+ * type MyOmniGraph = InferOmniGraph<MyOmniGraphHardhat>
+ * ```
+ */
+export type InferOmniGraph<TOmniGraphHardhat extends OmniGraphHardhat> =
+    TOmniGraphHardhat extends OmniGraphHardhat<infer TNodeConfig, infer TEdgeConfig>
+        ? OmniGraph<TNodeConfig, TEdgeConfig>
+        : never
+
 export type OmniContractFactoryHardhat = OmniContractFactory<OmniPointHardhat>
 
 export type OmniPointHardhatTransformer = Factory<[OmniPointHardhat | OmniPoint], OmniPoint>

--- a/packages/devtools-evm-hardhat/test/omnigraph/types.test.ts
+++ b/packages/devtools-evm-hardhat/test/omnigraph/types.test.ts
@@ -1,0 +1,30 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+/* eslint-disable jest/expect-expect */
+
+import type { InferOmniGraph, OmniGraphHardhat } from '@/omnigraph/types'
+import type { OmniGraph } from '@layerzerolabs/devtools'
+
+describe('omnigraph/types', () => {
+    describe('InferOmniGraph', () => {
+        type MyNodeConfig = string
+        type MyEdgeConfig = number
+        type MyOmniGraphHardhat = OmniGraphHardhat<MyNodeConfig, MyEdgeConfig>
+
+        it('should not allow non-OmniGraphHardhat type parameter', () => {
+            // @ts-expect-error should only accept OmniGraphHardhat type
+            type MyOmniGraph = InferOmniGraph<string>
+        })
+
+        it('should turn OmniGraphHardhat into matching OmniGraph', () => {
+            type ExpectedOmniGraph = OmniGraph<MyNodeConfig, MyEdgeConfig>
+            type MyOmniGraph = InferOmniGraph<MyOmniGraphHardhat>
+
+            const graph: MyOmniGraph = { contracts: [], connections: [] }
+            const expectedGraph: ExpectedOmniGraph = graph
+
+            type UnexpectedOmniGraph = OmniGraph<boolean, bigint>
+            // @ts-expect-error UnexpectedOmniGraph is not compatible with MyOmniGraph
+            const unexpectedOmniGraph: UnexpectedOmniGraph = graph
+        })
+    })
+})

--- a/packages/devtools/src/omnigraph/types.ts
+++ b/packages/devtools/src/omnigraph/types.ts
@@ -1,5 +1,6 @@
 import type { EndpointId } from '@layerzerolabs/lz-definitions'
 import type { Factory, OmniAddress, WithOptionals } from '@/types'
+import { OmniTransaction } from '..'
 
 /**
  * OmniPoint identifies a point in omniverse, an omnichain universe.
@@ -73,7 +74,12 @@ export interface IOmniSDK {
 /**
  * Base factory for all SDK factories
  */
-export type OmniSDKFactory<TOmniSDK extends IOmniSDK = IOmniSDK, TOmniPoint = OmniPoint> = Factory<
-    [TOmniPoint],
-    TOmniSDK
->
+export type OmniSDKFactory<TOmniSDK = IOmniSDK, TOmniPoint = OmniPoint> = Factory<[TOmniPoint], TOmniSDK>
+
+/**
+ * Helper type for configuration functions
+ */
+export type Configurator<TOmniGraph extends OmniGraph = OmniGraph, TOmniSDK = IOmniSDK> = (
+    graph: TOmniGraph,
+    createSdk: OmniSDKFactory<TOmniSDK>
+) => Promise<OmniTransaction[]>

--- a/packages/devtools/src/transactions/signer.ts
+++ b/packages/devtools/src/transactions/signer.ts
@@ -12,6 +12,16 @@ export type SignAndSendResult = [
     pending: OmniTransaction[],
 ]
 
+export type OnSignAndSendProgress = (
+    result: OmniTransactionWithReceipt,
+    results: OmniTransactionWithReceipt[]
+) => unknown
+
+export type SignAndSend = (
+    transactions: OmniTransaction[],
+    onProgress?: OnSignAndSendProgress
+) => Promise<SignAndSendResult>
+
 /**
  * Creates a sign & send utility for a list of transaction
  * with a help of `OmniSignerFactory`
@@ -19,11 +29,8 @@ export type SignAndSendResult = [
  * @param {OmniSignerFactory} createSigner
  */
 export const createSignAndSend =
-    (createSigner: OmniSignerFactory) =>
-    async (
-        transactions: OmniTransaction[],
-        onProgress?: (result: OmniTransactionWithReceipt, results: OmniTransactionWithReceipt[]) => unknown
-    ): Promise<SignAndSendResult> => {
+    (createSigner: OmniSignerFactory): SignAndSend =>
+    async (transactions, onProgress): Promise<SignAndSendResult> => {
         const logger = createModuleLogger('sign & send')
 
         // Put it here so that we don't need to type like seven toilet rolls of variable names

--- a/packages/protocol-devtools/src/dvn/config.ts
+++ b/packages/protocol-devtools/src/dvn/config.ts
@@ -1,7 +1,5 @@
 import { flattenTransactions, isDeepEqual, type OmniTransaction } from '@layerzerolabs/devtools'
-import type { DVNFactory, DVNOmniGraph } from './types'
-
-export type DVNConfigurator = (graph: DVNOmniGraph, createSdk: DVNFactory) => Promise<OmniTransaction[]>
+import type { DVNConfigurator } from './types'
 
 export const configureDVN: DVNConfigurator = async (graph, createSdk) =>
     flattenTransactions([await configureDVNDstConfig(graph, createSdk)])

--- a/packages/protocol-devtools/src/dvn/types.ts
+++ b/packages/protocol-devtools/src/dvn/types.ts
@@ -1,4 +1,11 @@
-import type { IOmniSDK, OmniGraph, OmniPoint, OmniSDKFactory, OmniTransaction } from '@layerzerolabs/devtools'
+import type {
+    Configurator,
+    IOmniSDK,
+    OmniGraph,
+    OmniPoint,
+    OmniSDKFactory,
+    OmniTransaction,
+} from '@layerzerolabs/devtools'
 import type { EndpointId } from '@layerzerolabs/lz-definitions'
 
 export interface IDVN extends IOmniSDK {
@@ -19,3 +26,5 @@ export interface DVNEdgeConfig {
 export type DVNOmniGraph = OmniGraph<unknown, DVNEdgeConfig>
 
 export type DVNFactory<TDVN extends IDVN = IDVN, TOmniPoint = OmniPoint> = OmniSDKFactory<TDVN, TOmniPoint>
+
+export type DVNConfigurator<TDVN extends IDVN = IDVN> = Configurator<DVNOmniGraph, TDVN>

--- a/packages/protocol-devtools/src/endpointv2/config.ts
+++ b/packages/protocol-devtools/src/endpointv2/config.ts
@@ -1,10 +1,5 @@
 import { flattenTransactions, type OmniTransaction, OmniPointMap, Bytes32 } from '@layerzerolabs/devtools'
-import type { EndpointV2Factory, EndpointV2OmniGraph, IEndpointV2 } from './types'
-
-export type EndpointV2Configurator = (
-    graph: EndpointV2OmniGraph,
-    createSdk: EndpointV2Factory
-) => Promise<OmniTransaction[]>
+import type { EndpointV2Configurator, IEndpointV2 } from './types'
 
 export const configureEndpointV2: EndpointV2Configurator = async (graph, createSdk) =>
     flattenTransactions([

--- a/packages/protocol-devtools/src/endpointv2/types.ts
+++ b/packages/protocol-devtools/src/endpointv2/types.ts
@@ -7,6 +7,7 @@ import type {
     Bytes32,
     PossiblyBytes,
     OmniSDKFactory,
+    Configurator,
 } from '@layerzerolabs/devtools'
 import type { EndpointId } from '@layerzerolabs/lz-definitions'
 import type { IUln302, Uln302ExecutorConfig, Uln302UlnConfig, Uln302UlnUserConfig } from '@/uln302/types'
@@ -220,4 +221,9 @@ export type EndpointV2OmniGraph = OmniGraph<unknown, EndpointV2EdgeConfig>
 export type EndpointV2Factory<TEndpointV2 extends IEndpointV2 = IEndpointV2, TOmniPoint = OmniPoint> = OmniSDKFactory<
     TEndpointV2,
     TOmniPoint
+>
+
+export type EndpointV2Configurator<TEndpointV2 extends IEndpointV2 = IEndpointV2> = Configurator<
+    EndpointV2OmniGraph,
+    TEndpointV2
 >

--- a/packages/protocol-devtools/src/executor/config.ts
+++ b/packages/protocol-devtools/src/executor/config.ts
@@ -1,7 +1,5 @@
 import { flattenTransactions, isDeepEqual, type OmniTransaction } from '@layerzerolabs/devtools'
-import type { ExecutorFactory, ExecutorOmniGraph } from './types'
-
-export type ExecutorConfigurator = (graph: ExecutorOmniGraph, createSdk: ExecutorFactory) => Promise<OmniTransaction[]>
+import type { ExecutorConfigurator } from './types'
 
 export const configureExecutor: ExecutorConfigurator = async (graph, createSdk) =>
     flattenTransactions([await configureExecutorDstConfig(graph, createSdk)])

--- a/packages/protocol-devtools/src/executor/types.ts
+++ b/packages/protocol-devtools/src/executor/types.ts
@@ -1,4 +1,11 @@
-import type { IOmniSDK, OmniGraph, OmniPoint, OmniSDKFactory, OmniTransaction } from '@layerzerolabs/devtools'
+import type {
+    Configurator,
+    IOmniSDK,
+    OmniGraph,
+    OmniPoint,
+    OmniSDKFactory,
+    OmniTransaction,
+} from '@layerzerolabs/devtools'
 import type { EndpointId } from '@layerzerolabs/lz-definitions'
 
 export interface IExecutor extends IOmniSDK {
@@ -36,3 +43,5 @@ export type ExecutorFactory<TExecutor extends IExecutor = IExecutor, TOmniPoint 
     TExecutor,
     TOmniPoint
 >
+
+export type ExecutorConfigurator<TExecutor extends IExecutor = IExecutor> = Configurator<ExecutorOmniGraph, TExecutor>

--- a/packages/protocol-devtools/src/priceFeed/config.ts
+++ b/packages/protocol-devtools/src/priceFeed/config.ts
@@ -1,10 +1,5 @@
 import { flattenTransactions, isDeepEqual, type OmniTransaction } from '@layerzerolabs/devtools'
-import type { PriceFeedFactory, PriceFeedOmniGraph } from './types'
-
-export type PriceFeedConfigurator = (
-    graph: PriceFeedOmniGraph,
-    createSdk: PriceFeedFactory
-) => Promise<OmniTransaction[]>
+import type { PriceFeedConfigurator } from './types'
 
 export const configurePriceFeed: PriceFeedConfigurator = async (graph, createSdk) =>
     flattenTransactions([await configurePriceFeedPriceData(graph, createSdk)])

--- a/packages/protocol-devtools/src/priceFeed/types.ts
+++ b/packages/protocol-devtools/src/priceFeed/types.ts
@@ -1,4 +1,11 @@
-import type { IOmniSDK, OmniGraph, OmniPoint, OmniSDKFactory, OmniTransaction } from '@layerzerolabs/devtools'
+import type {
+    Configurator,
+    IOmniSDK,
+    OmniGraph,
+    OmniPoint,
+    OmniSDKFactory,
+    OmniTransaction,
+} from '@layerzerolabs/devtools'
 import type { EndpointId } from '@layerzerolabs/lz-definitions'
 
 export interface IPriceFeed extends IOmniSDK {
@@ -21,4 +28,9 @@ export type PriceFeedOmniGraph = OmniGraph<unknown, PriceFeedEdgeConfig>
 export type PriceFeedFactory<TPriceFeed extends IPriceFeed = IPriceFeed, TOmniPoint = OmniPoint> = OmniSDKFactory<
     TPriceFeed,
     TOmniPoint
+>
+
+export type PriceFeedConfigurator<TPriceFeed extends IPriceFeed = IPriceFeed> = Configurator<
+    PriceFeedOmniGraph,
+    TPriceFeed
 >

--- a/packages/protocol-devtools/src/uln302/config.ts
+++ b/packages/protocol-devtools/src/uln302/config.ts
@@ -1,7 +1,5 @@
 import { flattenTransactions, type OmniTransaction } from '@layerzerolabs/devtools'
-import type { Uln302Factory, Uln302OmniGraph } from './types'
-
-export type Uln302Configurator = (graph: Uln302OmniGraph, createSdk: Uln302Factory) => Promise<OmniTransaction[]>
+import type { Uln302Configurator } from './types'
 
 export const configureUln302: Uln302Configurator = async (graph, createSdk) =>
     flattenTransactions([

--- a/packages/protocol-devtools/src/uln302/types.ts
+++ b/packages/protocol-devtools/src/uln302/types.ts
@@ -5,6 +5,7 @@ import type {
     IOmniSDK,
     OmniPoint,
     OmniSDKFactory,
+    Configurator,
 } from '@layerzerolabs/devtools'
 import type { EndpointId } from '@layerzerolabs/lz-definitions'
 
@@ -126,3 +127,5 @@ export type Uln302Factory<TUln302 extends IUln302 = IUln302, TOmniPoint = OmniPo
     TUln302,
     TOmniPoint
 >
+
+export type Uln302Configurator<TUln302 extends IUln302 = IUln302> = Configurator<Uln302OmniGraph, TUln302>

--- a/packages/ua-devtools/src/lzapp/config.ts
+++ b/packages/ua-devtools/src/lzapp/config.ts
@@ -5,12 +5,10 @@ import {
     type OmniTransaction,
     sequence,
 } from '@layerzerolabs/devtools'
-import { LzAppFactory, LzAppOmniGraph } from './types'
+import { LzAppConfigurator } from './types'
 import { createModuleLogger, printBoolean } from '@layerzerolabs/io-devtools'
 
-export type LzAppConfigurator = (graph: LzAppOmniGraph, createSdk: LzAppFactory) => Promise<OmniTransaction[]>
-
-export const configureLzApp: LzAppConfigurator = async (graph: LzAppOmniGraph, createSdk: LzAppFactory) => {
+export const configureLzApp: LzAppConfigurator = async (graph, createSdk) => {
     const logger = createModuleLogger('LzApp')
     const tasks = [() => configureLzAppTrustedRemotes(graph, createSdk)]
     // For now we keep the parallel execution as an opt-in feature flag

--- a/packages/ua-devtools/src/lzapp/types.ts
+++ b/packages/ua-devtools/src/lzapp/types.ts
@@ -1,4 +1,5 @@
 import type {
+    Configurator,
     IOmniSDK,
     OmniAddress,
     OmniGraph,
@@ -17,3 +18,5 @@ export interface ILzApp extends IOmniSDK {
 export type LzAppOmniGraph = OmniGraph<unknown, unknown>
 
 export type LzAppFactory<TLzApp extends ILzApp = ILzApp, TOmniPoint = OmniPoint> = OmniSDKFactory<TLzApp, TOmniPoint>
+
+export type LzAppConfigurator<TLzApp extends ILzApp = ILzApp> = Configurator<LzAppOmniGraph, TLzApp>

--- a/packages/ua-devtools/src/oapp/config.ts
+++ b/packages/ua-devtools/src/oapp/config.ts
@@ -10,15 +10,13 @@ import {
     sequence,
     formatOmniPoint,
 } from '@layerzerolabs/devtools'
-import { OAppEnforcedOption, OAppEnforcedOptionParam, OAppFactory, OAppOmniGraph } from './types'
+import type { OAppConfigurator, OAppEnforcedOption, OAppEnforcedOptionParam, OAppFactory } from './types'
 import { createModuleLogger, printBoolean } from '@layerzerolabs/io-devtools'
-import { SetConfigParam } from '@layerzerolabs/protocol-devtools'
+import type { SetConfigParam } from '@layerzerolabs/protocol-devtools'
 import assert from 'assert'
 import { ExecutorOptionType, Options } from '@layerzerolabs/lz-v2-utilities'
 
-export type OAppConfigurator = (graph: OAppOmniGraph, createSdk: OAppFactory) => Promise<OmniTransaction[]>
-
-export const configureOApp: OAppConfigurator = async (graph: OAppOmniGraph, createSdk: OAppFactory) => {
+export const configureOApp: OAppConfigurator = async (graph, createSdk) => {
     const logger = createModuleLogger('OApp')
     const tasks = [
         () => configureOAppPeers(graph, createSdk),

--- a/packages/ua-devtools/src/oapp/types.ts
+++ b/packages/ua-devtools/src/oapp/types.ts
@@ -2,6 +2,7 @@ import type { EndpointId } from '@layerzerolabs/lz-definitions'
 import type { IEndpointV2, Timeout, Uln302ExecutorConfig, Uln302UlnUserConfig } from '@layerzerolabs/protocol-devtools'
 import type {
     Bytes,
+    Configurator,
     IOmniSDK,
     OmniAddress,
     OmniGraph,
@@ -112,3 +113,5 @@ export interface OAppEnforcedOptions {
 export type OAppOmniGraph = OmniGraph<OAppNodeConfig | undefined, OAppEdgeConfig | undefined>
 
 export type OAppFactory<TOApp extends IOApp = IOApp, TOmniPoint = OmniPoint> = OmniSDKFactory<TOApp, TOmniPoint>
+
+export type OAppConfigurator<TOApp extends IOApp = IOApp> = Configurator<OAppOmniGraph, TOApp>

--- a/packages/ua-devtools/src/ownable/config.ts
+++ b/packages/ua-devtools/src/ownable/config.ts
@@ -1,8 +1,6 @@
 import { createModuleLogger } from '@layerzerolabs/io-devtools'
-import type { OwnableFactory, OwnableOmniGraph } from './types'
-import { flattenTransactions, formatOmniPoint, type OmniTransaction } from '@layerzerolabs/devtools'
-
-export type OwnableConfigurator = (graph: OwnableOmniGraph, createSdk: OwnableFactory) => Promise<OmniTransaction[]>
+import type { OwnableConfigurator } from './types'
+import { flattenTransactions, formatOmniPoint } from '@layerzerolabs/devtools'
 
 export const configureOwnable: OwnableConfigurator = async (graph, createSdk) => {
     const logger = createModuleLogger('Ownable')

--- a/packages/ua-devtools/src/ownable/types.ts
+++ b/packages/ua-devtools/src/ownable/types.ts
@@ -1,4 +1,4 @@
-import type { Factory, OmniAddress, OmniGraph, OmniPoint, OmniTransaction } from '@layerzerolabs/devtools'
+import type { Configurator, Factory, OmniAddress, OmniGraph, OmniPoint, OmniTransaction } from '@layerzerolabs/devtools'
 
 export interface IOwnable {
     getOwner(): Promise<OmniAddress>
@@ -16,3 +16,5 @@ export type OwnableFactory<TOwnable extends IOwnable = IOwnable, TOmniPoint = Om
     [TOmniPoint],
     TOwnable
 >
+
+export type OwnableConfigurator<TOwnable extends IOwnable = IOwnable> = Configurator<OwnableOmniGraph, TOwnable>

--- a/tests/ua-devtools-evm-hardhat-test/layerzero.config.with-custom-configuration.ts
+++ b/tests/ua-devtools-evm-hardhat-test/layerzero.config.with-custom-configuration.ts
@@ -1,4 +1,4 @@
-import { OmniPoint, OmniTransaction, UIntBigIntSchema, flattenTransactions } from '@layerzerolabs/devtools'
+import { Configurator, OmniTransaction, UIntBigIntSchema, flattenTransactions } from '@layerzerolabs/devtools'
 import { BigNumberishBigIntSchema } from '@layerzerolabs/devtools-evm'
 import {
     createOmniEdgeHardhatSchema,
@@ -35,10 +35,7 @@ export type MyCustomOmniGraphHardhat = OmniGraphHardhat<MyCustomNodeConfig, OApp
 
 export type MyCustomOmniGraph = InferOmniGraph<MyCustomOmniGraphHardhat>
 
-export type MyCustomOAppConfigurator = (
-    graph: MyCustomOmniGraph,
-    createSdk: (point: OmniPoint) => Promise<MyCustomOAppSDK>
-) => Promise<OmniTransaction[]>
+export type MyCustomOAppConfigurator = Configurator<MyCustomOmniGraph, MyCustomOAppSDK>
 
 //   .-.-.   .-.-.   .-.-.   .-.-.   .-.-.   .-.-.   .-.-.   .-.-
 //  / / \ \ / / \ \ / / \ \ / / \ \ / / \ \ / / \ \ / / \ \ / / \

--- a/tests/ua-devtools-evm-hardhat-test/layerzero.config.with-custom-configuration.ts
+++ b/tests/ua-devtools-evm-hardhat-test/layerzero.config.with-custom-configuration.ts
@@ -1,10 +1,11 @@
-import { OmniGraph, OmniPoint, OmniTransaction, UIntBigIntSchema, flattenTransactions } from '@layerzerolabs/devtools'
+import { OmniPoint, OmniTransaction, UIntBigIntSchema, flattenTransactions } from '@layerzerolabs/devtools'
 import { BigNumberishBigIntSchema } from '@layerzerolabs/devtools-evm'
 import {
     createOmniEdgeHardhatSchema,
     createOmniGraphHardhatSchema,
     createOmniNodeHardhatSchema,
     type OmniGraphHardhat,
+    type InferOmniGraph,
 } from '@layerzerolabs/devtools-evm-hardhat'
 import { EndpointId } from '@layerzerolabs/lz-definitions'
 import {
@@ -32,7 +33,7 @@ export interface MyCustomNodeConfig extends OAppNodeConfig {
 
 export type MyCustomOmniGraphHardhat = OmniGraphHardhat<MyCustomNodeConfig, OAppEdgeConfig | undefined>
 
-export type MyCustomOmniGraph = OmniGraph<MyCustomNodeConfig, OAppEdgeConfig | undefined>
+export type MyCustomOmniGraph = InferOmniGraph<MyCustomOmniGraphHardhat>
 
 export type MyCustomOAppConfigurator = (
     graph: MyCustomOmniGraph,


### PR DESCRIPTION
### In this PR

- Add helper types to reduce boilerplate for custom configurations
  - `InferOmniGraph` for transforming `OmniGraphHardhat` to `OmniGraph`
  - `Configurator` for defining custom configuration functions
  - `SignAndSend` type for the result of `createSignAndSend`