### PR TITLE
🧹 Make SubtaskConfigureTaskArgs type generic

### DIFF
--- a/.changeset/tiny-avocados-begin.md
+++ b/.changeset/tiny-avocados-begin.md
@@ -1,0 +1,5 @@
+---
+"@layerzerolabs/ua-devtools-evm-hardhat": patch
+---
+
+Make SubtaskConfigureTaskArgs type generic

--- a/packages/ua-devtools-evm-hardhat/src/tasks/oapp/wire/subtask.configure.ts
+++ b/packages/ua-devtools-evm-hardhat/src/tasks/oapp/wire/subtask.configure.ts
@@ -2,13 +2,13 @@ import { SUBTASK_LZ_OAPP_WIRE_CONFIGURE } from '@/constants'
 import { OmniGraphBuilder, OmniTransaction } from '@layerzerolabs/devtools'
 import { createConnectedContractFactory, types } from '@layerzerolabs/devtools-evm-hardhat'
 import { createModuleLogger, printJson } from '@layerzerolabs/io-devtools'
-import { configureOApp } from '@layerzerolabs/ua-devtools'
+import { IOApp, OAppOmniGraph, configureOApp } from '@layerzerolabs/ua-devtools'
 import { createOAppFactory } from '@layerzerolabs/ua-devtools-evm'
 import { subtask } from 'hardhat/config'
 import type { ActionType } from 'hardhat/types'
 import type { SubtaskConfigureTaskArgs } from './types'
 
-const action: ActionType<SubtaskConfigureTaskArgs> = async ({
+const action: ActionType<SubtaskConfigureTaskArgs<OAppOmniGraph, IOApp>> = async ({
     graph,
     configurator = configureOApp,
     oappFactory = createOAppFactory(createConnectedContractFactory()),

--- a/packages/ua-devtools-evm-hardhat/src/tasks/oapp/wire/subtask.configure.ts
+++ b/packages/ua-devtools-evm-hardhat/src/tasks/oapp/wire/subtask.configure.ts
@@ -11,7 +11,7 @@ import type { SubtaskConfigureTaskArgs } from './types'
 const action: ActionType<SubtaskConfigureTaskArgs<OAppOmniGraph, IOApp>> = async ({
     graph,
     configurator = configureOApp,
-    oappFactory = createOAppFactory(createConnectedContractFactory()),
+    sdkFactory = createOAppFactory(createConnectedContractFactory()),
 }): Promise<OmniTransaction[]> => {
     const logger = createModuleLogger(SUBTASK_LZ_OAPP_WIRE_CONFIGURE)
 
@@ -36,7 +36,7 @@ const action: ActionType<SubtaskConfigureTaskArgs<OAppOmniGraph, IOApp>> = async
     // The only thing this task does is it uses the provided arguments
     // to compile a list of OmniTransactions
     try {
-        return await configurator(graph, oappFactory)
+        return await configurator(graph, sdkFactory)
     } catch (error) {
         logger.verbose(`Encountered an error: ${error}`)
 
@@ -45,6 +45,6 @@ const action: ActionType<SubtaskConfigureTaskArgs<OAppOmniGraph, IOApp>> = async
 }
 
 subtask(SUBTASK_LZ_OAPP_WIRE_CONFIGURE, 'Create a list of OmniTransactions that configure your OApp', action)
-    .addParam('graph', 'Configuration of you OApp of type OAppOmniGraph', undefined, types.any)
-    .addParam('configurator', 'Configuration function of type OAppConfigurator', undefined, types.any, true)
-    .addParam('oappFactory', 'SDK factory for OApp SDK of type OAppFactory', undefined, types.any, true)
+    .addParam('graph', 'Configuration graph', undefined, types.any)
+    .addParam('configurator', 'Configuration function matching the SDK factory', undefined, types.any, true)
+    .addParam('sdkFactory', 'SDK factory for an OmniSDK', undefined, types.any, true)

--- a/packages/ua-devtools-evm-hardhat/src/tasks/oapp/wire/types.ts
+++ b/packages/ua-devtools-evm-hardhat/src/tasks/oapp/wire/types.ts
@@ -3,5 +3,5 @@ import { Configurator, IOmniSDK, OmniGraph, OmniSDKFactory } from '@layerzerolab
 export interface SubtaskConfigureTaskArgs<TOmniGraph extends OmniGraph = OmniGraph, TSDK = IOmniSDK> {
     graph: TOmniGraph
     configurator?: Configurator<TOmniGraph, TSDK>
-    oappFactory?: OmniSDKFactory<TSDK>
+    sdkFactory?: OmniSDKFactory<TSDK>
 }

--- a/packages/ua-devtools-evm-hardhat/src/tasks/oapp/wire/types.ts
+++ b/packages/ua-devtools-evm-hardhat/src/tasks/oapp/wire/types.ts
@@ -1,7 +1,7 @@
-import type { OAppOmniGraph, OAppConfigurator, OAppFactory } from '@layerzerolabs/ua-devtools'
+import { Configurator, IOmniSDK, OmniGraph, OmniSDKFactory } from '@layerzerolabs/devtools'
 
-export interface SubtaskConfigureTaskArgs {
-    graph: OAppOmniGraph
-    configurator?: OAppConfigurator
-    oappFactory?: OAppFactory
+export interface SubtaskConfigureTaskArgs<TOmniGraph extends OmniGraph = OmniGraph, TSDK = IOmniSDK> {
+    graph: TOmniGraph
+    configurator?: Configurator<TOmniGraph, TSDK>
+    oappFactory?: OmniSDKFactory<TSDK>
 }

--- a/tests/ua-devtools-evm-hardhat-test/hardhat.config.with-custom-configuration.ts
+++ b/tests/ua-devtools-evm-hardhat-test/hardhat.config.with-custom-configuration.ts
@@ -60,11 +60,11 @@ task(SUBTASK_CUSTOM_CONFIGURE, 'Custom configuration subtask', async (args: Subt
     // Here we create the SDK factory
     const contractFactory = createConnectedContractFactory()
     const endpointV2Factory = createEndpointV2Factory(contractFactory)
-    const oappFactory = async (point) => new MyCustomOAppSDK(await contractFactory(point), endpointV2Factory)
+    const sdkFactory = async (point) => new MyCustomOAppSDK(await contractFactory(point), endpointV2Factory)
 
     return hre.run(SUBTASK_LZ_OAPP_WIRE_CONFIGURE, {
         ...args,
-        oappFactory,
+        sdkFactory,
         configurator: myCustomOAppConfigurator as OAppConfigurator,
     } satisfies SubtaskConfigureTaskArgs)
 })


### PR DESCRIPTION
### In this PR

- Make `SubtaskConfigureTaskArgs` type generic since this task is capable of configuring using any matching combination of `configurator` and ~~`oappFactory`~~ `sdkfactory`