### PR TITLE
🪲 Fix an issue with non-prototype property access in AsyncRetriable

### DIFF
--- a/.changeset/cuddly-goats-rush.md
+++ b/.changeset/cuddly-goats-rush.md
@@ -1,0 +1,6 @@
+---
+"@layerzerolabs/devtools": patch
+"@layerzerolabs/toolbox-hardhat": patch
+---
+
+Fix AsyncRetriable for non-prototype properties

--- a/packages/devtools/test/common/retry.test.ts
+++ b/packages/devtools/test/common/retry.test.ts
@@ -44,6 +44,24 @@ describe('common/retry', () => {
                 expect(mock).toHaveBeenNthCalledWith(2, 'y')
                 expect(mock).toHaveBeenNthCalledWith(3, 'y')
             })
+
+            it('should have access to non-prototype properties', async () => {
+                const mock = jest.fn().mockResolvedValue(true)
+
+                class WithAsyncRetriable {
+                    constructor(protected readonly property = 7) {}
+
+                    @AsyncRetriable({ enabled: true })
+                    async iHaveAccessToProperties() {
+                        return mock(this.property)
+                    }
+                }
+
+                await expect(new WithAsyncRetriable().iHaveAccessToProperties()).resolves.toBe(true)
+
+                expect(mock).toHaveBeenCalledTimes(1)
+                expect(mock).toHaveBeenNthCalledWith(1, 7)
+            })
         })
 
         describe('when LZ_ENABLE_EXPERIMENTAL_RETRY is on', () => {


### PR DESCRIPTION
### In this PR

- `AsyncRetriable` needs to call the replaced method with the current `this` context as opposed to the `target` context that points to the object's prototype, otherwise it has no access to non-prototype properties