### PR TITLE
🗞️ Experimental transaction sending

### DIFF
--- a/.changeset/metal-ducks-compete.md
+++ b/.changeset/metal-ducks-compete.md
@@ -1,0 +1,6 @@
+---
+"@layerzerolabs/devtools": patch
+"@layerzerolabs/toolbox-hardhat": patch
+---
+
+Add feature-glagged batched transaction waits

--- a/.changeset/metal-ducks-compete.md
+++ b/.changeset/metal-ducks-compete.md
@@ -3,4 +3,4 @@
 "@layerzerolabs/toolbox-hardhat": patch
 ---
 
-Add feature-glagged batched transaction waits
+Add feature-flagged batched transaction waits

--- a/EXPERIMENTAL.md
+++ b/EXPERIMENTAL.md
@@ -46,7 +46,7 @@ By default, the RPC calls that check the current state of your contracts are exe
 
 `LZ_ENABLE_EXPERIMENTAL_RETRY=`
 
-## Automatic retries <a id="batched-wait"></a>
+## Batched transaction awating <a id="batched-wait"></a>
 
 By default, the transactions are submitted and awaited one by one. This means a transaction will only be submitted once the previous transaction has been mined (which results in transactions being mined in consecutive blocks, one transaction per block).
 

--- a/EXPERIMENTAL.md
+++ b/EXPERIMENTAL.md
@@ -45,3 +45,19 @@ By default, the RPC calls that check the current state of your contracts are exe
 ### To disable
 
 `LZ_ENABLE_EXPERIMENTAL_RETRY=`
+
+## Automatic retries <a id="batched-wait"></a>
+
+By default, the transactions are submitted and awaited one by one. This means a transaction will only be submitted once the previous transaction has been mined (which results in transactions being mined in consecutive blocks, one transaction per block).
+
+This feature flag changes this behavior and allows all transactions to be submitted first to potentially the same block. Only after all of the transactions have been submitted will the code wait for them to be mined.
+
+**Important** Enabling this behavior can incur higher costs of transaction reverts since a failing transaction can result in more than one revert.
+
+### To enable
+
+`LZ_ENABLE_EXPERIMENTAL_BATCHED_WAIT=1`
+
+### To disable
+
+`LZ_ENABLE_EXPERIMENTAL_BATCHED_WAIT=`

--- a/EXPERIMENTAL.md
+++ b/EXPERIMENTAL.md
@@ -46,7 +46,7 @@ By default, the RPC calls that check the current state of your contracts are exe
 
 `LZ_ENABLE_EXPERIMENTAL_RETRY=`
 
-## Batched transaction awating <a id="batched-wait"></a>
+## Batched transaction awaiting <a id="batched-wait"></a>
 
 By default, the transactions are submitted and awaited one by one. This means a transaction will only be submitted once the previous transaction has been mined (which results in transactions being mined in consecutive blocks, one transaction per block).
 

--- a/packages/devtools/src/transactions/signer.ts
+++ b/packages/devtools/src/transactions/signer.ts
@@ -200,6 +200,9 @@ const waitAfterSendingAll: TransactionSignerLogic = async (eid, logger, signer, 
 
             // Update the error state
             onError({ transaction, error })
+
+            // Stop submitting any other transactions
+            break
         }
     }
 

--- a/packages/devtools/src/transactions/signer.ts
+++ b/packages/devtools/src/transactions/signer.ts
@@ -193,14 +193,13 @@ const waitAfterSendingAll: TransactionSignerLogic = async (eid, logger, signer, 
             const response = await signer.signAndSend(transaction)
 
             logger.debug(`Signed ${ordinal} transaction for ${eidName}, got hash ${response.transactionHash}`)
+
+            responses.push({ transaction, response })
         } catch (error) {
             logger.debug(`Failed to sign ${ordinal} transaction for ${eidName}: ${error}`)
 
             // Update the error state
             onError({ transaction, error })
-
-            // We want to stop the moment we hit an error
-            return
         }
     }
 
@@ -220,9 +219,6 @@ const waitAfterSendingAll: TransactionSignerLogic = async (eid, logger, signer, 
 
             // Update the error state
             onError({ transaction, error })
-
-            // We want to stop the moment we hit an error
-            return
         }
     }
 }

