### PR TITLE
🗞️ Support local network environments

### DIFF
--- a/.changeset/pretty-trainers-grab.md
+++ b/.changeset/pretty-trainers-grab.md
@@ -1,0 +1,6 @@
+---
+"@layerzerolabs/devtools-evm-hardhat": patch
+"@layerzerolabs/toolbox-hardhat": patch
+---
+
+Support local LayerZero environments

--- a/packages/devtools-evm-hardhat/src/config.ts
+++ b/packages/devtools-evm-hardhat/src/config.ts
@@ -75,7 +75,7 @@ export const withLayerZeroDeployments = (...packageNames: string[]) => {
 
                     try {
                         // This operation is unsafe and can throw - let's make sure we don't explode with some unreadable error
-                        const layerZeroNetworkName = endpointIdToNetwork(eid)
+                        const layerZeroNetworkName = endpointIdToNetwork(eid, networkConfig?.isLocalEid)
                         const layerZeroNetworkDeploymentsDirectories = resolvedDeploymentsDirectories.map(
                             (deploymentsDirectory) => join(deploymentsDirectory, layerZeroNetworkName)
                         )

--- a/packages/devtools-evm-hardhat/src/type-extensions.ts
+++ b/packages/devtools-evm-hardhat/src/type-extensions.ts
@@ -27,6 +27,17 @@ declare module 'hardhat/types/config' {
         eid?: EndpointId
 
         /**
+         * Use a "local" LayerZero environment for the network.
+         *
+         * Local environments are postfixed with `-local` in the deployment directories
+         * and represent contracts deployed to ephemerous development networks.
+         *
+         * Local environments cannot coexists with their non-local counterparts
+         * in hardhat configs since they share the same `eid`
+         */
+        isLocalEid?: boolean
+
+        /**
          * Optional gnosis safe config.
          */
         safeConfig?: SafeConfig
@@ -43,6 +54,17 @@ declare module 'hardhat/types/config' {
          * for LayerZero protocol contracts using the standard hardhat deploy methods
          */
         eid?: EndpointId
+
+        /**
+         * Use a "local" LayerZero environment for the network.
+         *
+         * Local environments are postfixed with `-local` in the deployment directories
+         * and represent contracts deployed to ephemerous development networks
+         *
+         * Local environments cannot coexists with their non-local counterparts
+         * in hardhat configs since they share the same `eid`
+         */
+        isLocalEid?: boolean
 
         /**
          * Optional gnosis safe config.

--- a/packages/devtools-evm-hardhat/test/config.test.ts
+++ b/packages/devtools-evm-hardhat/test/config.test.ts
@@ -79,6 +79,33 @@ describe('config', () => {
             })
         })
 
+        it('should append local deployments is isLocalEid is truthy', () => {
+            const config = {
+                networks: {
+                    'vengaboys-testnet': {
+                        eid: EndpointId.ARBITRUM_MAINNET,
+                        isLocalEid: true,
+                    },
+                },
+            }
+
+            expect(withLayerZeroDeployments('@layerzerolabs/lz-evm-sdk-v1')(config)).toEqual({
+                networks: {
+                    'vengaboys-testnet': {
+                        eid: EndpointId.ARBITRUM_MAINNET,
+                        isLocalEid: true,
+                    },
+                },
+                external: {
+                    deployments: {
+                        'vengaboys-testnet': [
+                            join(resolvedLzEvmSdkPackageJson, 'deployments', 'arbitrum-mainnet-local'),
+                        ],
+                    },
+                },
+            })
+        })
+
         it('should not append duplicate external deployments for all networks', () => {
             const config = {
                 networks: {


### PR DESCRIPTION
### In this PR

- Support `-local` networks in hardhat config. These are ephemeral networks mostly used internally
- The shortcoming here is that since they share an `eid` with their non-local counterparts, these cannot coexist in the hardhat config