### PR TITLE
🧹 Support contractName property on OmniPoint

### DIFF
--- a/.changeset/soft-gorillas-promise.md
+++ b/.changeset/soft-gorillas-promise.md
@@ -1,0 +1,8 @@
+---
+"@layerzerolabs/devtools-evm-hardhat": patch
+"@layerzerolabs/test-devtools": patch
+"@layerzerolabs/devtools": patch
+"@layerzerolabs/toolbox-hardhat": patch
+---
+
+Support contractName on OmniPoint

--- a/packages/devtools-evm-hardhat/src/omnigraph/coordinates.ts
+++ b/packages/devtools-evm-hardhat/src/omnigraph/coordinates.ts
@@ -1,4 +1,4 @@
-import type { OmniPoint } from '@layerzerolabs/devtools'
+import { formatEid, type OmniPoint } from '@layerzerolabs/devtools'
 import pMemoize from 'p-memoize'
 import { OmniContract } from '@layerzerolabs/devtools-evm'
 import { Contract } from '@ethersproject/contracts'
@@ -6,6 +6,7 @@ import assert from 'assert'
 import { OmniContractFactoryHardhat, OmniDeployment } from './types'
 import { createGetHreByEid } from '@/runtime'
 import { assertHardhatDeploy } from '@/internal/assertions'
