### PR TITLE
🧹 Improve logging

### DIFF
--- a/.changeset/blue-starfishes-lick.md
+++ b/.changeset/blue-starfishes-lick.md
@@ -1,0 +1,5 @@
+---
+"@layerzerolabs/io-devtools": patch
+---
+
+Add createWithAsyncLogger logging utility for async functions

--- a/packages/io-devtools/jest.config.js
+++ b/packages/io-devtools/jest.config.js
@@ -3,6 +3,7 @@ module.exports = {
     cache: false,
     reporters: [['github-actions', { silent: false }], 'default'],
     testEnvironment: 'node',
+    setupFilesAfterEnv: ['<rootDir>/jest.setup.js'],
     moduleNameMapper: {
         '^@/(.*)$': '<rootDir>/src/$1',
     },

--- a/packages/io-devtools/jest.setup.js
+++ b/packages/io-devtools/jest.setup.js
@@ -1,0 +1,4 @@
+import * as jestExtended from 'jest-extended';
+
+// add all jest-extended matchers
+expect.extend(jestExtended);

--- a/packages/io-devtools/package.json
+++ b/packages/io-devtools/package.json
@@ -55,6 +55,7 @@
     "ink-gradient": "^2.0.0",
     "ink-table": "^3.1.0",
     "jest": "^29.7.0",
+    "jest-extended": "^4.0.2",
     "react": "^17.0.2",
     "ts-node": "^10.9.2",
     "tslib": "~2.6.2",

--- a/packages/io-devtools/test/stdio/logger.test.ts
+++ b/packages/io-devtools/test/stdio/logger.test.ts
@@ -1,0 +1,102 @@
+/// <reference types="jest-extended" />
+
+import { Logger, createModuleLogger, createWithAsyncLogger } from '@/stdio'
+import fc from 'fast-check'
+
+describe('stdio/logger', () => {
+    describe('createWithAsyncLogger()', () => {
+        const customLogger = createModuleLogger('my-module')
+        const createLoggerMock = jest.fn().mockReturnValue(customLogger)
+
+        describe.each([
+            ['default logger', undefined],
+            ['custom logger', createLoggerMock],
+        ] as const)(`with %s`, (name, loggerFactory) => {
+            let withAsyncLogger: ReturnType<typeof createWithAsyncLogger>
+
+            beforeEach(() => {
+                withAsyncLogger = createWithAsyncLogger(loggerFactory)
+            })
+
+            it('should call onStart & onSuccess when the callback resolves', async () => {
+                await fc.assert(
+                    fc.asyncProperty(fc.array(fc.anything()), fc.anything(), async (args, returnValue) => {
+                        const fn = jest.fn().mockResolvedValue(returnValue)
+                        const onStart = jest.fn().mockImplementation((logger: Logger) => logger.debug(`onStart`))
+                        const onSuccess = jest.fn().mockImplementation((logger: Logger) => logger.debug(`onSuccess`))
+
+                        await expect(withAsyncLogger(fn, { onStart, onSuccess })(...args)).resolves.toBe(returnValue)
+
+                        expect(onStart).toHaveBeenCalledWith(expect.anything(), args)
+                        expect(onSuccess).toHaveBeenCalledWith(expect.anything(), args, returnValue)
+                        expect(onStart).toHaveBeenCalledBefore(onSuccess)
+                    })
+                )
+            })
+
+            it('should call onStart & onFailure when callback rejects', async () => {
+                await fc.assert(
+                    fc.asyncProperty(fc.array(fc.anything()), fc.anything(), async (args, error) => {
+                        const fn = jest.fn().mockRejectedValue(error)
+                        const onStart = jest.fn().mockImplementation((logger: Logger) => logger.debug(`onStart`))
+                        const onError = jest.fn().mockImplementation((logger: Logger) => logger.debug(`onSuccess`))
+
+                        await expect(withAsyncLogger(fn, { onStart, onError })(...args)).rejects.toBe(error)
+
+                        expect(onStart).toHaveBeenCalledWith(expect.anything(), args)
+                        expect(onError).toHaveBeenCalledWith(expect.anything(), args, error)
+                        expect(onStart).toHaveBeenCalledBefore(onError)
+                    })
+                )
+            })
+
+            it('should resolve if onSuccess call throws', async () => {
+                await fc.assert(
+                    fc.asyncProperty(
+                        fc.array(fc.anything()),
+                        fc.anything(),
+                        fc.anything(),
+                        async (args, returnValue, loggerError) => {
+                            const fn = jest.fn().mockResolvedValue(returnValue)
+                            const onStart = jest.fn().mockImplementation((logger: Logger) => logger.debug(`onStart`))
+                            const onSuccess = jest.fn().mockImplementation(() => {
+                                throw loggerError
+                            })
+
+                            await expect(withAsyncLogger(fn, { onStart, onSuccess })(...args)).resolves.toBe(
+                                returnValue
+                            )
+
+                            expect(onStart).toHaveBeenCalledWith(expect.anything(), args)
+                            expect(onSuccess).toHaveBeenCalledWith(expect.anything(), args, returnValue)
+                            expect(onStart).toHaveBeenCalledBefore(onSuccess)
+                        }
+                    )
+                )
+            })
+
+            it('should reject with the original error if onError callback throws', async () => {
+                await fc.assert(
+                    fc.asyncProperty(
+                        fc.array(fc.anything()),
+                        fc.anything(),
+                        fc.anything(),
+                        async (args, error, loggerError) => {
+                            const fn = jest.fn().mockRejectedValue(error)
+                            const onStart = jest.fn().mockImplementation((logger: Logger) => logger.debug(`onStart`))
+                            const onError = jest.fn().mockImplementation(() => {
+                                throw loggerError
+                            })
+
+                            await expect(withAsyncLogger(fn, { onStart, onError })(...args)).rejects.toBe(error)
+
+                            expect(onStart).toHaveBeenCalledWith(expect.anything(), args)
+                            expect(onError).toHaveBeenCalledWith(expect.anything(), args, error)
+                            expect(onStart).toHaveBeenCalledBefore(onError)
+                        }
+                    )
+                )
+            })
+        })
+    })
+})

--- a/packages/ua-devtools/src/oapp/config.ts
+++ b/packages/ua-devtools/src/oapp/config.ts
@@ -402,7 +402,7 @@ const enforcedOptionsReducer = (
     }
 }
 
