### PR TITLE
🗞️ Helpers for reducing boilerplate for custom configurations

### DIFF
--- a/.changeset/beige-lies-scream.md
+++ b/.changeset/beige-lies-scream.md
@@ -1,0 +1,7 @@
+---
+"@layerzerolabs/devtools": patch
+"@layerzerolabs/toolbox-foundry": patch
+"@layerzerolabs/toolbox-hardhat": patch
+---
+
+Add boilerplate reducing helpers for configuration

--- a/packages/devtools/src/omnigraph/config.ts
+++ b/packages/devtools/src/omnigraph/config.ts
@@ -1,0 +1,84 @@
+import type { Factory } from '@/types'
+import type { Configurator, IOmniSDK, InferOmniEdge, InferOmniNode, OmniGraph, OmniSDKFactory } from './types'
+import type { OmniTransaction } from '@/transactions/types'
+import { flattenTransactions } from '@/transactions/utils'
+
+export type CreateTransactionsFromOmniNodes<TOmniGraph extends OmniGraph = OmniGraph, TOmniSDK = IOmniSDK> = Factory<
+    [InferOmniNode<TOmniGraph>, TOmniSDK, TOmniGraph, OmniSDKFactory<TOmniSDK>],
+    OmniTransaction[] | OmniTransaction | null | undefined
+>
+
+export type CreateTransactionsFromOmniEdges<TOmniGraph extends OmniGraph = OmniGraph, TOmniSDK = IOmniSDK> = Factory<
+    [InferOmniEdge<TOmniGraph>, TOmniSDK, TOmniGraph, OmniSDKFactory<TOmniSDK>],
+    OmniTransaction[] | OmniTransaction | null | undefined
+>
+
+/**
+ * Function that takes care of the boilerplate for node configuration functions.
+ *
+ * It will create an SDK for every node in the graph, then call `createTransactions`
+ * with the node itself, the created SDK, the whole graph and the SDK factory.
+ *
+ * ```
+ * const configureSomething = createConfigureNodes(async ({ config }: OmniNode<{ something: string }>, sdk) => {
+ *   const something = await sdk.getSomething()
+ *   if (something !== config.something) return []
+ *
+ *   return sdk.setSomething(config.something)
+ * })
+ * ```
+ *
+ * @template TOmniGraph
+ * @template TOmniSDK
+ * @param {CreateTransactionsFromOmniNodes<TOmniGraph, TOmniSDK>} createTransactions
+ * @returns {Configurator<TOmniGraph, TOmniSDK>}
+ */
+export const createConfigureNodes =
+    <TOmniGraph extends OmniGraph = OmniGraph, TOmniSDK = IOmniSDK>(
+        createTransactions: CreateTransactionsFromOmniNodes<TOmniGraph, TOmniSDK>
+    ): Configurator<TOmniGraph, TOmniSDK> =>
+    async (graph, createSdk) =>
+        flattenTransactions(
+            await Promise.all(
+                graph.contracts.map(async (node) => {
+                    const sdk = await createSdk(node.point)
+
+                    return await createTransactions(node, sdk, graph, createSdk)
+                })
+            )
+        )
+
+/**
+ * Function that takes care of the boilerplate for edge configuration functions.
+ *
+ * It will create an SDK for every edge (using the `from` field) in the graph, then call `createTransactions`
+ * with the edge itself, the created SDK, the whole graph and the SDK factory.
+ *
+ * ```
+ * const configureSomething = createConfigureEdges(async ({ config, vector: { to } }: OmniEdge<{ something: string }>, sdk) => {
+ *   const something = await sdk.getSomethingFor(to.eid)
+ *   if (something !== config.something) return []
+ *
+ *   return sdk.setSomething(to.eid, config.something)
+ * })
+ * ```
+ *
+ * @template TOmniGraph
+ * @template TOmniSDK
+ * @param {CreateTransactionsFromOmniEdges<TOmniGraph, TOmniSDK>} createTransactions
+ * @returns {Configurator<TOmniGraph, TOmniSDK>}
+ */
+export const createConfigureEdges =
+    <TOmniGraph extends OmniGraph = OmniGraph, TOmniSDK = IOmniSDK>(
+        createTransactions: CreateTransactionsFromOmniEdges<TOmniGraph, TOmniSDK>
+    ): Configurator<TOmniGraph, TOmniSDK> =>
+    async (graph, createSdk) =>
+        flattenTransactions(
+            await Promise.all(
+                graph.connections.map(async (edge) => {
+                    const sdk = await createSdk(edge.vector.from)
+
+                    return await createTransactions(edge, sdk, graph, createSdk)
+                })
+            )
+        )