+import { createModuleLogger } from '@layerzerolabs/io-devtools'
 
 export const omniDeploymentToPoint = ({ eid, deployment }: OmniDeployment): OmniPoint => ({
     eid,
@@ -19,19 +20,31 @@ export const omniDeploymentToContract = ({ eid, deployment }: OmniDeployment): O
 
 export const createContractFactory = (environmentFactory = createGetHreByEid()): OmniContractFactoryHardhat => {
     return pMemoize(async ({ eid, address, contractName }) => {
+        const logger = createModuleLogger(`Contract factory @ ${formatEid(eid)}`)
+
         const env = await environmentFactory(eid)
         assertHardhatDeploy(env)
 
         // If we have both the contract name & address, we go off artifacts
         if (contractName != null && address != null) {
-            const artifact = await env.deployments.getArtifact(contractName)
-            const contract = new Contract(address, artifact.abi)
+            logger.verbose(`Looking for contract ${contractName} on address ${address} in artifacts`)
 
-            return { eid, contract }
+            const artifact = await env.deployments.getArtifact(contractName).catch((error) => {
+                logger.verbose(`Failed to load artifact for contract ${contractName} on address ${address}: ${error}`)
+                logger.verbose(`Will search for the contract by its address only`)
+            })
+
+            if (artifact != null) {
+                const contract = new Contract(address, artifact.abi)
+
+                return { eid, contract }
+            }
         }
 
         // If we have the contract name but no address, we need to get it from the deployments by name
         if (contractName != null && address == null) {
+            logger.verbose(`Looking for contract ${contractName} in deployments`)
+
             const deployment = await env.deployments.getOrNull(contractName)
             assert(deployment != null, `Could not find a deployment for contract '${contractName}'`)
 
@@ -40,6 +53,8 @@ export const createContractFactory = (environmentFactory = createGetHreByEid()):
 
         // And if we only have the address, we need to go get it from deployments by address
         if (address != null) {
+            logger.verbose(`Looking for contract with address ${address} in deployments`)
+
             // The deployments can contain multiple deployment files for the same address
             //
             // This happens (besides of course a case of switching RPC URLs without changing network names)

--- a/packages/devtools-evm-hardhat/src/omnigraph/transformations.ts
+++ b/packages/devtools-evm-hardhat/src/omnigraph/transformations.ts
@@ -21,7 +21,7 @@ import { parallel } from '@layerzerolabs/devtools'
 export const createOmniPointHardhatTransformer =
     (contractFactory: OmniContractFactoryHardhat = createContractFactory()): OmniPointHardhatTransformer =>
     async (point) =>
-        isOmniPoint(point) ? point : omniContractToPoint(await contractFactory(point))
+        isOmniPoint(point) ? point : { ...point, ...omniContractToPoint(await contractFactory(point)) }
 
 /**
  * Create a function capable of transforming `OmniNodeHardhat` to a regular `OmniNode`

--- a/packages/devtools-evm-hardhat/src/omnigraph/types.ts
+++ b/packages/devtools-evm-hardhat/src/omnigraph/types.ts
@@ -19,6 +19,7 @@ export type OmniDeployment = WithEid<{
 export type OmniPointHardhat = WithEid<{
     contractName?: string | null
     address?: string | null
+    proxyAddress?: string | null
 }>
 
 export type WithContractName<T> = T & { contractName: string }

--- a/packages/devtools-evm-hardhat/src/omnigraph/types.ts
+++ b/packages/devtools-evm-hardhat/src/omnigraph/types.ts
@@ -19,7 +19,6 @@ export type OmniDeployment = WithEid<{
 export type OmniPointHardhat = WithEid<{
     contractName?: string | null
     address?: string | null
-    proxyAddress?: string | null
 }>
 
 export type WithContractName<T> = T & { contractName: string }

--- a/packages/devtools-evm-hardhat/test/omnigraph/coordinates.test.ts
+++ b/packages/devtools-evm-hardhat/test/omnigraph/coordinates.test.ts
@@ -87,6 +87,7 @@ describe('omnigraph/coordinates', () => {
                 const environmentFactory = createGetHreByEid(hre)
                 const contractFactory = createContractFactory(environmentFactory)
 
+                const address = makeZeroAddress()
                 const env = await environmentFactory(EndpointId.ETHEREUM_V2_MAINNET)
                 jest.spyOn(env.deployments, 'getArtifact').mockRejectedValue(new Error(`oh no`))
                 jest.spyOn(env.deployments, 'getDeploymentsFromAddress').mockResolvedValue([
@@ -99,7 +100,7 @@ describe('omnigraph/coordinates', () => {
                 // Then check whether the factory will get it for us
                 const deployment = await contractFactory({
                     eid: EndpointId.ETHEREUM_V2_MAINNET,
-                    address: makeZeroAddress(),
+                    address,
                     contractName: 'MyContract',
                 })
 
@@ -107,7 +108,8 @@ describe('omnigraph/coordinates', () => {
                     eid: EndpointId.ETHEREUM_V2_MAINNET,
                     contract: expect.any(Contract),
                 })
-                expect(env.deployments.getOrNull).toHaveBeenCalledWith('MyContract')
+                expect(env.deployments.getArtifact).toHaveBeenCalledWith('MyContract')
+                expect(env.deployments.getDeploymentsFromAddress).toHaveBeenCalledWith(address)
             })
 
             it('should resolve when contract has been deployed', async () => {

--- a/packages/devtools-evm-hardhat/test/omnigraph/coordinates.test.ts
+++ b/packages/devtools-evm-hardhat/test/omnigraph/coordinates.test.ts
@@ -89,10 +89,12 @@ describe('omnigraph/coordinates', () => {
 
                 const env = await environmentFactory(EndpointId.ETHEREUM_V2_MAINNET)
                 jest.spyOn(env.deployments, 'getArtifact').mockRejectedValue(new Error(`oh no`))
-                jest.spyOn(env.deployments, 'getOrNull').mockResolvedValue({
-                    address: makeZeroAddress(undefined),
-                    abi: [],
-                })
+                jest.spyOn(env.deployments, 'getDeploymentsFromAddress').mockResolvedValue([
+                    {
+                        address: makeZeroAddress(undefined),
+                        abi: [],
+                    },
+                ])
 
                 // Then check whether the factory will get it for us
                 const deployment = await contractFactory({

--- a/packages/devtools-evm-hardhat/test/omnigraph/transformations.test.ts
+++ b/packages/devtools-evm-hardhat/test/omnigraph/transformations.test.ts
@@ -56,7 +56,7 @@ describe('omnigraph/transformations', () => {
 
                     const transformed = await transformer(point)
 
-                    expect(transformed).toEqual({ eid: point.eid, address })
+                    expect(transformed).toEqual({ ...point, address })
                     expect(contractFactory).toHaveBeenCalledTimes(1)
                     expect(contractFactory).toHaveBeenCalledWith(point)
                 })

--- a/packages/devtools-evm-hardhat/test/omnigraph/transformations.test.ts
+++ b/packages/devtools-evm-hardhat/test/omnigraph/transformations.test.ts
@@ -62,6 +62,26 @@ describe('omnigraph/transformations', () => {
                 })
             )
         })
+
+        it('should add the contractName if point is not an OmniPoint', async () => {
+            await fc.assert(
+                fc.asyncProperty(pointHardhatArbitrary, evmAddressArbitrary, async (point, address) => {
+                    fc.pre(!isOmniPoint(point))
+
+                    const contract = new Contract(address, [])
+                    const contractFactory = jest
+                        .fn()
+                        .mockImplementation(async (point: OmniPointHardhat) => ({ eid: point.eid, contract }))
+                    const transformer = createOmniPointHardhatTransformer(contractFactory)
+
+                    const transformed = await transformer(point)
+
+                    expect(transformed).toEqual({ eid: point.eid, address, contractName: point.contractName })
+                    expect(contractFactory).toHaveBeenCalledTimes(1)
+                    expect(contractFactory).toHaveBeenCalledWith(point)
+                })
+            )
+        })
     })
 
     describe('createOmniNodeHardhatTransformer', () => {

--- a/packages/devtools/src/omnigraph/coordinates.ts
+++ b/packages/devtools/src/omnigraph/coordinates.ts
@@ -9,7 +9,8 @@ import { OmniVector, OmniPoint, OmniNode, WithEid } from './types'
  *
  * @returns `true` if the vector point to the same point in omniverse
  */
-export const arePointsEqual = (a: OmniPoint, b: OmniPoint): boolean => a.address === b.address && a.eid === b.eid
+export const arePointsEqual = (a: OmniPoint, b: OmniPoint): boolean =>
+    a.address === b.address && a.eid === b.eid && a.contractName === b.contractName
 
 /**
  * Checks if two points are on the same endpoint

--- a/packages/devtools/src/omnigraph/format.ts
+++ b/packages/devtools/src/omnigraph/format.ts
@@ -3,7 +3,8 @@ import type { OmniPoint, OmniVector } from './types'
 
 export const formatEid = (eid: EndpointId): string => EndpointId[eid] ?? `Unknown EndpointId (${eid})`
 
-export const formatOmniPoint = ({ eid, address }: OmniPoint): string => `[${address} @ ${formatEid(eid)}]`
+export const formatOmniPoint = ({ eid, address, contractName }: OmniPoint): string =>
+    `[${address}${contractName ? ` (${contractName})` : ``} @ ${formatEid(eid)}]`
 
 export const formatOmniVector = ({ from, to }: OmniVector): string =>
     `${formatOmniPoint(from)} → ${formatOmniPoint(to)}`

--- a/packages/devtools/src/omnigraph/schema.ts
+++ b/packages/devtools/src/omnigraph/schema.ts
@@ -52,6 +52,7 @@ export const EndpointIdSchema: z.ZodSchema<EndpointId, z.ZodTypeDef, string | nu
 export const OmniPointSchema: z.ZodSchema<OmniPoint, z.ZodTypeDef, unknown> = z.object({
     address: AddressSchema,
     eid: EndpointIdSchema,
+    contractName: z.string().nullish(),
 })
 
 export const OmniVectorSchema: z.ZodSchema<OmniVector, z.ZodTypeDef, unknown> = z.object({

--- a/packages/devtools/src/omnigraph/types.ts
+++ b/packages/devtools/src/omnigraph/types.ts
@@ -9,6 +9,7 @@ import { OmniTransaction } from '..'
  */
 export type OmniPoint = WithEid<{
     address: OmniAddress
+    contractName?: string | null
 }>
 
 /**

--- a/packages/devtools/test/omnigraph/coordinates.test.ts
+++ b/packages/devtools/test/omnigraph/coordinates.test.ts
@@ -8,7 +8,13 @@ import {
     isVectorPossible,
     withEid,
 } from '@/omnigraph/coordinates'
-import { addressArbitrary, endpointArbitrary, pointArbitrary, vectorArbitrary } from '@layerzerolabs/test-devtools'
+import {
+    addressArbitrary,
+    endpointArbitrary,
+    nullableArbitrary,
+    pointArbitrary,
+    vectorArbitrary,
+} from '@layerzerolabs/test-devtools'
 import { endpointIdToStage } from '@layerzerolabs/lz-definitions'
 
 describe('omnigraph/vector', () => {
@@ -46,6 +52,16 @@ describe('omnigraph/vector', () => {
                         fc.pre(point.eid !== eid)
 
                         expect(arePointsEqual(point, { ...point, eid })).toBeFalsy()
+                    })
+                )
+            })
+
+            it("should be false when contract names don't match", () => {
+                fc.assert(
+                    fc.property(pointArbitrary, nullableArbitrary(fc.string()), (point, contractName) => {
+                        fc.pre(point.contractName !== contractName)
+
+                        expect(arePointsEqual(point, { ...point, contractName })).toBeFalsy()
                     })
                 )
             })

--- a/packages/devtools/test/omnigraph/format.test.ts
+++ b/packages/devtools/test/omnigraph/format.test.ts
@@ -20,10 +20,24 @@ describe('omnigraph/format', () => {
     })
 
     describe('formatOmniPoint', () => {
-        it('should just work innit', () => {
+        it('should work without contract name innit', () => {
             fc.assert(
                 fc.property(pointArbitrary, (point) => {
+                    fc.pre(point.contractName == null)
+
                     expect(formatOmniPoint(point)).toBe(`[${point.address} @ ${formatEid(point.eid)}]`)
+                })
+            )
+        })
+
+        it('should work with contract name innit', () => {
+            fc.assert(
+                fc.property(pointArbitrary, (point) => {
+                    fc.pre(point.contractName != null)
+
+                    expect(formatOmniPoint(point)).toBe(
+                        `[${point.address} (${point.contractName}) @ ${formatEid(point.eid)}]`
+                    )
                 })
             )
         })

--- a/packages/devtools/test/omnigraph/format.test.ts
+++ b/packages/devtools/test/omnigraph/format.test.ts
@@ -23,7 +23,7 @@ describe('omnigraph/format', () => {
         it('should work without contract name innit', () => {
             fc.assert(
                 fc.property(pointArbitrary, (point) => {
-                    fc.pre(point.contractName == null)
+                    fc.pre(!point.contractName)
 
                     expect(formatOmniPoint(point)).toBe(`[${point.address} @ ${formatEid(point.eid)}]`)
                 })
@@ -33,7 +33,7 @@ describe('omnigraph/format', () => {
         it('should work with contract name innit', () => {
             fc.assert(
                 fc.property(pointArbitrary, (point) => {
-                    fc.pre(point.contractName != null)
+                    fc.pre(!!point.contractName)
 
                     expect(formatOmniPoint(point)).toBe(
                         `[${point.address} (${point.contractName}) @ ${formatEid(point.eid)}]`

--- a/packages/test-devtools/src/arbitraries.ts
+++ b/packages/test-devtools/src/arbitraries.ts
@@ -28,6 +28,7 @@ export const mnemonicArbitrary: fc.Arbitrary<string> = fc
 export const pointArbitrary = fc.record({
     eid: endpointArbitrary,
     address: evmAddressArbitrary,
+    contractName: nullableArbitrary(fc.string()),
 })
 
 export const vectorArbitrary = fc.record({


### PR DESCRIPTION
### In this PR

- Add `contractName` property on `OmniPoint` to support scenarios such as proxy contracts. When using proxy contracts, the contract ABI is not present in the deployment for a particular `address` - instead the ABI needs to be pulled from artifacts by the contract name and associated with an address (this is already the case in `createContractFactory`)