### PR TITLE
🧹 Add Ownable SDK

### DIFF
--- a/.changeset/mighty-rules-film.md
+++ b/.changeset/mighty-rules-film.md
@@ -1,0 +1,7 @@
+---
+"@layerzerolabs/ua-devtools-evm": patch
+"@layerzerolabs/ua-devtools": patch
+"@layerzerolabs/toolbox-hardhat": patch
+---
+
+Add Ownable SDK for easy reuse

--- a/packages/ua-devtools-evm/src/oapp/sdk.ts
+++ b/packages/ua-devtools-evm/src/oapp/sdk.ts
@@ -13,55 +13,16 @@ import {
 import { type OmniContract, formatOmniContract } from '@layerzerolabs/devtools-evm'
 import type { EndpointId } from '@layerzerolabs/lz-definitions'
 import type { EndpointV2Factory, IEndpointV2 } from '@layerzerolabs/protocol-devtools'
-import { OmniSDK } from '@layerzerolabs/devtools-evm'
 import { printJson } from '@layerzerolabs/io-devtools'
 import { mapError, AsyncRetriable } from '@layerzerolabs/devtools'
-import { OwnableMixin } from '@/ownable/mixin'
+import { Ownable } from '@/ownable/sdk'
 
-export class OApp extends OmniSDK implements IOApp {
+export class OApp extends Ownable implements IOApp {
     constructor(
         contract: OmniContract,
         protected readonly endpointV2Factory: EndpointV2Factory
     ) {
         super(contract)
-    }
-
-    @AsyncRetriable()
-    getOwner(): Promise<string> {
-        // TODO This is a quick and dirty way of applying OwnableMixin
-        //
-        // The proper solution involves :
-        // - Option A: Using class decorators
-        // - Option B: Using dynamic classes
-        //
-        // TypeScript support for these is still lacking and the resulting code would slow
-        // down the development at this point
-        return OwnableMixin.getOwner.call(this)
-    }
-
-    @AsyncRetriable()
-    hasOwner(address: string): Promise<boolean> {
-        // TODO This is a quick and dirty way of applying OwnableMixin
-        //
-        // The proper solution involves :
-        // - Option A: Using class decorators
-        // - Option B: Using dynamic classes
-        //
-        // TypeScript support for these is still lacking and the resulting code would slow
-        // down the development at this point
-        return OwnableMixin.hasOwner.call(this, address)
-    }
-
-    setOwner(address: string): Promise<OmniTransaction> {
-        // TODO This is a quick and dirty way of applying OwnableMixin
-        //
-        // The proper solution involves :
-        // - Option A: Using class decorators
-        // - Option B: Using dynamic classes
-        //
-        // TypeScript support for these is still lacking and the resulting code would slow
-        // down the development at this point
-        return OwnableMixin.setOwner.call(this, address)
     }
 
     @AsyncRetriable()

--- a/packages/ua-devtools-evm/src/ownable/index.ts
+++ b/packages/ua-devtools-evm/src/ownable/index.ts
@@ -1,2 +1,3 @@
 export * from './factory'
 export * from './mixin'
+export * from './sdk'

--- a/packages/ua-devtools-evm/src/ownable/mixin.ts
+++ b/packages/ua-devtools-evm/src/ownable/mixin.ts
@@ -1,9 +1,9 @@
-import { OmniAddress, OmniTransaction, areBytes32Equal, mapError } from '@layerzerolabs/devtools'
+import { OmniAddress, OmniTransaction, areBytes32Equal, ignoreZero, mapError } from '@layerzerolabs/devtools'
 import { OmniSDK } from '@layerzerolabs/devtools-evm'
 import type { IOwnable } from '@layerzerolabs/ua-devtools'
 
 export const OwnableMixin: IOwnable = {
-    async getOwner(this: OmniSDK): Promise<OmniAddress> {
+    async getOwner(this: OmniSDK): Promise<OmniAddress | undefined> {
         this.logger.debug(`Getting owner`)
 
         const owner = await mapError(
@@ -11,7 +11,7 @@ export const OwnableMixin: IOwnable = {
             (error) => new Error(`Failed to get owner for OApp ${this.label}: ${error}`)
         )
 
-        return this.logger.debug(`Got owner: ${owner}`), owner
+        return this.logger.debug(`Got owner: ${owner}`), ignoreZero(owner)
     },
     async hasOwner(this: OmniSDK, address: OmniAddress): Promise<boolean> {
         this.logger.debug(`Checking whether owner is ${address}`)

--- a/packages/ua-devtools-evm/src/ownable/sdk.ts
+++ b/packages/ua-devtools-evm/src/ownable/sdk.ts
@@ -1,0 +1,21 @@
+import type { OmniAddress, OmniTransaction } from '@layerzerolabs/devtools'
+import { OmniSDK } from '@layerzerolabs/devtools-evm'
+import type { IOwnable } from '@layerzerolabs/ua-devtools'
+import { AsyncRetriable } from '@layerzerolabs/devtools'
+import { OwnableMixin } from './mixin'
+
+export class Ownable extends OmniSDK implements IOwnable {
+    @AsyncRetriable()
+    async getOwner(): Promise<OmniAddress | undefined> {
+        return OwnableMixin.getOwner.call(this)
+    }
+
+    @AsyncRetriable()
+    hasOwner(address: string): Promise<boolean> {
+        return OwnableMixin.hasOwner.call(this, address)
+    }
+
+    setOwner(address: string): Promise<OmniTransaction> {
+        return OwnableMixin.setOwner.call(this, address)
+    }
+}

--- a/packages/ua-devtools/src/ownable/types.ts
+++ b/packages/ua-devtools/src/ownable/types.ts
@@ -1,7 +1,7 @@
 import type { Configurator, Factory, OmniAddress, OmniGraph, OmniPoint, OmniTransaction } from '@layerzerolabs/devtools'
 
 export interface IOwnable {
-    getOwner(): Promise<OmniAddress>
+    getOwner(): Promise<OmniAddress | undefined>
     hasOwner(address: OmniAddress): Promise<boolean>
     setOwner(address: OmniAddress): Promise<OmniTransaction>
 }


### PR DESCRIPTION
### In this PR

- Add an `Ownable` SDK for easier consumption by OApps that extend OpenZeppelin `IOwnable`
- Ignore zero addresses when getting the owner, return `undefined` instead