### PR TITLE
🗞️ Add the ability to inherit task definitions

### DIFF
--- a/.changeset/slow-ligers-sit.md
+++ b/.changeset/slow-ligers-sit.md
@@ -1,0 +1,6 @@
+---
+"@layerzerolabs/devtools-evm-hardhat": patch
+"@layerzerolabs/toolbox-hardhat": patch
+---
+
+Add the ability to inherit task definitions


### PR DESCRIPTION
### In this PR

- This feature aims at complex projects with multiple custom configurations. These projects can create custom copies of already existing tasks without overriding them - basically inheriting all the `task`/`subtask` setup and adding their own custom logic

```typescript
import { inheritTask } from '@layerzerolabs/devtools-evm-hardhat'
import { TASK_LZ_OAPP_WIRE } from '@layerzerolabs/ua-devtools-evm-hardhat'

const inheritWireTask = inheritTask(TASK_LZ_OAPP_WIRE)

// This custom task will have access to all the flags & parameters of the wire task
// so it can adjust & pass them to the original wire or do something completely different
inheritWireTask('my-custom-wire-of-type-A').setAction(async ({ ci, oappConfig, /* ... */ }) => {})

// And you can create multiple copies
inheritWireTask('my-custom-wire-of-type-B').setAction(async ({ ci, oappConfig, /* ... */ }) => {})
```