### PR TITLE
🗞️ Add the ability to use named signers

### DIFF
--- a/.changeset/hot-planets-help.md
+++ b/.changeset/hot-planets-help.md
@@ -1,0 +1,8 @@
+---
+"@layerzerolabs/ua-devtools-evm-hardhat-test": patch
+"@layerzerolabs/ua-devtools-evm-hardhat": patch
+"@layerzerolabs/devtools-evm-hardhat": patch
+"@layerzerolabs/devtools-evm": patch
+---
+
+Add ability to use named signers

--- a/packages/devtools-evm-hardhat/test/cli.test.ts
+++ b/packages/devtools-evm-hardhat/test/cli.test.ts
@@ -4,8 +4,8 @@ import fc from 'fast-check'
 
 describe('cli', () => {
     describe('signer', () => {
-        it('should throw if invalid address is passed', () => {
-            expect(() => signer.parse('signer', 'wat')).toThrow()
+        it('should return a named definition if a non-address non-integer is passed', () => {
+            expect(signer.parse('signer', 'wat')).toEqual({ type: 'named', name: 'wat' })
         })
 
         it('should throw if negative index is passed', () => {
@@ -19,7 +19,7 @@ describe('cli', () => {
         it('should return the address if valid address is passed', () => {
             fc.assert(
                 fc.property(evmAddressArbitrary, (address) => {
-                    expect(signer.parse('signer', address)).toBe(address)
+                    expect(signer.parse('signer', address)).toEqual({ type: 'address', address })
                 })
             )
         })
@@ -27,7 +27,7 @@ describe('cli', () => {
         it('should return the index if non-negative index is passed', () => {
             fc.assert(
                 fc.property(fc.integer({ min: 0 }), (index) => {
-                    expect(signer.parse('signer', String(index))).toBe(index)
+                    expect(signer.parse('signer', String(index))).toEqual({ type: 'index', index })
                 })
             )
         })

--- a/packages/devtools-evm-hardhat/test/transactions/signer.test.ts
+++ b/packages/devtools-evm-hardhat/test/transactions/signer.test.ts
@@ -1,8 +1,12 @@
 import 'hardhat'
 import { EndpointId } from '@layerzerolabs/lz-definitions'
-import { createSignerFactory } from '@/transactions/signer'
+import { createSignerAddressOrIndexFactory, createSignerFactory } from '@/transactions/signer'
 import { JsonRpcProvider, JsonRpcSigner } from '@ethersproject/providers'
 import { OmniSignerEVM } from '@layerzerolabs/devtools-evm'
+import fc from 'fast-check'
+import { endpointArbitrary } from '@layerzerolabs/test-devtools'
+import { evmAddressArbitrary } from '@layerzerolabs/test-devtools'
+import { formatEid } from '@layerzerolabs/devtools'
 
 // Ethers calls the eth_chainId RPC method when initializing a provider so we mock the result
 jest.spyOn(JsonRpcProvider.prototype, 'detectNetwork').mockResolvedValue({ chainId: 1, name: 'mock' })
@@ -26,6 +30,66 @@ describe('signer', () => {
             // If we don't wait for the provider to be ready, jest will complain
             // about requests being made after test teardown
             await (signer.signer.provider as JsonRpcProvider)?.ready
+        })
+    })
+
+    describe('createSignerAddressOrIndexFactory', () => {
+        it('should return undefined if called with undefined definition', async () => {
+            await fc.assert(
+                fc.asyncProperty(endpointArbitrary, async (eid) => {
+                    await expect(createSignerAddressOrIndexFactory()(eid)).resolves.toBeUndefined()
+                })
+            )
+        })
+
+        it('should return address if called with address definition', async () => {
+            await fc.assert(
+                fc.asyncProperty(evmAddressArbitrary, endpointArbitrary, async (address, eid) => {
+                    await expect(createSignerAddressOrIndexFactory({ type: 'address', address })(eid)).resolves.toBe(
+                        address
+                    )
+                })
+            )
+        })
+
+        it('should return index if called with index definition', async () => {
+            await fc.assert(
+                fc.asyncProperty(fc.integer(), endpointArbitrary, async (index, eid) => {
+                    await expect(createSignerAddressOrIndexFactory({ type: 'index', index })(eid)).resolves.toBe(index)
+                })
+            )
+        })
+
+        it('should reject if called with a missing named definition', async () => {
+            const mockGetNamedAccounts = jest.fn().mockResolvedValue({ wombat: '0xwombat' })
+            const mockHre = {
+                getNamedAccounts: mockGetNamedAccounts,
+            }
+            const hreFactory = jest.fn().mockResolvedValue(mockHre)
+
+            await fc.assert(
+                fc.asyncProperty(endpointArbitrary, async (eid) => {
+                    await expect(
+                        createSignerAddressOrIndexFactory({ type: 'named', name: 'no-wombat' }, hreFactory)(eid)
+                    ).rejects.toThrow(`Missing named account 'no-wombat' for eid ${formatEid(eid)}`)
+                })
+            )
+        })
+
+        it('should resolve with an address if called with a defined named definition', async () => {
+            const mockGetNamedAccounts = jest.fn().mockResolvedValue({ wombat: '0xwombat' })
+            const mockHre = {
+                getNamedAccounts: mockGetNamedAccounts,
+            }
+            const hreFactory = jest.fn().mockResolvedValue(mockHre)
+
+            await fc.assert(
+                fc.asyncProperty(endpointArbitrary, async (eid) => {
+                    await expect(
+                        createSignerAddressOrIndexFactory({ type: 'named', name: 'wombat' }, hreFactory)(eid)
+                    ).resolves.toBe('0xwombat')
+                })
+            )
         })
     })
 })

--- a/packages/devtools-evm/src/signer/index.ts
+++ b/packages/devtools-evm/src/signer/index.ts
@@ -1,1 +1,2 @@
 export * from './sdk'
+export * from './types'

--- a/packages/devtools-evm/src/signer/types.ts
+++ b/packages/devtools-evm/src/signer/types.ts
@@ -1,0 +1,24 @@
+import type { OmniAddress } from '@layerzerolabs/devtools'
+
+export interface SignerIndex {
+    type: 'index'
+    address?: never
+    index: number
+    name?: never
+}
+
+export interface SignerAddress {
+    type: 'address'
+    address: OmniAddress
+    index?: never
+    name?: never
+}
+
+export interface SignerName {
+    type: 'named'
+    address?: never
+    index?: never
+    name: string
+}
+
+export type SignerDefinition = SignerIndex | SignerAddress | SignerName

--- a/packages/ua-devtools-evm-hardhat/src/tasks/oapp/wire/index.ts
+++ b/packages/ua-devtools-evm-hardhat/src/tasks/oapp/wire/index.ts
@@ -18,13 +18,14 @@ import type { SignAndSendTaskArgs } from '@layerzerolabs/devtools-evm-hardhat/ta
 import './subtask.configure'
 import { OAppOmniGraphHardhatSchema } from '@/oapp'
 import { SubtaskLoadConfigTaskArgs } from '@/tasks/oapp/types'
+import type { SignerDefinition } from '@layerzerolabs/devtools-evm'
 
 interface TaskArgs {
     oappConfig: string
     logLevel?: string
     ci?: boolean
     safe?: boolean
-    signer?: string
+    signer?: SignerDefinition
     /**
      * Name of a custom config loading subtask
      *

--- a/packages/ua-devtools-evm-hardhat/src/tasks/oapp/wire/index.ts
+++ b/packages/ua-devtools-evm-hardhat/src/tasks/oapp/wire/index.ts
@@ -108,6 +108,9 @@ const action: ActionType<TaskArgs> = async (
     )
 
     // Now let's create the signer
+    logger.debug(
+        signer == null ? `Creating a default signer` : `Creating a signer based on definition: ${printJson(signer)}`
+    )
     const createSigner = safe ? createGnosisSignerFactory(signer) : createSignerFactory(signer)
 
     // Now sign & send the transactions

--- a/packages/ua-devtools-evm-hardhat/src/tasks/ownable/transfer.ownership.ts
+++ b/packages/ua-devtools-evm-hardhat/src/tasks/ownable/transfer.ownership.ts
@@ -17,13 +17,14 @@ import { OwnableOmniGraphHardhatSchema } from '@/ownable'
 import { configureOwnable } from '@layerzerolabs/ua-devtools'
 import { createOAppFactory, createOwnableFactory } from '@layerzerolabs/ua-devtools-evm'
 import type { SubtaskLoadConfigTaskArgs } from '@/tasks/oapp/types'
+import type { SignerDefinition } from '@layerzerolabs/devtools-evm'
 
 interface TaskArgs {
     oappConfig: string
     logLevel?: string
     ci?: boolean
     safe?: boolean
-    signer?: string
+    signer?: SignerDefinition
 }
 
 const action: ActionType<TaskArgs> = async (

--- a/tests/ua-devtools-evm-hardhat-test/test/task/oapp/wire.test.ts
+++ b/tests/ua-devtools-evm-hardhat-test/test/task/oapp/wire.test.ts
@@ -245,7 +245,7 @@ describe(`task ${TASK_LZ_OAPP_WIRE}`, () => {
                 .mockResolvedValueOnce(false) // We don't want to see the list
                 .mockResolvedValueOnce(true) // We want to continue
 
-            await hre.run(TASK_LZ_OAPP_WIRE, { oappConfig, safe: true, signer })
+            await hre.run(TASK_LZ_OAPP_WIRE, { oappConfig, safe: true, signer: { type: 'address', address: signer } })
 
             expect(createGnosisSignerFactory).toHaveBeenCalledOnce()
             expect(createGnosisSignerFactory).toHaveBeenCalledWith(signer)

--- a/tests/ua-devtools-evm-hardhat-test/test/task/oapp/wire.test.ts
+++ b/tests/ua-devtools-evm-hardhat-test/test/task/oapp/wire.test.ts
@@ -209,6 +209,34 @@ describe(`task ${TASK_LZ_OAPP_WIRE}`, () => {
             expect(errors).toEqual([])
         })
 
+        it('should use a named signer if a signer name is passed', async () => {
+            const oappConfig = configPathFixture('valid.config.connected.js')
+            const signer = { type: 'named', name: 'wombat' }
+
+            promptToContinueMock
+                .mockResolvedValueOnce(false) // We don't want to see the list
+                .mockResolvedValueOnce(true) // We want to continue
+
+            await hre.run(TASK_LZ_OAPP_WIRE, { oappConfig, signer })
+
+            expect(createSignerFactoryMock).toHaveBeenCalledOnce()
+            expect(createSignerFactoryMock).toHaveBeenCalledWith(signer)
+        })
+
+        it('should use a named safe signer if a signer name is passed', async () => {
+            const oappConfig = configPathFixture('valid.config.connected.js')
+            const signer = { type: 'named', name: 'wombat' }
+
+            promptToContinueMock
+                .mockResolvedValueOnce(false) // We don't want to see the list
+                .mockResolvedValueOnce(true) // We want to continue
+
+            await hre.run(TASK_LZ_OAPP_WIRE, { oappConfig, safe: true, signer })
+
+            expect(createSignerFactoryMock).toHaveBeenCalledOnce()
+            expect(createSignerFactoryMock).toHaveBeenCalledWith(signer)
+        })
+
         it('should use gnosis safe signer if --safe flag is passed', async () => {
             const oappConfig = configPathFixture('valid.config.connected.js')
 

--- a/tests/ua-devtools-evm-hardhat-test/test/task/oapp/wire.test.ts
+++ b/tests/ua-devtools-evm-hardhat-test/test/task/oapp/wire.test.ts
@@ -233,8 +233,8 @@ describe(`task ${TASK_LZ_OAPP_WIRE}`, () => {
 
             await hre.run(TASK_LZ_OAPP_WIRE, { oappConfig, safe: true, signer })
 
-            expect(createSignerFactoryMock).toHaveBeenCalledOnce()
-            expect(createSignerFactoryMock).toHaveBeenCalledWith(signer)
+            expect(createGnosisSignerFactory).toHaveBeenCalledOnce()
+            expect(createGnosisSignerFactory).toHaveBeenCalledWith(signer)
         })
 
         it('should use gnosis safe signer if --safe flag is passed', async () => {
@@ -276,7 +276,7 @@ describe(`task ${TASK_LZ_OAPP_WIRE}`, () => {
             await hre.run(TASK_LZ_OAPP_WIRE, { oappConfig, safe: true, signer: { type: 'address', address: signer } })
 
             expect(createGnosisSignerFactory).toHaveBeenCalledOnce()
-            expect(createGnosisSignerFactory).toHaveBeenCalledWith(signer)
+            expect(createGnosisSignerFactory).toHaveBeenCalledWith({ type: 'address', address: signer })
 
             // Get the created gnosis signer factory
             const createSigner = createGnosisSignerFactoryMock.mock.results[0]?.value


### PR DESCRIPTION
### In this PR

- Allow the `--signer` argument to accept a name of a signer as defined using `namedAccounts` configuration