### PR TITLE
🪲 Add forgotten delegate configuration to wire

### DIFF
--- a/.changeset/tricky-laws-cry.md
+++ b/.changeset/tricky-laws-cry.md
@@ -1,0 +1,8 @@
+---
+"@layerzerolabs/ua-devtools": patch
+"@layerzerolabs/toolbox-hardhat": patch
+"@layerzerolabs/ua-devtools-evm": patch
+"@layerzerolabs/ua-devtools-evm-hardhat": patch
+---
+
+Add missing delegate configuration

--- a/packages/ua-devtools/src/oapp/config.ts
+++ b/packages/ua-devtools/src/oapp/config.ts
@@ -26,6 +26,7 @@ export const configureOApp: OAppConfigurator = async (graph, createSdk) => {
         () => configureSendConfig(graph, createSdk),
         () => configureReceiveConfig(graph, createSdk),
         () => configureEnforcedOptions(graph, createSdk),
+        () => configureOAppDelegates(graph, createSdk),
     ]
 
     // For now we keep the parallel execution as an opt-in feature flag


### PR DESCRIPTION
### In this PR

- The delegate configuration was not being executed in `lz:oapp:wire`, this fixes it