### PR TITLE
🗞️ Helper for executing multiple configuration functions

### DIFF
--- a/.changeset/pink-apricots-live.md
+++ b/.changeset/pink-apricots-live.md
@@ -1,0 +1,7 @@
+---
+"@layerzerolabs/ua-devtools": patch
+"@layerzerolabs/devtools": patch
+"@layerzerolabs/toolbox-hardhat": patch
+---
+
+Add createConfigureMultiple helper function

--- a/packages/ua-devtools/src/lzapp/config.ts
+++ b/packages/ua-devtools/src/lzapp/config.ts
@@ -1,26 +1,11 @@
 import {
     flattenTransactions,
     formatOmniVector,
-    parallel,
     type OmniTransaction,
-    sequence,
+    createConfigureMultiple,
 } from '@layerzerolabs/devtools'
 import { LzAppConfigurator } from './types'
 import { createModuleLogger, printBoolean } from '@layerzerolabs/io-devtools'
-
-export const configureLzApp: LzAppConfigurator = async (graph, createSdk) => {
-    const logger = createModuleLogger('LzApp')
-    const tasks = [() => configureLzAppTrustedRemotes(graph, createSdk)]
-    // For now we keep the parallel execution as an opt-in feature flag
-    // before we have a retry logic fully in place for the SDKs
-    //
-    // This is to avoid 429 too many requests errors from the RPCs
-    const applicative = process.env.LZ_ENABLE_EXPERIMENTAL_PARALLEL_EXECUTION
-        ? (logger.warn(`You are using experimental parallel configuration`), parallel)
-        : sequence
-
-    return flattenTransactions(await applicative(tasks))
-}
 
 export const configureLzAppTrustedRemotes: LzAppConfigurator = async (graph, createSdk) => {
     const logger = createModuleLogger('LzApp')
@@ -44,3 +29,5 @@ export const configureLzAppTrustedRemotes: LzAppConfigurator = async (graph, cre
         )
     )
 }
+
+export const configureLzApp: LzAppConfigurator = createConfigureMultiple(configureLzAppTrustedRemotes)


### PR DESCRIPTION
### In this PR

- `createConfigureMultiple` function has been promoted from a local implementation to a utility so that the world can use it should the world want to use it
- In these turbulent times the world should have a choice to use it