### PR TITLE
🧹 Consistent feature flag names; Bit of docs on some of the experimental features

### DIFF
--- a/.changeset/short-melons-approve.md
+++ b/.changeset/short-melons-approve.md
@@ -1,0 +1,5 @@
+---
+"@layerzerolabs/devtools": patch
+---
+
+Update name of the LZ_ENABLE_EXPERIMENTAL_RETRY feature flag

--- a/EXPERIMENTAL.md
+++ b/EXPERIMENTAL.md
@@ -1,0 +1,47 @@
+<p align="center">
+  <a href="https://layerzero.network">
+    <img alt="LayerZero" style="max-width: 500px" src="https://d3a2dpnnrypp5h.cloudfront.net/bridge-app/lz.png"/>
+  </a>
+</p>
+
+<p align="center">
+  <a href="https://layerzero.network" style="color: #a77dff">Homepage</a> | <a href="https://docs.layerzero.network/" style="color: #a77dff">Docs</a> | <a href="https://layerzero.network/developers" style="color: #a77dff">Developers</a>
+</p>
+
+<h1 align="center">Experimental Functionality</h1>
+
+This document lists the functionality that can be enabled using environment variables.
+
+---
+
+**Please note** that this functionality is marked _experimental_ for a reason and should be used with caution. We welcome feedback and will try to provide support but until the _experimental_ label is removed, we cannot guarantee that this functionality will work for all setups.
+
+---
+
+## Parallel configuration <a id="parallel-configuration"></a>
+
+By default, the RPC calls that check the current state of your contracts are executed in series. For large projects, this process can take some time as the number of connections between `N` contracts is in the order of <code>N<sup>2</sup></code>.
+
+Parallel execution can improve the speed of this process significantly. However, since it requires a large number of RPC calls to be executed simultaneously, it can result in `HTTP 429 Too Many Requests` RPC errors when used with public RPCs.
+
+In general, we recommend combining this feature with <a href="#automatic-retries">automatic retries</a>.
+
+### To enable
+
+`LZ_EXPERIMENTAL_ENABLE_PARALLEL_EXECUTION=1`
+
+### To disable
+
+`LZ_EXPERIMENTAL_ENABLE_PARALLEL_EXECUTION=`
+
+## Automatic retries <a id="automatic-retries"></a>
+
+By default, the RPC calls that check the current state of your contracts are executed without retrying any failed requests. This feature flag enables an exponential backoff retry functionality on the RPC reads.
+
+### To enable
+
+`LZ_ENABLE_EXPERIMENTAL_RETRY=1`
+
+### To disable
+
+`LZ_ENABLE_EXPERIMENTAL_RETRY=`

--- a/packages/devtools/src/common/retry.ts
+++ b/packages/devtools/src/common/retry.ts
@@ -56,7 +56,7 @@ export const createDefaultRetryHandler = (loggerName: string = 'AsyncRetriable')
 
 export const AsyncRetriable = ({
     // We'll feature flag this functionality for the time being
-    enabled = !!process.env.LZ_EXPERIMENTAL_ENABLE_RETRY,
+    enabled = !!process.env.LZ_ENABLE_EXPERIMENTAL_RETRY,
     maxDelay,
     numAttempts = 3,
     onRetry = createDefaultRetryHandler(),

--- a/packages/devtools/test/common/retry.test.ts
+++ b/packages/devtools/test/common/retry.test.ts
@@ -2,10 +2,10 @@ import { AsyncRetriable } from '@/common/retry'
 
 describe('common/retry', () => {
     describe('AsyncRetriable', () => {
-        describe('when LZ_EXPERIMENTAL_ENABLE_RETRY is off', () => {
+        describe('when LZ_ENABLE_EXPERIMENTAL_RETRY is off', () => {
             beforeAll(() => {
                 // We'll enable the AsyncRetriable for these tests
-                process.env.LZ_EXPERIMENTAL_ENABLE_RETRY = ''
+                process.env.LZ_ENABLE_EXPERIMENTAL_RETRY = ''
             })
 
             it('shoult not retry', async () => {
@@ -46,14 +46,14 @@ describe('common/retry', () => {
             })
         })
 
-        describe('when LZ_EXPERIMENTAL_ENABLE_RETRY is on', () => {
+        describe('when LZ_ENABLE_EXPERIMENTAL_RETRY is on', () => {
             beforeAll(() => {
                 // We'll enable the AsyncRetriable for these tests
-                process.env.LZ_EXPERIMENTAL_ENABLE_RETRY = '1'
+                process.env.LZ_ENABLE_EXPERIMENTAL_RETRY = '1'
             })
 
             afterAll(() => {
-                process.env.LZ_EXPERIMENTAL_ENABLE_RETRY = ''
+                process.env.LZ_ENABLE_EXPERIMENTAL_RETRY = ''
             })
 
             it('should retry a method call 3 times by default', async () => {


### PR DESCRIPTION
### In this PR

- Use `LZ_ENABLE_EXPERIMENTAL_XXX` for all feature flags
- Add a stub markdown file that lists some of the feature flags we have (local simulation is missing but that's for another time)