### PR TITLE
🧹 Add default Manta verify contract url

### DIFF
--- a/.changeset/purple-poems-pump.md
+++ b/.changeset/purple-poems-pump.md
@@ -1,0 +1,5 @@
+---
+"@layerzerolabs/verify-contract": patch
+---
+
+Add a default verify url for Manta

--- a/packages/verify-contract/src/common/url.ts
+++ b/packages/verify-contract/src/common/url.ts
@@ -77,4 +77,5 @@ const DEFAULT_SCAN_API_URLS: Map<NetworkName, string> = new Map([
     ['mode', 'https://explorer.mode.network/api'],
     ['etherlink', 'https://explorer.etherlink.com/api'],
     ['blast', 'https://api.blastscan.io/api'],
+    ['manta', 'https://pacific-explorer.manta.network/api'],
 ])


### PR DESCRIPTION
Adds a default url to be used when verifying contracts on Manta