### PR TITLE
🗞️ Retry functionality for SDKs

### DIFF
--- a/.changeset/many-toys-explain.md
+++ b/.changeset/many-toys-explain.md
@@ -1,0 +1,11 @@
+---
+"@layerzerolabs/protocol-devtools-evm": patch
+"@layerzerolabs/ua-devtools-evm": patch
+"@layerzerolabs/devtools": patch
+"@layerzerolabs/devtools-evm": patch
+"@layerzerolabs/devtools-evm-hardhat": patch
+"@layerzerolabs/toolbox-hardhat": patch
+"@layerzerolabs/ua-devtools-evm-hardhat": patch
+---
+
+Adding `AsyncRetriable` to SDKs

--- a/packages/devtools/.swcrc
+++ b/packages/devtools/.swcrc
@@ -1,0 +1,11 @@
+{
+    "jsc": {
+        "parser": {
+            "syntax": "typescript",
+            "decorators": true
+        },
+        "transform": {
+            "legacyDecorator": true
+        }
+    }
+}

--- a/packages/devtools/src/common/index.ts
+++ b/packages/devtools/src/common/index.ts
@@ -1,4 +1,5 @@
 export * from './assertion'
 export * from './bytes'
 export * from './promise'
+export * from './retry'
 export * from './strings'