--- a/packages/devtools/src/omnigraph/index.ts
+++ b/packages/devtools/src/omnigraph/index.ts
@@ -1,4 +1,5 @@
 export * from './builder'
+export * from './config'
 export * from './coordinates'
 export * from './map'
 export * from './format'

--- a/packages/devtools/src/omnigraph/types.ts
+++ b/packages/devtools/src/omnigraph/types.ts
@@ -60,6 +60,16 @@ export interface OmniGraph<TNodeConfig = unknown, TEdgeConfig = unknown> {
 }
 
 /**
+ * Helper type for inferring the type of element in the `contracts` array of an `OmniGraph`
+ */
+export type InferOmniNode<TOmniGraph extends OmniGraph> = TOmniGraph['contracts'][number]
+
+/**
+ * Helper type for inferring the type of element in the `connections` array of an `OmniGraph`
+ */
+export type InferOmniEdge<TOmniGraph extends OmniGraph> = TOmniGraph['connections'][number]
+
+/**
  * Helper type that adds eid property to an underlying type
  */
 export type WithEid<TValue> = TValue & { eid: EndpointId }

--- a/packages/devtools/test/omnigraph/config.test.ts
+++ b/packages/devtools/test/omnigraph/config.test.ts
@@ -1,0 +1,170 @@
+import { OmniEdge, OmniGraph, OmniNode, OmniPoint, createConfigureEdges, createConfigureNodes } from '@/omnigraph'
+import { createEdgeArbitrary, createNodeArbitrary } from '../__utils__/arbitraries'
+import fc from 'fast-check'
+
+describe('omnigraph/config', () => {
+    const nodeArbitrary = createNodeArbitrary(fc.anything())
+    const nodesArbitrary = fc.array(nodeArbitrary)
+    const edgeArbitrary = createEdgeArbitrary(fc.anything())
+    const edgesArbitrary = fc.array(edgeArbitrary)
+
+    describe('createConfigureNodes', () => {
+        it('should do nothing for a graph with no nodes', async () => {
+            const createSdk = jest.fn()
+            const configureNode = jest.fn()
+            const configureNodes = createConfigureNodes<OmniGraph>(configureNode)
+
+            await expect(configureNodes({ contracts: [], connections: [] }, createSdk)).resolves.toEqual([])
+
+            expect(createSdk).not.toHaveBeenCalled()
+            expect(configureNode).not.toHaveBeenCalled()
+        })
+
+        it('should return an empty array if configuration function returns null, undefined or an empty array', async () => {
+            const createSdk = jest.fn()
+            const configureNode = jest.fn()
+            const configureNodes = createConfigureNodes<OmniGraph>(configureNode)
+
+            await fc.assert(
+                fc.asyncProperty(nodesArbitrary, async (contracts) => {
+                    createSdk.mockClear()
+                    configureNode.mockClear()
+
+                    // We mock the node configurator to only return empty values
+                    configureNode.mockResolvedValueOnce(null).mockResolvedValueOnce(undefined).mockResolvedValue([])
+
+                    const graph = { contracts, connections: [] }
+                    await expect(configureNodes(graph, createSdk)).resolves.toEqual([])
+
+                    expect(createSdk).toHaveBeenCalledTimes(contracts.length)
+                    expect(configureNode).toHaveBeenCalledTimes(contracts.length)
+                })
+            )
+        })
+
+        it('should create an SDK and execute configurator for every node', async () => {
+            // Just some random SDK factory
+            const createSdk = jest.fn().mockImplementation((point: OmniPoint) => ({ sdkFor: point }))
+            // And a configuration function that returns something that we can identify in the result
+            const configureNode = jest
+                .fn()
+                .mockImplementation((node: OmniNode, sdk: unknown) => ({ point: node.point, sdk }))
+            const configureNodes = createConfigureNodes<OmniGraph>(configureNode)
+
+            await fc.assert(
+                fc.asyncProperty(nodesArbitrary, async (contracts) => {
+                    createSdk.mockClear()
+                    configureNode.mockClear()
+
+                    const graph = { contracts, connections: [] }
+                    const transactions = await configureNodes(graph, createSdk)
+
+                    // First we check that the transactions match what our configuration function would return
+                    expect(transactions).toHaveLength(contracts.length)
+                    expect(transactions).toEqual(
+                        contracts.map(({ point }) => ({
+                            point,
+                            sdk: {
+                                sdkFor: point,
+                            },
+                        }))
+                    )
+
+                    // Then we check that the configurations have been called properly
+                    expect(createSdk).toHaveBeenCalledTimes(contracts.length)
+                    expect(configureNode).toHaveBeenCalledTimes(contracts.length)
+
+                    for (const contract of contracts) {
+                        expect(createSdk).toHaveBeenCalledWith(contract.point)
+                        expect(configureNode).toHaveBeenCalledWith(
+                            contract,
+                            expect.objectContaining({ sdkFor: contract.point }),
+                            graph,
+                            createSdk
+                        )
+                    }
+                })
+            )
+        })
+    })
+
+    describe('createConfigureEdges', () => {
+        it('should do nothing for a graph with no connections', async () => {
+            const createSdk = jest.fn()
+            const configureEdge = jest.fn()
+            const configureEdges = createConfigureEdges<OmniGraph>(configureEdge)
+
+            await expect(configureEdges({ contracts: [], connections: [] }, createSdk)).resolves.toEqual([])
+
+            expect(createSdk).not.toHaveBeenCalled()
+            expect(configureEdge).not.toHaveBeenCalled()
+        })
+
+        it('should return an empty array if configuration function returns null, undefined or an empty array', async () => {
+            const createSdk = jest.fn()
+            const configureEdge = jest.fn()
+            const configureEdges = createConfigureEdges<OmniGraph>(configureEdge)
+
+            await fc.assert(
+                fc.asyncProperty(edgesArbitrary, async (connections) => {
+                    createSdk.mockClear()
+                    configureEdge.mockClear()
+
+                    // We mock the node configurator to only return empty values
+                    configureEdge.mockResolvedValueOnce(null).mockResolvedValueOnce(undefined).mockResolvedValue([])
+
+                    const graph = { contracts: [], connections }
+                    await expect(configureEdges(graph, createSdk)).resolves.toEqual([])
+
+                    expect(createSdk).toHaveBeenCalledTimes(connections.length)
+                    expect(configureEdge).toHaveBeenCalledTimes(connections.length)
+                })
+            )
+        })
+
+        it('should create an SDK and execute configurator for every connection', async () => {
+            // Just some random SDK factory
+            const createSdk = jest.fn().mockImplementation((point: OmniPoint) => ({ sdkFor: point }))
+            // And a configuration function that returns something that we can identify in the result
+            const configureEdge = jest
+                .fn()
+                .mockImplementation((edge: OmniEdge, sdk: unknown) => ({ vector: edge.vector, sdk }))
+            const configureEdges = createConfigureEdges<OmniGraph>(configureEdge)
+
+            await fc.assert(
+                fc.asyncProperty(edgesArbitrary, async (connections) => {
+                    createSdk.mockClear()
+                    configureEdge.mockClear()
+
+                    const graph = { contracts: [], connections }
+                    const transactions = await configureEdges(graph, createSdk)
+
+                    // First we check that the transactions match what our configuration function would return
+                    expect(transactions).toHaveLength(connections.length)
+                    expect(transactions).toEqual(
+                        connections.map(({ vector }) => ({
+                            vector,
+                            sdk: {
+                                sdkFor: vector.from,
+                            },
+                        }))
+                    )
+
+                    // Then we check that the configurations have been called properly
+                    expect(createSdk).toHaveBeenCalledTimes(connections.length)
+                    expect(configureEdge).toHaveBeenCalledTimes(connections.length)
+
+                    for (const contract of connections) {
+                        expect(createSdk).toHaveBeenCalledWith(contract.vector.from)
+                        expect(configureEdge).toHaveBeenCalledWith(
+                            contract,
+                            expect.objectContaining({ sdkFor: contract.vector.from }),
+                            graph,
+                            createSdk
+                        )
+                    }
+                })
+            )
+        })
+    })
+})


### PR DESCRIPTION
### In this PR

- `createConfigureNodes` and `createConfigureEdges` helper functions to reduce the boilerplate for large, custom configurations. These perform the SDK creation, `contracts` / `connections` mapping to `OmniTransaction` objects