--- a/packages/devtools/test/transactions/signer.test.ts
+++ b/packages/devtools/test/transactions/signer.test.ts
@@ -15,255 +15,370 @@ describe('transactions/signer', () => {
     })
 
     describe('createSignAndSend', () => {
-        it('should return no successes and no errors when called with an empty array', async () => {
-            const signAndSend = jest.fn().mockRejectedValue('Oh no')
-            const sign = jest.fn().mockRejectedValue('Oh god no')
-            const signerFactory: OmniSignerFactory = () => ({ signAndSend, sign })
-            const signAndSendTransactions = createSignAndSend(signerFactory)
+        describe.each(['', '1'])(
+            `when LZ_ENABLE_EXPERIMENTAL_BATCHED_WAIT environment variable is set to '%s'`,
+            (LZ_ENABLE_EXPERIMENTAL_BATCHED_WAIT) => {
+                beforeAll(() => {
+                    process.env.LZ_ENABLE_EXPERIMENTAL_BATCHED_WAIT = LZ_ENABLE_EXPERIMENTAL_BATCHED_WAIT
+                })
 
-            expect(await signAndSendTransactions([])).toEqual([[], [], []])
+                afterAll(() => {
+                    process.env.LZ_ENABLE_EXPERIMENTAL_BATCHED_WAIT = LZ_ENABLE_EXPERIMENTAL_BATCHED_WAIT
+                })
 
-            expect(signAndSend).not.toHaveBeenCalled()
-            expect(sign).not.toHaveBeenCalled()
-        })
-
-        it('should return all successful transactions if they all go through', async () => {
-            await fc.assert(
-                fc.asyncProperty(fc.array(transactionArbitrary), async (transactions) => {
-                    // We'll prepare some mock objects for this test
-                    // to mock the transaction responses and receipts
-                    const receipt = { transactionHash: '0x0' }
-
-                    // Our successful wait will produce a receipt
-                    const successfulWait = jest.fn().mockResolvedValue(receipt)
-                    const successfulResponse: OmniTransactionResponse = {
-                        transactionHash: '0x0',
-                        wait: successfulWait,
-                    }
-
-                    // Our signAndSend will then use the map to resolve/reject transactions
-                    const signAndSend = jest.fn().mockResolvedValue(successfulResponse)
+                it('should return no successes and no errors when called with an empty array', async () => {
+                    const signAndSend = jest.fn().mockRejectedValue('Oh no')
                     const sign = jest.fn().mockRejectedValue('Oh god no')
-                    const signerFactory: OmniSignerFactory = jest.fn().mockResolvedValue({ signAndSend, sign })
+                    const signerFactory: OmniSignerFactory = () => ({ signAndSend, sign })
                     const signAndSendTransactions = createSignAndSend(signerFactory)
 
-                    // Now we send all the transactions to the flow and observe the output
-                    const [successful, errors, pending] = await signAndSendTransactions(transactions)
+                    expect(await signAndSendTransactions([])).toEqual([[], [], []])
 
-                    // Since we are executing groups of transactions in parallel,
-                    // in general the order of successful transaction will not match the order of input transactions
-                    expect(successful).toContainAllValues(transactions.map((transaction) => ({ transaction, receipt })))
-                    expect(errors).toEqual([])
-                    expect(pending).toEqual([])
-
-                    // What needs to match though is the order of successful transactions within groups
-                    //
-                    // For that we group the successful transactions and make sure those are equal to the grouped original transactions
-                    const groupedSuccessful = groupTransactionsByEid(successful.map(({ transaction }) => transaction))
-                    expect(groupedSuccessful).toEqual(groupTransactionsByEid(transactions))
-
-                    // We also check that the signer factory has been called with the eids
-                    for (const transaction of transactions) {
-                        expect(signerFactory).toHaveBeenCalledWith(transaction.point.eid)
-                    }
+                    expect(signAndSend).not.toHaveBeenCalled()
+                    expect(sign).not.toHaveBeenCalled()
                 })
-            )
-        })
 
-        it('should bail on the first wait error', async () => {
-            await fc.assert(
-                fc.asyncProperty(
-                    fc.array(transactionArbitrary),
-                    transactionArbitrary,
-                    fc.array(transactionArbitrary),
-                    async (firstBatch, failedTransaction, secondBatch) => {
-                        // We'll prepare some mock objects for this test
-                        // to mock the transaction responses and receipts
-                        const error = new Error('Failed transaction')
-                        const receipt = { transactionHash: '0x0' }
+                it('should return all successful transactions if they all go through', async () => {
+                    await fc.assert(
+                        fc.asyncProperty(fc.array(transactionArbitrary), async (transactions) => {
+                            // We'll prepare some mock objects for this test
+                            // to mock the transaction responses and receipts
+                            const receipt = { transactionHash: '0x0' }
 
-                        // Our successful wait will produce a receipt
-                        const successfulWait = jest.fn().mockResolvedValue(receipt)
-                        const successfulResponse: OmniTransactionResponse = {
-                            transactionHash: '0x0',
-                            wait: successfulWait,
-                        }
+                            // Our successful wait will produce a receipt
+                            const successfulWait = jest.fn().mockResolvedValue(receipt)
+                            const successfulResponse: OmniTransactionResponse = {
+                                transactionHash: '0x0',
+                                wait: successfulWait,
+                            }
 
-                        // Our unsuccessful wait will throw an error
-                        const unsuccessfulWait = jest.fn().mockRejectedValue(error)
-                        const unsuccessfulResponse: OmniTransactionResponse = {
-                            transactionHash: '0x0',
-                            wait: unsuccessfulWait,
-                        }
+                            // Our signAndSend will then use the map to resolve/reject transactions
+                            const signAndSend = jest.fn().mockResolvedValue(successfulResponse)
+                            const sign = jest.fn().mockRejectedValue('Oh god no')
+                            const signerFactory: OmniSignerFactory = jest.fn().mockResolvedValue({ signAndSend, sign })
+                            const signAndSendTransactions = createSignAndSend(signerFactory)
 
-                        // In order to resolve the good ones and reject the bad ones
-                        // we'll prepare a map between a transaction and its response
-                        //
-                        // This map relies on the fact that we are passing the transaction object without modifying it
-                        // so the objects are referentially equal
-                        const implementations: Map<OmniTransaction, Promise<unknown>> = new Map([
-                            ...firstBatch.map((t) => [t, Promise.resolve(successfulResponse)] as const),
-                            ...secondBatch.map((t) => [t, Promise.resolve(successfulResponse)] as const),
-                            [failedTransaction, Promise.resolve(unsuccessfulResponse)],
-                        ])
+                            // Now we send all the transactions to the flow and observe the output
+                            const [successful, errors, pending] = await signAndSendTransactions(transactions)
 
-                        const expectedSuccessful = [
-                            // The first batch should all go through
-                            ...firstBatch,
-                            // The transactions that are not on the chain affected by the failed transaction should also pass
-                            ...secondBatch.filter(({ point }) => point.eid !== failedTransaction.point.eid),
-                        ]
+                            // Since we are executing groups of transactions in parallel,
+                            // in general the order of successful transaction will not match the order of input transactions
+                            expect(successful).toContainAllValues(
+                                transactions.map((transaction) => ({ transaction, receipt }))
+                            )
+                            expect(errors).toEqual([])
+                            expect(pending).toEqual([])
 
-                        const expectedPending = secondBatch.filter(
-                            ({ point }) => point.eid === failedTransaction.point.eid
-                        )
+                            // What needs to match though is the order of successful transactions within groups
+                            //
+                            // For that we group the successful transactions and make sure those are equal to the grouped original transactions
+                            const groupedSuccessful = groupTransactionsByEid(
+                                successful.map(({ transaction }) => transaction)
+                            )
+                            expect(groupedSuccessful).toEqual(groupTransactionsByEid(transactions))
 
-                        // Our signAndSend will then use the map to resolve/reject transactions
-                        const signAndSend = jest.fn().mockImplementation((t) => implementations.get(t))
-                        const sign = jest.fn().mockRejectedValue('Oh god no')
-                        const signerFactory: OmniSignerFactory = jest.fn().mockResolvedValue({ signAndSend, sign })
-                        const signAndSendTransactions = createSignAndSend(signerFactory)
-
-                        // Now we send all the transactions to the flow and observe the output
-                        const transactions = [...firstBatch, failedTransaction, ...secondBatch]
-                        const [successful, errors, pending] = await signAndSendTransactions(transactions)
-
-                        // Since we are executing groups of transactions in parallel,
-                        // in general the order of successful transaction will not match the order of input transactions
-                        expect(successful).toContainAllValues(
-                            expectedSuccessful.map((transaction) => ({ transaction, receipt }))
-                        )
-                        expect(errors).toEqual([{ transaction: failedTransaction, error }])
-                        expect(pending).toEqual([failedTransaction, ...expectedPending])
-
-                        // What needs to match though is the order of successful transactions within groups
-                        //
-                        // For that we group the successful transactions and make sure those are equal to the grouped original transactions
-                        const groupedSuccessful = groupTransactionsByEid(
-                            successful.map(({ transaction }) => transaction)
-                        )
-                        expect(groupedSuccessful).toEqual(groupTransactionsByEid(expectedSuccessful))
-
-                        // We also check that the signer factory has been called with the eids
-                        expect(signerFactory).toHaveBeenCalledWith(failedTransaction.point.eid)
-                        for (const transaction of firstBatch) {
-                            expect(signerFactory).toHaveBeenCalledWith(transaction.point.eid)
-                        }
-                    }
-                )
-            )
-        })
-
-        it('should bail on the first submission error', async () => {
-            await fc.assert(
-                fc.asyncProperty(
-                    fc.array(transactionArbitrary),
-                    transactionArbitrary,
-                    fc.array(transactionArbitrary),
-                    async (firstBatch, failedTransaction, secondBatch) => {
-                        // We'll prepare some mock objects for this test
-                        // to mock the transaction responses and receipts
-                        const error = new Error('Failed transaction')
-                        const receipt = { transactionHash: '0x0' }
-                        const successfulWait = jest.fn().mockResolvedValue(receipt)
-                        const successfulResponse: OmniTransactionResponse = {
-                            transactionHash: '0x0',
-                            wait: successfulWait,
-                        }
-
-                        // In order to resolve the good ones and reject the bad ones
-                        // we'll prepare a map between a transaction and its response
-                        //
-                        // This map relies on the fact that we are passing the transaction object without modifying it
-                        // so the objects are referentially equal
-                        const implementations: Map<OmniTransaction, Promise<unknown>> = new Map([
-                            ...firstBatch.map((t) => [t, Promise.resolve(successfulResponse)] as const),
-                            ...secondBatch.map((t) => [t, Promise.resolve(successfulResponse)] as const),
-                            [failedTransaction, Promise.reject(error)],
-                        ])
-
-                        const expectedSuccessful = [
-                            // The first batch should all go through
-                            ...firstBatch,
-                            // The transactions that are not on the chain affected by the failed transaction should also pass
-                            ...secondBatch.filter(({ point }) => point.eid !== failedTransaction.point.eid),
-                        ]
-
-                        const expectedPending = secondBatch.filter(
-                            ({ point }) => point.eid === failedTransaction.point.eid
-                        )
-
-                        // Our signAndSend will then use the map to resolve/reject transactions
-                        const signAndSend = jest.fn().mockImplementation((t) => implementations.get(t))
-                        const sign = jest.fn().mockRejectedValue('Oh god no')
-                        const signerFactory: OmniSignerFactory = jest.fn().mockResolvedValue({ signAndSend, sign })
-                        const signAndSendTransactions = createSignAndSend(signerFactory)
-
-                        // Now we send all the transactions to the flow and observe the output
-                        const transactions = [...firstBatch, failedTransaction, ...secondBatch]
-                        const [successful, errors, pending] = await signAndSendTransactions(transactions)
-
-                        // Since we are executing groups of transactions in parallel,
-                        // in general the order of successful transaction will not match the order of input transactions
-                        expect(successful).toContainAllValues(
-                            expectedSuccessful.map((transaction) => ({ transaction, receipt }))
-                        )
-                        expect(errors).toEqual([{ transaction: failedTransaction, error }])
-                        expect(pending).toEqual([failedTransaction, ...expectedPending])
-
-                        // What needs to match though is the order of successful transactions within groups
-                        //
-                        // For that we group the successful transactions and make sure those are equal to the grouped original transactions
-                        const groupedSuccessful = groupTransactionsByEid(
-                            successful.map(({ transaction }) => transaction)
-                        )
-                        expect(groupedSuccessful).toEqual(groupTransactionsByEid(expectedSuccessful))
-
-                        // We also check that the signer factory has been called with the eids
-                        expect(signerFactory).toHaveBeenCalledWith(failedTransaction.point.eid)
-                        for (const transaction of firstBatch) {
-                            expect(signerFactory).toHaveBeenCalledWith(transaction.point.eid)
-                        }
-                    }
-                )
-            )
-        })
-
-        it('should call onProgress for every successful transaction', async () => {
-            await fc.assert(
-                fc.asyncProperty(fc.array(transactionArbitrary), async (transactions) => {
-                    // We'll prepare some mock objects for this test
-                    // to mock the transaction responses and receipts
-                    const receipt = { transactionHash: '0x0' }
-
-                    // Our successful wait will produce a receipt
-                    const successfulWait = jest.fn().mockResolvedValue(receipt)
-                    const successfulResponse: OmniTransactionResponse = {
-                        transactionHash: '0x0',
-                        wait: successfulWait,
-                    }
-
-                    // Our signAndSend will then use the map to resolve/reject transactions
-                    const signAndSend = jest.fn().mockResolvedValue(successfulResponse)
-                    const sign = jest.fn().mockRejectedValue('Oh god no')
-                    const signerFactory: OmniSignerFactory = jest.fn().mockResolvedValue({ signAndSend, sign })
-                    const signAndSendTransactions = createSignAndSend(signerFactory)
-
-                    const handleProgress = jest.fn()
-                    const [successful] = await signAndSendTransactions(transactions, handleProgress)
-
-                    // We check whether onProgress has been called for every transaction
-                    for (const [index, transaction] of successful.entries()) {
-                        expect(handleProgress).toHaveBeenNthCalledWith(
-                            index + 1,
-                            // We expect the transaction in question to be passed
-                            transaction,
-                            // As well as the list of all the successful transactions so far
-                            successful.slice(0, index + 1)
-                        )
-                    }
+                            // We also check that the signer factory has been called with the eids
+                            for (const transaction of transactions) {
+                                expect(signerFactory).toHaveBeenCalledWith(transaction.point.eid)
+                            }
+                        })
+                    )
                 })
-            )
+
+                it('should bail on the first submission error', async () => {
+                    await fc.assert(
+                        fc.asyncProperty(
+                            fc.array(transactionArbitrary),
+                            transactionArbitrary,
+                            fc.array(transactionArbitrary),
+                            async (firstBatch, failedTransaction, secondBatch) => {
+                                // We'll prepare some mock objects for this test
+                                // to mock the transaction responses and receipts
+                                const error = new Error('Failed transaction')
+                                const receipt = { transactionHash: '0x0' }
+                                const successfulWait = jest.fn().mockResolvedValue(receipt)
+                                const successfulResponse: OmniTransactionResponse = {
+                                    transactionHash: '0x0',
+                                    wait: successfulWait,
+                                }
+
+                                // In order to resolve the good ones and reject the bad ones
+                                // we'll prepare a map between a transaction and its response
+                                //
+                                // This map relies on the fact that we are passing the transaction object without modifying it
+                                // so the objects are referentially equal
+                                const implementations: Map<OmniTransaction, Promise<unknown>> = new Map([
+                                    ...firstBatch.map((t) => [t, Promise.resolve(successfulResponse)] as const),
+                                    ...secondBatch.map((t) => [t, Promise.resolve(successfulResponse)] as const),
+                                    [failedTransaction, Promise.reject(error)],
+                                ])
+
+                                const expectedSuccessful = [
+                                    // The first batch should all go through
+                                    ...firstBatch,
+                                    // The transactions that are not on the chain affected by the failed transaction should also pass
+                                    ...secondBatch.filter(({ point }) => point.eid !== failedTransaction.point.eid),
+                                ]
+
+                                const expectedPending = secondBatch.filter(
+                                    ({ point }) => point.eid === failedTransaction.point.eid
+                                )
+
+                                // Our signAndSend will then use the map to resolve/reject transactions
+                                const signAndSend = jest.fn().mockImplementation((t) => implementations.get(t))
+                                const sign = jest.fn().mockRejectedValue('Oh god no')
+                                const signerFactory: OmniSignerFactory = jest
+                                    .fn()
+                                    .mockResolvedValue({ signAndSend, sign })
+                                const signAndSendTransactions = createSignAndSend(signerFactory)
+
+                                // Now we send all the transactions to the flow and observe the output
+                                const transactions = [...firstBatch, failedTransaction, ...secondBatch]
+                                const [successful, errors, pending] = await signAndSendTransactions(transactions)
+
+                                // Since we are executing groups of transactions in parallel,
+                                // in general the order of successful transaction will not match the order of input transactions
+                                expect(successful).toContainAllValues(
+                                    expectedSuccessful.map((transaction) => ({ transaction, receipt }))
+                                )
+                                expect(errors).toEqual([{ transaction: failedTransaction, error }])
+                                expect(pending).toEqual([failedTransaction, ...expectedPending])
+
+                                // What needs to match though is the order of successful transactions within groups
+                                //
+                                // For that we group the successful transactions and make sure those are equal to the grouped original transactions
+                                const groupedSuccessful = groupTransactionsByEid(
+                                    successful.map(({ transaction }) => transaction)
+                                )
+                                expect(groupedSuccessful).toEqual(groupTransactionsByEid(expectedSuccessful))
+
+                                // We also check that the signer factory has been called with the eids
+                                expect(signerFactory).toHaveBeenCalledWith(failedTransaction.point.eid)
+                                for (const transaction of firstBatch) {
+                                    expect(signerFactory).toHaveBeenCalledWith(transaction.point.eid)
+                                }
+                            }
+                        )
+                    )
+                })
+
+                it('should call onProgress for every successful transaction', async () => {
+                    await fc.assert(
+                        fc.asyncProperty(fc.array(transactionArbitrary), async (transactions) => {
+                            // We'll prepare some mock objects for this test
+                            // to mock the transaction responses and receipts
+                            const receipt = { transactionHash: '0x0' }
+
+                            // Our successful wait will produce a receipt
+                            const successfulWait = jest.fn().mockResolvedValue(receipt)
+                            const successfulResponse: OmniTransactionResponse = {
+                                transactionHash: '0x0',
+                                wait: successfulWait,
+                            }
+
+                            // Our signAndSend will then use the map to resolve/reject transactions
+                            const signAndSend = jest.fn().mockResolvedValue(successfulResponse)
+                            const sign = jest.fn().mockRejectedValue('Oh god no')
+                            const signerFactory: OmniSignerFactory = jest.fn().mockResolvedValue({ signAndSend, sign })
+                            const signAndSendTransactions = createSignAndSend(signerFactory)
+
+                            const handleProgress = jest.fn()
+                            const [successful] = await signAndSendTransactions(transactions, handleProgress)
+
+                            // We check whether onProgress has been called for every transaction
+                            for (const [index, transaction] of successful.entries()) {
+                                expect(handleProgress).toHaveBeenNthCalledWith(
+                                    index + 1,
+                                    // We expect the transaction in question to be passed
+                                    transaction,
+                                    // As well as the list of all the successful transactions so far
+                                    successful.slice(0, index + 1)
+                                )
+                            }
+                        })
+                    )
+                })
+            }
+        )
+
+        describe(`when LZ_ENABLE_EXPERIMENTAL_BATCHED_WAIT environment variable is set to ''`, () => {
+            beforeAll(() => {
+                process.env.LZ_ENABLE_EXPERIMENTAL_BATCHED_WAIT = ''
+            })
+
+            it('should bail on the first wait error', async () => {
+                await fc.assert(
+                    fc.asyncProperty(
+                        fc.array(transactionArbitrary),
+                        transactionArbitrary,
+                        fc.array(transactionArbitrary),
+                        async (firstBatch, failedTransaction, secondBatch) => {
+                            // We'll prepare some mock objects for this test
+                            // to mock the transaction responses and receipts
+                            const error = new Error('Failed transaction')
+                            const receipt = { transactionHash: '0x0' }
+
+                            // Our successful wait will produce a receipt
+                            const successfulWait = jest.fn().mockResolvedValue(receipt)
+                            const successfulResponse: OmniTransactionResponse = {
+                                transactionHash: '0x0',
+                                wait: successfulWait,
+                            }
+
+                            // Our unsuccessful wait will throw an error
+                            const unsuccessfulWait = jest.fn().mockRejectedValue(error)
+                            const unsuccessfulResponse: OmniTransactionResponse = {
+                                transactionHash: '0x0',
+                                wait: unsuccessfulWait,
+                            }
+
+                            // In order to resolve the good ones and reject the bad ones
+                            // we'll prepare a map between a transaction and its response
+                            //
+                            // This map relies on the fact that we are passing the transaction object without modifying it
+                            // so the objects are referentially equal
+                            const implementations: Map<OmniTransaction, Promise<unknown>> = new Map([
+                                ...firstBatch.map((t) => [t, Promise.resolve(successfulResponse)] as const),
+                                ...secondBatch.map((t) => [t, Promise.resolve(successfulResponse)] as const),
+                                [failedTransaction, Promise.resolve(unsuccessfulResponse)],
+                            ])
+
+                            const expectedSuccessful = [
+                                // The first batch should all go through
+                                ...firstBatch,
+                                // The transactions that are not on the chain affected by the failed transaction should also pass
+                                ...secondBatch.filter(({ point }) => point.eid !== failedTransaction.point.eid),
+                            ]
+
+                            const expectedPending = secondBatch.filter(
+                                ({ point }) => point.eid === failedTransaction.point.eid
+                            )
+
+                            // Our signAndSend will then use the map to resolve/reject transactions
+                            const signAndSend = jest.fn().mockImplementation((t) => implementations.get(t))
+                            const sign = jest.fn().mockRejectedValue('Oh god no')
+                            const signerFactory: OmniSignerFactory = jest.fn().mockResolvedValue({ signAndSend, sign })
+                            const signAndSendTransactions = createSignAndSend(signerFactory)
+
+                            // Now we send all the transactions to the flow and observe the output
+                            const transactions = [...firstBatch, failedTransaction, ...secondBatch]
+                            const [successful, errors, pending] = await signAndSendTransactions(transactions)
+
+                            // Since we are executing groups of transactions in parallel,
+                            // in general the order of successful transaction will not match the order of input transactions
+                            expect(successful).toContainAllValues(
+                                expectedSuccessful.map((transaction) => ({ transaction, receipt }))
+                            )
+                            expect(errors).toEqual([{ transaction: failedTransaction, error }])
+                            expect(pending).toEqual([failedTransaction, ...expectedPending])
+
+                            // What needs to match though is the order of successful transactions within groups
+                            //
+                            // For that we group the successful transactions and make sure those are equal to the grouped original transactions
+                            const groupedSuccessful = groupTransactionsByEid(
+                                successful.map(({ transaction }) => transaction)
+                            )
+                            expect(groupedSuccessful).toEqual(groupTransactionsByEid(expectedSuccessful))
+
+                            // We also check that the signer factory has been called with the eids
+                            expect(signerFactory).toHaveBeenCalledWith(failedTransaction.point.eid)
+                            for (const transaction of firstBatch) {
+                                expect(signerFactory).toHaveBeenCalledWith(transaction.point.eid)
+                            }
+                        }
+                    )
+                )
+            })
+        })
+
+        describe(`when LZ_ENABLE_EXPERIMENTAL_BATCHED_WAIT environment variable is set to '1'`, () => {
+            beforeAll(() => {
+                process.env.LZ_ENABLE_EXPERIMENTAL_BATCHED_WAIT = '1'
+            })
+
+            it('should bail on the first wait error', async () => {
+                await fc.assert(
+                    fc.asyncProperty(
+                        fc.array(transactionArbitrary),
+                        transactionArbitrary,
+                        fc.array(transactionArbitrary),
+                        async (firstBatch, failedTransaction, secondBatch) => {
+                            // We'll prepare some mock objects for this test
+                            // to mock the transaction responses and receipts
+                            const error = new Error('Failed transaction')
+                            const receipt = { transactionHash: '0x0' }
+
+                            // Our successful wait will produce a receipt
+                            const successfulWait = jest.fn().mockResolvedValue(receipt)
+                            const successfulResponse: OmniTransactionResponse = {
+                                transactionHash: '0x0',
+                                wait: successfulWait,
+                            }
+
+                            // Our unsuccessful wait will throw an error
+                            const unsuccessfulWait = jest.fn().mockRejectedValue(error)
+                            const unsuccessfulResponse: OmniTransactionResponse = {
+                                transactionHash: '0x0',
+                                wait: unsuccessfulWait,
+                            }
+
+                            // In order to resolve the good ones and reject the bad ones
+                            // we'll prepare a map between a transaction and its response
+                            //
+                            // This map relies on the fact that we are passing the transaction object without modifying it
+                            // so the objects are referentially equal
+                            const implementations: Map<OmniTransaction, Promise<unknown>> = new Map([
+                                ...firstBatch.map((t) => [t, Promise.resolve(successfulResponse)] as const),
+                                ...secondBatch.map((t) => [t, Promise.resolve(successfulResponse)] as const),
+                                [failedTransaction, Promise.resolve(unsuccessfulResponse)],
+                            ])
+
+                            const expectedSuccessful = [
+                                // The first batch should all go through
+                                ...firstBatch,
+                                // The transactions that are not on the chain affected by the failed transaction should also pass
+                                ...secondBatch.filter(({ point }) => point.eid !== failedTransaction.point.eid),
+                            ]
+
+                            const expectedPending = secondBatch.filter(
+                                ({ point }) => point.eid === failedTransaction.point.eid
+                            )
+
+                            // Our signAndSend will then use the map to resolve/reject transactions
+                            const signAndSend = jest.fn().mockImplementation((t) => implementations.get(t))
+                            const sign = jest.fn().mockRejectedValue('Oh god no')
+                            const signerFactory: OmniSignerFactory = jest.fn().mockResolvedValue({ signAndSend, sign })
+                            const signAndSendTransactions = createSignAndSend(signerFactory)
+
+                            // Now we send all the transactions to the flow and observe the output
+                            const transactions = [...firstBatch, failedTransaction, ...secondBatch]
+                            const [successful, errors, pending] = await signAndSendTransactions(transactions)
+
+                            // Since we are executing groups of transactions in parallel,
+                            // in general the order of successful transaction will not match the order of input transactions
+                            expect(successful).toContainAllValues(
+                                expectedSuccessful.map((transaction) => ({ transaction, receipt }))
+                            )
+                            expect(errors).toEqual([{ transaction: failedTransaction, error }])
+                            expect(pending).toEqual([failedTransaction, ...expectedPending])
+
+                            // What needs to match though is the order of successful transactions within groups
+                            //
+                            // For that we group the successful transactions and make sure those are equal to the grouped original transactions
+                            const groupedSuccessful = groupTransactionsByEid(
+                                successful.map(({ transaction }) => transaction)
+                            )
+                            expect(groupedSuccessful).toEqual(groupTransactionsByEid(expectedSuccessful))
+
+                            // We also check that the signer factory has been called with the eids
+                            expect(signerFactory).toHaveBeenCalledWith(failedTransaction.point.eid)
+                            for (const transaction of firstBatch) {
+                                expect(signerFactory).toHaveBeenCalledWith(transaction.point.eid)
+                            }
+                        }
+                    )
+                )
+            })
         })
     })
 })


### PR DESCRIPTION
### In this PR

- Add a new feature flag `LZ_ENABLE_EXPERIMENTAL_BATCHED_WAIT` that controls the behavior of the transaction signing logic