--- a/packages/devtools/src/common/retry.ts
+++ b/packages/devtools/src/common/retry.ts
@@ -31,9 +31,12 @@ export interface RetriableConfig<TInstance = unknown> {
     /**
      * Callback called on every failed attempt.
      *
-     * @param {number} attempt
-     * @param {unknown} error
-     * @param {this} target
+     * @param {number} attempt 1-indexed number of attempt of executing the method
+     * @param {number} numAttempts Maximum/total number of attempts that will be executed
+     * @param {unknown} error The error that caused the function to be retried
+     * @param {unknown} target The object whose method is being retried
+     * @param {string} method The method name
+     * @param {unknown[]} args The method parameters
      * @returns {boolean | undefined} This function can stop the retry train by returning false
      */
     onRetry?: OnRetry<TInstance>

--- a/packages/devtools/src/common/retry.ts
+++ b/packages/devtools/src/common/retry.ts
@@ -1,0 +1,36 @@
+import assert from 'assert'
+import { backOff } from 'exponential-backoff'
+
+export interface RetriableConfig<TInstance = unknown> {
+    numAttempts?: number
+    onRetry?: (attempt: number, error: unknown, target: TInstance) => boolean | void | undefined
+}
+
+export const AsyncRetriable = ({ numAttempts = 3, onRetry }: RetriableConfig = {}) => {
+    return function AsyncRetriableDecorator<TArgs extends unknown[], TResult>(
+        target: unknown,
+        propertyKey: string,
+        descriptor: TypedPropertyDescriptor<(...args: TArgs) => Promise<TResult>>
+    ) {
+        // Grab the original method and ensure that we are decorating a method
+        const originalMethod = descriptor.value
+        assert(
+            typeof originalMethod === 'function',
+            `AsyncRetriable must be applied to an instance method, ${propertyKey} property looks more like ${typeof originalMethod}`
+        )
+
+        // We'll wrap the retry handler from exponential backoff
+        // to make it a bit nicer to use
+        //
+        // - We'll put the attempt as the first argument
+        // - We'll add the decorator target as the last argument
+        const handleRetry = (error: unknown, attempt: number): boolean => onRetry?.(attempt, error, target) ?? true
+
+        // Create the retried method
+        const retriedMethod = (...args: TArgs): Promise<TResult> =>
+            backOff(() => originalMethod.apply(target, args), { numOfAttempts: numAttempts, retry: handleRetry })
+
+        // return our new descriptor
+        return (descriptor.value = retriedMethod), descriptor
+    }
+}

--- a/packages/devtools/src/common/retry.ts
+++ b/packages/devtools/src/common/retry.ts
@@ -23,7 +23,7 @@ export interface RetriableConfig<TInstance = unknown> {
      */
     maxDelay?: number
     /**
-     * Number of time the method call will be retried. The default is 3
+     * Number of times the method call will be retried. The default is 3
      *
      * @default 3
      */

--- a/packages/devtools/src/common/retry.ts
+++ b/packages/devtools/src/common/retry.ts
@@ -2,16 +2,55 @@ import assert from 'assert'
 import { backOff } from 'exponential-backoff'
 
 export interface RetriableConfig<TInstance = unknown> {
+    /**
+     * Enable / disable the retry behavior
+     */
+    enabled?: boolean
+    /**
+     * The maximum delay, in milliseconds, between two consecutive attempts.
+     *
+     * @default Infinity
+     */
+    maxDelay?: number
+    /**
+     * Number of time the method call will be retried. The default is 3
+     *
+     * @default 3
+     */
     numAttempts?: number
-    onRetry?: (attempt: number, error: unknown, target: TInstance) => boolean | void | undefined
+    /**
+     * Callback called on every failed attempt.
+     *
+     * @param {number} attempt
+     * @param {unknown} error
+     * @param {this} target
+     * @returns {boolean | undefined} This function can stop the retry train by returning false
+     */
+    onRetry?: <TArgs extends unknown[] = unknown[]>(
+        attempt: number,
+        error: unknown,
+        target: TInstance,
+        args: TArgs
+    ) => boolean | void | undefined
 }
 
-export const AsyncRetriable = ({ numAttempts = 3, onRetry }: RetriableConfig = {}) => {
+export const AsyncRetriable = ({
+    // We'll feature flag this functionality for the time being
+    enabled = !!process.env.LZ_EXPERIMENTAL_ENABLE_RETRY,
+    maxDelay,
+    numAttempts = 3,
+    onRetry,
+}: RetriableConfig = {}) => {
     return function AsyncRetriableDecorator<TArgs extends unknown[], TResult>(
         target: unknown,
         propertyKey: string,
         descriptor: TypedPropertyDescriptor<(...args: TArgs) => Promise<TResult>>
     ) {
+        // If we are disabled, we are disabled
+        if (!enabled) {
+            return descriptor
+        }
+
         // Grab the original method and ensure that we are decorating a method
         const originalMethod = descriptor.value
         assert(
@@ -24,11 +63,23 @@ export const AsyncRetriable = ({ numAttempts = 3, onRetry }: RetriableConfig = {
         //
         // - We'll put the attempt as the first argument
         // - We'll add the decorator target as the last argument
-        const handleRetry = (error: unknown, attempt: number): boolean => onRetry?.(attempt, error, target) ?? true
+        //
+        // We'll curry this function so that it can pass the arguments to onRetry
+        const handleRetry =
+            (args: TArgs) =>
+            (error: unknown, attempt: number): boolean =>
+                onRetry?.(attempt, error, target, args) ?? true
 
         // Create the retried method
         const retriedMethod = (...args: TArgs): Promise<TResult> =>
-            backOff(() => originalMethod.apply(target, args), { numOfAttempts: numAttempts, retry: handleRetry })
+            backOff(() => originalMethod.apply(target, args), {
+                // A typical problem in our case is 429 Too many requests
+                // which would still happen if we didn't introduce a bit of randomness into the delay
+                jitter: 'full',
+                maxDelay,
+                numOfAttempts: numAttempts,
+                retry: handleRetry(args),
+            })
 
         // return our new descriptor
         return (descriptor.value = retriedMethod), descriptor

--- a/packages/devtools/test/common/retry.test.ts
+++ b/packages/devtools/test/common/retry.test.ts
@@ -3,6 +3,11 @@ import { AsyncRetriable } from '@/common/retry'
 describe('common/retry', () => {
     describe('AsyncRetriable', () => {
         describe('when LZ_EXPERIMENTAL_ENABLE_RETRY is off', () => {
+            beforeAll(() => {
+                // We'll enable the AsyncRetriable for these tests
+                process.env.LZ_EXPERIMENTAL_ENABLE_RETRY = ''
+            })
+
             it('shoult not retry', async () => {
                 const error = new Error('Told ya')
                 const handleRetry = jest.fn()
@@ -42,12 +47,12 @@ describe('common/retry', () => {
         })
 
         describe('when LZ_EXPERIMENTAL_ENABLE_RETRY is on', () => {
-            beforeEach(() => {
+            beforeAll(() => {
                 // We'll enable the AsyncRetriable for these tests
                 process.env.LZ_EXPERIMENTAL_ENABLE_RETRY = '1'
             })
 
-            afterEach(() => {
+            afterAll(() => {
                 process.env.LZ_EXPERIMENTAL_ENABLE_RETRY = ''
             })
 

--- a/packages/devtools/test/common/retry.test.ts
+++ b/packages/devtools/test/common/retry.test.ts
@@ -1,0 +1,109 @@
+import { AsyncRetriable } from '@/common/retry'
+
+describe('common/retry', () => {
+    describe('AsyncRetriable', () => {
+        it('should retry a method call 3 times by default', async () => {
+            const error = new Error('Told ya')
+            const mock = jest.fn().mockRejectedValue(error)
+
+            class WithAsyncRetriable {
+                @AsyncRetriable()
+                async iAlwaysFail(value: string) {
+                    return mock(value)
+                }
+            }
+
+            await expect(new WithAsyncRetriable().iAlwaysFail('y')).rejects.toBe(error)
+
+            expect(mock).toHaveBeenCalledTimes(3)
+            expect(mock).toHaveBeenNthCalledWith(1, 'y')
+            expect(mock).toHaveBeenNthCalledWith(2, 'y')
+            expect(mock).toHaveBeenNthCalledWith(3, 'y')
+        })
+
+        it('should retry a method call N times if numAttempts is specified', async () => {
+            const error = new Error('Told ya')
+            const mock = jest.fn().mockRejectedValue(error)
+
+            class WithAsyncRetriable {
+                @AsyncRetriable({ numAttempts: 2 })
+                async iAlwaysFail(value: string) {
+                    return mock(value)
+                }
+            }
+
+            await expect(new WithAsyncRetriable().iAlwaysFail('y')).rejects.toBe(error)
+
+            expect(mock).toHaveBeenCalledTimes(2)
+        })
+
+        it('should stop retrying if the onRetry handler returns false', async () => {
+            const error = new Error('Told ya')
+            const mock = jest.fn().mockRejectedValue(error)
+            const handleRetry = jest
+                .fn()
+                // We check that if we return undefined/void we'll keep trying
+                .mockReturnValueOnce(undefined)
+                // We check that if we return true we keep trying
+                .mockReturnValueOnce(true)
+                // After the third attempt we return false
+                .mockReturnValueOnce(false)
+
+            class WithAsyncRetriable {
+                @AsyncRetriable({ numAttempts: 10_000, onRetry: handleRetry })
+                async iAlwaysFail(value: string) {
+                    return mock(value)
+                }
+            }
+
+            await expect(new WithAsyncRetriable().iAlwaysFail('y')).rejects.toBe(error)
+
+            expect(mock).toHaveBeenCalledTimes(3)
+            expect(handleRetry).toHaveBeenCalledTimes(3)
+        })
+
+        it('should call the onRetry callback if provided', async () => {
+            const error = new Error('Told ya')
+            const handleRetry = jest.fn()
+            const mock = jest.fn().mockRejectedValue(error)
+
+            class WithAsyncRetriable {
+                @AsyncRetriable({ onRetry: handleRetry })
+                async iAlwaysFail(value: string) {
+                    return mock(value)
+                }
+            }
+
+            const withAsyncRetriable = new WithAsyncRetriable()
+
+            await expect(withAsyncRetriable.iAlwaysFail('y')).rejects.toBe(error)
+
+            expect(handleRetry).toHaveBeenCalledTimes(3)
+            expect(handleRetry).toHaveBeenNthCalledWith(1, 1, error, withAsyncRetriable)
+            expect(handleRetry).toHaveBeenNthCalledWith(2, 2, error, withAsyncRetriable)
+            expect(handleRetry).toHaveBeenNthCalledWith(3, 3, error, withAsyncRetriable)
+        })
+
+        it('should resolve if the method resolves within the specified number of attempts', async () => {
+            const error = new Error('Told ya')
+            const value = {}
+            const handleRetry = jest.fn()
+            const mock = jest.fn().mockRejectedValueOnce(error).mockRejectedValueOnce(error).mockResolvedValue(value)
+
+            class WithAsyncRetriable {
+                @AsyncRetriable({ onRetry: handleRetry })
+                async iAlwaysFail(value: string) {
+                    return mock(value)
+                }
+            }
+
+            const withAsyncRetriable = new WithAsyncRetriable()
+
+            await expect(withAsyncRetriable.iAlwaysFail('y')).resolves.toBe(value)
+
+            expect(handleRetry).toHaveBeenCalledTimes(2)
+            expect(handleRetry).toHaveBeenNthCalledWith(1, 1, error, withAsyncRetriable)
+            expect(handleRetry).toHaveBeenNthCalledWith(2, 2, error, withAsyncRetriable)
+        })
+    })
+})

--- a/packages/devtools/test/common/retry.test.ts
+++ b/packages/devtools/test/common/retry.test.ts
@@ -2,108 +2,162 @@ import { AsyncRetriable } from '@/common/retry'
 
 describe('common/retry', () => {
     describe('AsyncRetriable', () => {
-        it('should retry a method call 3 times by default', async () => {
-            const error = new Error('Told ya')
-            const mock = jest.fn().mockRejectedValue(error)
+        describe('when LZ_EXPERIMENTAL_ENABLE_RETRY is off', () => {
+            it('shoult not retry', async () => {
+                const error = new Error('Told ya')
+                const handleRetry = jest.fn()
+                const mock = jest.fn().mockRejectedValue(error)
 
-            class WithAsyncRetriable {
-                @AsyncRetriable()
-                async iAlwaysFail(value: string) {
-                    return mock(value)
+                class WithAsyncRetriable {
+                    @AsyncRetriable({ onRetry: handleRetry })
+                    async iAlwaysFail(value: string) {
+                        return mock(value)
+                    }
                 }
-            }
 
-            await expect(new WithAsyncRetriable().iAlwaysFail('y')).rejects.toBe(error)
+                await expect(new WithAsyncRetriable().iAlwaysFail('y')).rejects.toBe(error)
 
-            expect(mock).toHaveBeenCalledTimes(3)
-            expect(mock).toHaveBeenNthCalledWith(1, 'y')
-            expect(mock).toHaveBeenNthCalledWith(2, 'y')
-            expect(mock).toHaveBeenNthCalledWith(3, 'y')
+                expect(mock).toHaveBeenCalledTimes(1)
+                expect(handleRetry).not.toHaveBeenCalled()
+            })
+
+            it('should retry if enabled is set to true', async () => {
+                const error = new Error('Told ya')
+                const mock = jest.fn().mockRejectedValue(error)
+
+                class WithAsyncRetriable {
+                    @AsyncRetriable({ enabled: true })
+                    async iAlwaysFail(value: string) {
+                        return mock(value)
+                    }
+                }
+
+                await expect(new WithAsyncRetriable().iAlwaysFail('y')).rejects.toBe(error)
+
+                expect(mock).toHaveBeenCalledTimes(3)
+                expect(mock).toHaveBeenNthCalledWith(1, 'y')
+                expect(mock).toHaveBeenNthCalledWith(2, 'y')
+                expect(mock).toHaveBeenNthCalledWith(3, 'y')
+            })
         })
 
-        it('should retry a method call N times if numAttempts is specified', async () => {
-            const error = new Error('Told ya')
-            const mock = jest.fn().mockRejectedValue(error)
+        describe('when LZ_EXPERIMENTAL_ENABLE_RETRY is on', () => {
+            beforeEach(() => {
+                // We'll enable the AsyncRetriable for these tests
+                process.env.LZ_EXPERIMENTAL_ENABLE_RETRY = '1'
+            })
 
-            class WithAsyncRetriable {
-                @AsyncRetriable({ numAttempts: 2 })
-                async iAlwaysFail(value: string) {
-                    return mock(value)
+            afterEach(() => {
+                process.env.LZ_EXPERIMENTAL_ENABLE_RETRY = ''
+            })
+
+            it('should retry a method call 3 times by default', async () => {
+                const error = new Error('Told ya')
+                const mock = jest.fn().mockRejectedValue(error)
+
+                class WithAsyncRetriable {
+                    @AsyncRetriable()
+                    async iAlwaysFail(value: string) {
+                        return mock(value)
+                    }
                 }
-            }
 
-            await expect(new WithAsyncRetriable().iAlwaysFail('y')).rejects.toBe(error)
+                await expect(new WithAsyncRetriable().iAlwaysFail('y')).rejects.toBe(error)
 
-            expect(mock).toHaveBeenCalledTimes(2)
-        })
+                expect(mock).toHaveBeenCalledTimes(3)
+                expect(mock).toHaveBeenNthCalledWith(1, 'y')
+                expect(mock).toHaveBeenNthCalledWith(2, 'y')
+                expect(mock).toHaveBeenNthCalledWith(3, 'y')
+            })
 
-        it('should stop retrying if the onRetry handler returns false', async () => {
-            const error = new Error('Told ya')
-            const mock = jest.fn().mockRejectedValue(error)
-            const handleRetry = jest
-                .fn()
-                // We check that if we return undefined/void we'll keep trying
-                .mockReturnValueOnce(undefined)
-                // We check that if we return true we keep trying
-                .mockReturnValueOnce(true)
-                // After the third attempt we return false
-                .mockReturnValueOnce(false)
+            it('should retry a method call N times if numAttempts is specified', async () => {
+                const error = new Error('Told ya')
+                const mock = jest.fn().mockRejectedValue(error)
 
-            class WithAsyncRetriable {
-                @AsyncRetriable({ numAttempts: 10_000, onRetry: handleRetry })
-                async iAlwaysFail(value: string) {
-                    return mock(value)
+                class WithAsyncRetriable {
+                    @AsyncRetriable({ numAttempts: 2 })
+                    async iAlwaysFail(value: string) {
+                        return mock(value)
+                    }
                 }
-            }
 
-            await expect(new WithAsyncRetriable().iAlwaysFail('y')).rejects.toBe(error)
+                await expect(new WithAsyncRetriable().iAlwaysFail('y')).rejects.toBe(error)
 
-            expect(mock).toHaveBeenCalledTimes(3)
-            expect(handleRetry).toHaveBeenCalledTimes(3)
-        })
+                expect(mock).toHaveBeenCalledTimes(2)
+            })
 
-        it('should call the onRetry callback if provided', async () => {
-            const error = new Error('Told ya')
-            const handleRetry = jest.fn()
-            const mock = jest.fn().mockRejectedValue(error)
+            it('should stop retrying if the onRetry handler returns false', async () => {
+                const error = new Error('Told ya')
+                const mock = jest.fn().mockRejectedValue(error)
+                const handleRetry = jest
+                    .fn()
+                    // We check that if we return undefined/void we'll keep trying
+                    .mockReturnValueOnce(undefined)
+                    // We check that if we return true we keep trying
+                    .mockReturnValueOnce(true)
+                    // After the third attempt we return false
+                    .mockReturnValueOnce(false)
 
-            class WithAsyncRetriable {
-                @AsyncRetriable({ onRetry: handleRetry })
-                async iAlwaysFail(value: string) {
-                    return mock(value)
+                class WithAsyncRetriable {
+                    @AsyncRetriable({ numAttempts: 10_000, onRetry: handleRetry })
+                    async iAlwaysFail(value: string) {
+                        return mock(value)
+                    }
                 }
-            }
 
-            const withAsyncRetriable = new WithAsyncRetriable()
+                await expect(new WithAsyncRetriable().iAlwaysFail('y')).rejects.toBe(error)
 
-            await expect(withAsyncRetriable.iAlwaysFail('y')).rejects.toBe(error)
+                expect(mock).toHaveBeenCalledTimes(3)
+                expect(handleRetry).toHaveBeenCalledTimes(3)
+            })
 
-            expect(handleRetry).toHaveBeenCalledTimes(3)
-            expect(handleRetry).toHaveBeenNthCalledWith(1, 1, error, withAsyncRetriable)
-            expect(handleRetry).toHaveBeenNthCalledWith(2, 2, error, withAsyncRetriable)
-            expect(handleRetry).toHaveBeenNthCalledWith(3, 3, error, withAsyncRetriable)
-        })
+            it('should call the onRetry callback if provided', async () => {
+                const error = new Error('Told ya')
+                const handleRetry = jest.fn()
+                const mock = jest.fn().mockRejectedValue(error)
 
-        it('should resolve if the method resolves within the specified number of attempts', async () => {
-            const error = new Error('Told ya')
-            const value = {}
-            const handleRetry = jest.fn()
-            const mock = jest.fn().mockRejectedValueOnce(error).mockRejectedValueOnce(error).mockResolvedValue(value)
-
-            class WithAsyncRetriable {
-                @AsyncRetriable({ onRetry: handleRetry })
-                async iAlwaysFail(value: string) {
-                    return mock(value)
+                class WithAsyncRetriable {
+                    @AsyncRetriable({ onRetry: handleRetry })
+                    async iAlwaysFail(value: string) {
+                        return mock(value)
+                    }
                 }
-            }
 
-            const withAsyncRetriable = new WithAsyncRetriable()
+                const withAsyncRetriable = new WithAsyncRetriable()
 
-            await expect(withAsyncRetriable.iAlwaysFail('y')).resolves.toBe(value)
+                await expect(withAsyncRetriable.iAlwaysFail('y')).rejects.toBe(error)
 
-            expect(handleRetry).toHaveBeenCalledTimes(2)
-            expect(handleRetry).toHaveBeenNthCalledWith(1, 1, error, withAsyncRetriable)
-            expect(handleRetry).toHaveBeenNthCalledWith(2, 2, error, withAsyncRetriable)
+                expect(handleRetry).toHaveBeenCalledTimes(3)
+                expect(handleRetry).toHaveBeenNthCalledWith(1, 1, error, withAsyncRetriable, ['y'])
+                expect(handleRetry).toHaveBeenNthCalledWith(2, 2, error, withAsyncRetriable, ['y'])
+                expect(handleRetry).toHaveBeenNthCalledWith(3, 3, error, withAsyncRetriable, ['y'])
+            })
+
+            it('should resolve if the method resolves within the specified number of attempts', async () => {
+                const error = new Error('Told ya')
+                const value = {}
+                const handleRetry = jest.fn()
+                const mock = jest
+                    .fn()
+                    .mockRejectedValueOnce(error)
+                    .mockRejectedValueOnce(error)
+                    .mockResolvedValue(value)
+
+                class WithAsyncRetriable {
+                    @AsyncRetriable({ onRetry: handleRetry })
+                    async iAlwaysFail(value: string) {
+                        return mock(value)
+                    }
+                }
+
+                const withAsyncRetriable = new WithAsyncRetriable()
+
+                await expect(withAsyncRetriable.iAlwaysFail('y')).resolves.toBe(value)
+
+                expect(handleRetry).toHaveBeenCalledTimes(2)
+                expect(handleRetry).toHaveBeenNthCalledWith(1, 1, error, withAsyncRetriable, ['y'])
+                expect(handleRetry).toHaveBeenNthCalledWith(2, 2, error, withAsyncRetriable, ['y'])
+            })
         })
     })
 })

--- a/packages/devtools/test/common/retry.test.ts
+++ b/packages/devtools/test/common/retry.test.ts
@@ -128,9 +128,9 @@ describe('common/retry', () => {
                 await expect(withAsyncRetriable.iAlwaysFail('y')).rejects.toBe(error)
 
                 expect(handleRetry).toHaveBeenCalledTimes(3)
-                expect(handleRetry).toHaveBeenNthCalledWith(1, 1, error, withAsyncRetriable, ['y'])
-                expect(handleRetry).toHaveBeenNthCalledWith(2, 2, error, withAsyncRetriable, ['y'])
-                expect(handleRetry).toHaveBeenNthCalledWith(3, 3, error, withAsyncRetriable, ['y'])
+                expect(handleRetry).toHaveBeenNthCalledWith(1, 1, 3, error, withAsyncRetriable, 'iAlwaysFail', ['y'])
+                expect(handleRetry).toHaveBeenNthCalledWith(2, 2, 3, error, withAsyncRetriable, 'iAlwaysFail', ['y'])
+                expect(handleRetry).toHaveBeenNthCalledWith(3, 3, 3, error, withAsyncRetriable, 'iAlwaysFail', ['y'])
             })
 
             it('should resolve if the method resolves within the specified number of attempts', async () => {
@@ -155,8 +155,8 @@ describe('common/retry', () => {
                 await expect(withAsyncRetriable.iAlwaysFail('y')).resolves.toBe(value)
 
                 expect(handleRetry).toHaveBeenCalledTimes(2)
-                expect(handleRetry).toHaveBeenNthCalledWith(1, 1, error, withAsyncRetriable, ['y'])
-                expect(handleRetry).toHaveBeenNthCalledWith(2, 2, error, withAsyncRetriable, ['y'])
+                expect(handleRetry).toHaveBeenNthCalledWith(1, 1, 3, error, withAsyncRetriable, 'iAlwaysFail', ['y'])
+                expect(handleRetry).toHaveBeenNthCalledWith(2, 2, 3, error, withAsyncRetriable, 'iAlwaysFail', ['y'])
             })
         })
     })

--- a/packages/devtools/tsconfig.json
+++ b/packages/devtools/tsconfig.json
@@ -3,6 +3,7 @@
   "exclude": ["dist", "node_modules"],
   "include": ["src", "test"],
   "compilerOptions": {
+    "experimentalDecorators": true,
     "types": ["node", "jest"],
     "paths": {
       "@/*": ["./src/*"]

--- a/packages/protocol-devtools-evm/.swcrc
+++ b/packages/protocol-devtools-evm/.swcrc
@@ -1,0 +1,11 @@
+{
+    "jsc": {
+        "parser": {
+            "syntax": "typescript",
+            "decorators": true
+        },
+        "transform": {
+            "legacyDecorator": true
+        }
+    }
+}

--- a/packages/protocol-devtools-evm/src/endpointv2/sdk.ts
+++ b/packages/protocol-devtools-evm/src/endpointv2/sdk.ts
@@ -18,6 +18,7 @@ import {
     isZero,
     ignoreZero,
     areBytes32Equal,
+    AsyncRetriable,
 } from '@layerzerolabs/devtools'
 import type { EndpointId } from '@layerzerolabs/lz-definitions'
 import { makeZeroAddress, type OmniContract, OmniSDK } from '@layerzerolabs/devtools-evm'
@@ -42,6 +43,7 @@ export class EndpointV2 extends OmniSDK implements IEndpointV2 {
         super(contract)
     }
 
+    @AsyncRetriable()
     async getDelegate(oapp: OmniAddress): Promise<OmniAddress | undefined> {
         this.logger.debug(`Getting delegate for OApp ${oapp}`)
 
@@ -67,18 +69,21 @@ export class EndpointV2 extends OmniSDK implements IEndpointV2 {
         return await this.uln302Factory({ eid: this.point.eid, address })
     }
 
+    @AsyncRetriable()
     async getDefaultReceiveLibrary(eid: EndpointId): Promise<OmniAddress | undefined> {
         this.logger.debug(`Getting default receive library for eid ${eid} (${formatEid(eid)})`)
 
         return ignoreZero(await this.contract.contract.defaultReceiveLibrary(eid))
     }
 
+    @AsyncRetriable()
     async getSendLibrary(sender: OmniAddress, dstEid: EndpointId): Promise<OmniAddress | undefined> {
         this.logger.debug(`Getting send library for eid ${dstEid} (${formatEid(dstEid)}) and address ${sender}`)
 
         return ignoreZero(await this.contract.contract.getSendLibrary(sender, dstEid))
     }
 
+    @AsyncRetriable()
     async getReceiveLibrary(
         receiver: OmniAddress,
         srcEid: EndpointId
@@ -109,12 +114,14 @@ export class EndpointV2 extends OmniSDK implements IEndpointV2 {
         }
     }
 
+    @AsyncRetriable()
     async getDefaultSendLibrary(eid: EndpointId): Promise<OmniAddress | undefined> {
         this.logger.debug(`Getting default send library for eid ${eid} (${formatEid(eid)})`)
 
         return ignoreZero(await this.contract.contract.defaultSendLibrary(eid))
     }
 
+    @AsyncRetriable()
     async isDefaultSendLibrary(sender: OmniAddress, dstEid: EndpointId): Promise<boolean> {
         this.logger.debug(
             `Checking default send library for eid ${dstEid} (${formatEid(dstEid)}) and address ${sender}`
@@ -179,6 +186,7 @@ export class EndpointV2 extends OmniSDK implements IEndpointV2 {
         }
     }
 
+    @AsyncRetriable()
     async getReceiveLibraryTimeout(receiver: OmniAddress, srcEid: EndpointId): Promise<Timeout> {
         this.logger.debug(
             `Getting receive library timeout for eid ${srcEid} (${formatEid(srcEid)}) and address ${receiver}`
@@ -189,6 +197,7 @@ export class EndpointV2 extends OmniSDK implements IEndpointV2 {
         return TimeoutSchema.parse({ ...timeout })
     }
 
+    @AsyncRetriable()
     async getDefaultReceiveLibraryTimeout(eid: EndpointId): Promise<Timeout> {
         this.logger.debug(`Getting default receive library timeout for eid ${eid} (${formatEid(eid)})`)
 
@@ -321,6 +330,7 @@ export class EndpointV2 extends OmniSDK implements IEndpointV2 {
         return ulnSdk.hasAppUlnConfig(eid, oapp, config)
     }
 
+    @AsyncRetriable()
     isRegisteredLibrary(uln: OmniAddress): Promise<boolean> {
         return this.contract.contract.isRegisteredLibrary(uln)
     }
@@ -334,6 +344,7 @@ export class EndpointV2 extends OmniSDK implements IEndpointV2 {
         }
     }
 
+    @AsyncRetriable()
     public async quote(params: MessageParams, sender: OmniAddress): Promise<MessagingFee> {
         const { nativeFee, lzTokenFee } = await this.contract.contract.quote(params, sender)
         return {

--- a/packages/protocol-devtools-evm/src/uln302/sdk.ts
+++ b/packages/protocol-devtools-evm/src/uln302/sdk.ts
@@ -15,13 +15,14 @@ import {
 import { Uln302ExecutorConfigSchema, Uln302UlnConfigSchema } from './schema'
 import assert from 'assert'
 import { printJson } from '@layerzerolabs/io-devtools'
-import { isZero } from '@layerzerolabs/devtools'
+import { isZero, AsyncRetriable } from '@layerzerolabs/devtools'
 import { OmniSDK, addChecksum, makeZeroAddress } from '@layerzerolabs/devtools-evm'
 
 export class Uln302 extends OmniSDK implements IUln302 {
     /**
      * @see {@link IUln302.getUlnConfig}
      */
+    @AsyncRetriable()
     async getUlnConfig(eid: EndpointId, address?: OmniAddress | null | undefined): Promise<Uln302UlnConfig> {
         this.logger.debug(
             `Getting ULN config for eid ${eid} (${formatEid(eid)}) and address ${makeZeroAddress(address)}`
@@ -38,6 +39,7 @@ export class Uln302 extends OmniSDK implements IUln302 {
     /**
      * @see {@link IUln302.getAppUlnConfig}
      */
+    @AsyncRetriable()
     async getAppUlnConfig(eid: EndpointId, address: OmniAddress): Promise<Uln302UlnConfig> {
         this.logger.debug(
             `Getting ULN config for eid ${eid} (${formatEid(eid)}) and address ${makeZeroAddress(address)}`
@@ -73,6 +75,7 @@ export class Uln302 extends OmniSDK implements IUln302 {
     /**
      * @see {@link IUln302.getExecutorConfig}
      */
+    @AsyncRetriable()
     async getExecutorConfig(eid: EndpointId, address?: OmniAddress | null | undefined): Promise<Uln302ExecutorConfig> {
         const config = await this.contract.contract.getExecutorConfig(makeZeroAddress(address), eid)
 
@@ -86,6 +89,7 @@ export class Uln302 extends OmniSDK implements IUln302 {
     /**
      * @see {@link IUln302.getAppExecutorConfig}
      */
+    @AsyncRetriable()
     async getAppExecutorConfig(eid: EndpointId, address: OmniAddress): Promise<Uln302ExecutorConfig> {
         const config = await this.contract.contract.executorConfigs(makeZeroAddress(address), eid)
 

--- a/packages/protocol-devtools-evm/tsconfig.json
+++ b/packages/protocol-devtools-evm/tsconfig.json
@@ -3,6 +3,7 @@
   "exclude": ["dist", "node_modules"],
   "include": ["src", "test", "*.config.ts"],
   "compilerOptions": {
+    "experimentalDecorators": true,
     "types": ["node", "jest"],
     "paths": {
       "@/*": ["./src/*"]

--- a/packages/ua-devtools-evm/.swcrc
+++ b/packages/ua-devtools-evm/.swcrc
@@ -1,0 +1,11 @@
+{
+    "jsc": {
+        "parser": {
+            "syntax": "typescript",
+            "decorators": true
+        },
+        "transform": {
+            "legacyDecorator": true
+        }
+    }
+}

--- a/packages/ua-devtools-evm/src/lzapp/sdk.ts
+++ b/packages/ua-devtools-evm/src/lzapp/sdk.ts
@@ -6,6 +6,7 @@ import {
     areBytes32Equal,
     ignoreZero,
     makeBytes32,
+    AsyncRetriable,
 } from '@layerzerolabs/devtools'
 import { type OmniContract, parseGenericError } from '@layerzerolabs/devtools-evm'
 import type { EndpointId } from '@layerzerolabs/lz-definitions'
@@ -16,6 +17,7 @@ export class LzApp extends OmniSDK implements ILzApp {
         super(contract)
     }
 
+    @AsyncRetriable()
     async getTrustedRemote(eid: EndpointId): Promise<OmniAddress | undefined> {
         this.logger.debug(`Getting trusted remote for eid ${eid} (${formatEid(eid)})`)
 

--- a/packages/ua-devtools-evm/src/oapp/sdk.ts
+++ b/packages/ua-devtools-evm/src/oapp/sdk.ts
@@ -15,7 +15,7 @@ import type { EndpointId } from '@layerzerolabs/lz-definitions'
 import type { EndpointV2Factory, IEndpointV2 } from '@layerzerolabs/protocol-devtools'
 import { OmniSDK } from '@layerzerolabs/devtools-evm'
 import { printJson } from '@layerzerolabs/io-devtools'
-import { mapError } from '@layerzerolabs/devtools'
+import { mapError, AsyncRetriable } from '@layerzerolabs/devtools'
 import { OwnableMixin } from '@/ownable/mixin'
 
 export class OApp extends OmniSDK implements IOApp {
@@ -26,6 +26,7 @@ export class OApp extends OmniSDK implements IOApp {
         super(contract)
     }
 
+    @AsyncRetriable()
     getOwner(): Promise<string> {
         // TODO This is a quick and dirty way of applying OwnableMixin
         //
@@ -38,6 +39,7 @@ export class OApp extends OmniSDK implements IOApp {
         return OwnableMixin.getOwner.call(this)
     }
 
+    @AsyncRetriable()
     hasOwner(address: string): Promise<boolean> {
         // TODO This is a quick and dirty way of applying OwnableMixin
         //
@@ -62,6 +64,7 @@ export class OApp extends OmniSDK implements IOApp {
         return OwnableMixin.setOwner.call(this, address)
     }
 
+    @AsyncRetriable()
     async getEndpointSDK(): Promise<IEndpointV2> {
         this.logger.debug(`Getting EndpointV2 SDK`)
 
@@ -84,6 +87,7 @@ export class OApp extends OmniSDK implements IOApp {
         return await this.endpointV2Factory({ address, eid: this.contract.eid })
     }
 
+    @AsyncRetriable()
     async getPeer(eid: EndpointId): Promise<Bytes32 | undefined> {
         const eidLabel = `eid ${eid} (${formatEid(eid)})`
 
@@ -110,6 +114,7 @@ export class OApp extends OmniSDK implements IOApp {
         }
     }
 
+    @AsyncRetriable()
     async getDelegate(): Promise<OmniAddress | undefined> {
         this.logger.debug(`Getting delegate`)
 
@@ -122,6 +127,7 @@ export class OApp extends OmniSDK implements IOApp {
         return this.logger.debug(delegate ? `Got delegate ${delegate}` : `OApp has no delegate`), delegate
     }
 
+    @AsyncRetriable()
     async isDelegate(delegate: OmniAddress): Promise<boolean> {
         this.logger.debug(`Checking whether ${delegate} is a delegate`)
 
@@ -145,6 +151,7 @@ export class OApp extends OmniSDK implements IOApp {
         }
     }
 
+    @AsyncRetriable()
     async getEnforcedOptions(eid: EndpointId, msgType: number): Promise<Bytes> {
         const eidLabel = `eid ${eid} (${formatEid(eid)})`
 

--- a/packages/ua-devtools-evm/tsconfig.json
+++ b/packages/ua-devtools-evm/tsconfig.json
@@ -3,6 +3,7 @@
   "exclude": ["dist", "node_modules"],
   "include": ["src", "test"],
   "compilerOptions": {
+    "experimentalDecorators": true,
     "types": ["node", "jest"],
     "paths": {
       "@/*": ["./src/*"]

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,6 @@
     "importHelpers": true,
     "noEmit": true,
     "declaration": true,
-    "experimentalDecorators": true,
     "forceConsistentCasingInFileNames": true,
     "sourceMap": true,
     "strict": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,7 @@
     "importHelpers": true,
     "noEmit": true,
     "declaration": true,
+    "experimentalDecorators": true,
     "forceConsistentCasingInFileNames": true,
     "sourceMap": true,
     "strict": true,
@@ -31,6 +32,6 @@
     "resolveJsonModule": true,
     "types": ["node"],
     "skipLibCheck": true,
-    "stripInternal": true,
-  },
+    "stripInternal": true
+  }
 }


### PR DESCRIPTION
### In this PR

- Adding `AsyncRetriable` decorator factory that can be applied to an `async` method and produces an `async` method that will retry its execution if it rejects
- This functionality is for now feature-flagged under `LZ_EXPERIMENTAL_ENABLE_RETRY` environment variable
- Since we compile `jest` test with `swc`, an additional `.swcrc` needed to be added for jest to be able to handle decorators