### PR TITLE
🧹 Add withEid helper

### DIFF
--- a/.changeset/pink-apricots-live.md
+++ b/.changeset/pink-apricots-live.md
@@ -1,0 +1,7 @@
+---
+"@layerzerolabs/ua-devtools": patch
+"@layerzerolabs/devtools": patch
+"@layerzerolabs/toolbox-hardhat": patch
+---
+
+Add createConfigureMultiple helper function

--- a/.changeset/strange-balloons-tie.md
+++ b/.changeset/strange-balloons-tie.md
@@ -1,0 +1,6 @@
+---
+"@layerzerolabs/ua-devtools": patch
+"@layerzerolabs/devtools": patch
+---
+
+Add withEid utility

--- a/packages/devtools/src/omnigraph/coordinates.ts
+++ b/packages/devtools/src/omnigraph/coordinates.ts
@@ -1,5 +1,5 @@
-import { endpointIdToStage } from '@layerzerolabs/lz-definitions'
-import { OmniVector, OmniPoint, OmniNode } from './types'
+import { EndpointId, endpointIdToStage } from '@layerzerolabs/lz-definitions'
+import { OmniVector, OmniPoint, OmniNode, WithEid } from './types'
 
 /**
  * Compares two points by value
@@ -71,3 +71,19 @@ export const serializeVector = ({ from, to }: OmniVector): string => `${serializ
  * @returns `OmniVector`
  */
 export const vectorFromNodes = (a: OmniNode, b: OmniNode): OmniVector => ({ from: a.point, to: b.point })
+
+/**
+ * Helper function to add an `eid` to arbitrary values, converting them to `WithEid`
+ *
+ * This is useful to reduce repetition when e.g. creating multiple `OmniPoint` instances on the same network:
+ *
+ * ```
+ * const onMainnet = withEid(EndpointId.ETHEREUM_V2_MAINNET)
+ *
+ * const onePoint = onMainnet({ address: '0x0' })
+ * const anotherPoint = onMainnet({ address: '0x1' })
+ * ```
+ */
+export const withEid =
+    (eid: EndpointId) =>
+    <T>(value: T): WithEid<T> => ({ ...value, eid })

--- a/packages/devtools/test/omnigraph/coordinates.test.ts
+++ b/packages/devtools/test/omnigraph/coordinates.test.ts
@@ -6,6 +6,7 @@ import {
     serializeVector,
     areSameEndpoint,
     isVectorPossible,
+    withEid,
 } from '@/omnigraph/coordinates'
 import { addressArbitrary, endpointArbitrary, pointArbitrary, vectorArbitrary } from '@layerzerolabs/test-devtools'
 import { endpointIdToStage } from '@layerzerolabs/lz-definitions'
@@ -174,6 +175,16 @@ describe('omnigraph/vector', () => {
                     })
                 )
             })
+        })
+    })
+
+    describe('withEid', () => {
+        it('should append eid to a value', () => {
+            fc.assert(
+                fc.property(endpointArbitrary, fc.dictionary(fc.string(), fc.anything()), (eid, value) => {
+                    expect(withEid(eid)(value)).toEqual({ ...value, eid })
+                })
+            )
         })
     })
 })

--- a/packages/ua-devtools/src/lzapp/config.ts
+++ b/packages/ua-devtools/src/lzapp/config.ts
@@ -1,26 +1,11 @@
 import {
     flattenTransactions,
     formatOmniVector,
-    parallel,
     type OmniTransaction,
-    sequence,
+    createConfigureMultiple,
 } from '@layerzerolabs/devtools'
 import { LzAppConfigurator } from './types'
 import { createModuleLogger, printBoolean } from '@layerzerolabs/io-devtools'
-
-export const configureLzApp: LzAppConfigurator = async (graph, createSdk) => {
-    const logger = createModuleLogger('LzApp')
-    const tasks = [() => configureLzAppTrustedRemotes(graph, createSdk)]
-    // For now we keep the parallel execution as an opt-in feature flag
-    // before we have a retry logic fully in place for the SDKs
-    //
-    // This is to avoid 429 too many requests errors from the RPCs
-    const applicative = process.env.LZ_ENABLE_EXPERIMENTAL_PARALLEL_EXECUTION
-        ? (logger.warn(`You are using experimental parallel configuration`), parallel)
-        : sequence
-
-    return flattenTransactions(await applicative(tasks))
-}
 
 export const configureLzAppTrustedRemotes: LzAppConfigurator = async (graph, createSdk) => {
     const logger = createModuleLogger('LzApp')
@@ -44,3 +29,5 @@ export const configureLzAppTrustedRemotes: LzAppConfigurator = async (graph, cre
         )
     )
 }
+
+export const configureLzApp: LzAppConfigurator = createConfigureMultiple(configureLzAppTrustedRemotes)


### PR DESCRIPTION
### In this PR

- Small `withEid` helper utility for curried `eid` assignment. Useful for DRYing when creating lots of `OmniPoint` / `OmniPointHardhat` etc objects on the same network