### PR TITLE
🧹 Add withEid helper

### DIFF
--- a/.changeset/strange-balloons-tie.md
+++ b/.changeset/strange-balloons-tie.md
@@ -1,0 +1,6 @@
+---
+"@layerzerolabs/ua-devtools": patch
+"@layerzerolabs/devtools": patch
+---
+
+Add withEid utility

--- a/packages/devtools/src/omnigraph/coordinates.ts
+++ b/packages/devtools/src/omnigraph/coordinates.ts
@@ -1,5 +1,5 @@
-import { endpointIdToStage } from '@layerzerolabs/lz-definitions'
-import { OmniVector, OmniPoint, OmniNode } from './types'
+import { EndpointId, endpointIdToStage } from '@layerzerolabs/lz-definitions'
+import { OmniVector, OmniPoint, OmniNode, WithEid } from './types'
 
 /**
  * Compares two points by value
@@ -71,3 +71,19 @@ export const serializeVector = ({ from, to }: OmniVector): string => `${serializ
  * @returns `OmniVector`
  */
 export const vectorFromNodes = (a: OmniNode, b: OmniNode): OmniVector => ({ from: a.point, to: b.point })
+
+/**
+ * Helper function to add an `eid` to arbitrary values, converting them to `WithEid`
+ *
+ * This is useful to reduce repetition when e.g. creating multiple `OmniPoint` instances on the same network:
+ *
+ * ```
+ * const onMainnet = withEid(EndpointId.ETHEREUM_V2_MAINNET)
+ *
+ * const onePoint = onMainnet({ address: '0x0' })
+ * const anotherPoint = onMainnet({ address: '0x1' })
+ * ```
+ */
+export const withEid =
+    (eid: EndpointId) =>
+    <T>(value: T): WithEid<T> => ({ ...value, eid })

--- a/packages/devtools/test/omnigraph/coordinates.test.ts
+++ b/packages/devtools/test/omnigraph/coordinates.test.ts
@@ -6,6 +6,7 @@ import {
     serializeVector,
     areSameEndpoint,
     isVectorPossible,
+    withEid,
 } from '@/omnigraph/coordinates'
 import { addressArbitrary, endpointArbitrary, pointArbitrary, vectorArbitrary } from '@layerzerolabs/test-devtools'
 import { endpointIdToStage } from '@layerzerolabs/lz-definitions'
@@ -174,6 +175,16 @@ describe('omnigraph/vector', () => {
                     })
                 )
             })
+        })
+    })
+
+    describe('withEid', () => {
+        it('should append eid to a value', () => {
+            fc.assert(
+                fc.property(endpointArbitrary, fc.dictionary(fc.string(), fc.anything()), (eid, value) => {
+                    expect(withEid(eid)(value)).toEqual({ ...value, eid })
+                })
+            )
         })
     })
 })


### PR DESCRIPTION
### In this PR

- Small `withEid` helper utility for curried `eid` assignment. Useful for DRYing when creating lots of `OmniPoint` / `OmniPointHardhat` etc objects on the same network