### PR TITLE
🪲 Fix deployment progress bar

### DIFF
--- a/.changeset/great-weeks-appear.md
+++ b/.changeset/great-weeks-appear.md
@@ -1,0 +1,6 @@
+---
+"@layerzerolabs/devtools-evm-hardhat": patch
+"@layerzerolabs/toolbox-hardhat": patch
+---
+
+Fix a display issue with deployment progressbar

--- a/packages/devtools-evm-hardhat/src/tasks/deploy.ts
+++ b/packages/devtools-evm-hardhat/src/tasks/deploy.ts
@@ -246,7 +246,7 @@ const action: ActionType<TaskArgs> = async (
                     createProgressBar({
                         before: 'Deploying... ',
                         after: ` ${numProcessed}/${selectedNetworks.length}`,
-                        progress: numProcessed,
+                        progress: numProcessed / selectedNetworks.length,
                     })
                 )
             }


### PR DESCRIPTION
### In this PR

- The progress bar in the deploy task was not being passed the progress as percentage but as a whole number so it was skipping to 100% immediatelly