-export const configureOApp: OAppConfigurator = createWithAsyncLogger(createOAppLogger)(
+export const configureOApp: OAppConfigurator = withOAppLogger(
     createConfigureMultiple(
         configureOAppPeers,
         configureSendLibraries,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -758,6 +758,9 @@ importers:
       jest:
         specifier: ^29.7.0
         version: 29.7.0(@types/node@18.18.14)(ts-node@10.9.2)
+      jest-extended:
+        specifier: ^4.0.2
+        version: 4.0.2(jest@29.7.0)
       react:
         specifier: ^17.0.2
         version: 17.0.2
@@ -8390,6 +8393,7 @@ packages:
     dependencies:
       is-hex-prefixed: 1.0.0
       strip-hex-prefix: 1.0.0
+    bundledDependencies: false
 
   /eventemitter3@4.0.4:
     resolution: {integrity: sha512-rlaVLnVxtxvoyLsQQFBx53YmXHDxRIzzTLbdfxqi4yocpSjAxXwkU0cScM5JgSKMqEhrZpnvQ2D9gjylR0AimQ==}


### PR DESCRIPTION
### In this PR

- Add a new utility function for wrapping `async` functions with logging - `createWithAsyncLogger`
- Add example usage of this function to the OApp config
  - The next steps are to add these logs to all the methods that are currently missing logging. Once all the methods are covered, we can switch the logging from `verbose` to `info`