### PR TITLE
🪲 Fix UIntBigIntSchema & UIntNumberSchema tests

### DIFF
--- a/packages/devtools/test/omnigraph/schema.test.ts
+++ b/packages/devtools/test/omnigraph/schema.test.ts
@@ -135,7 +135,12 @@ describe('omnigraph/schema', () => {
         it('should throw a ZodError for invalid values', () => {
             fc.assert(
                 fc.property(fc.anything(), (value) => {
-                    fc.pre(!UIntBigIntSchema.safeParse(value).success)
+                    try {
+                        fc.pre(!UIntBigIntSchema.safeParse(value).success)
+                    } catch {
+                        // If the parsing above fails (e.g. because the value is missing a toString or toValue methods),
+                        // we want to continue with the test since we want to check that an invalid value will fail
+                    }
 
                     // Here we expect that whatever we got, we'll not receive a SyntaxError
                     // (coming from a BigInt() constructor) but a ZodError
@@ -187,7 +192,12 @@ describe('omnigraph/schema', () => {
         it('should throw a ZodError for invalid values', () => {
             fc.assert(
                 fc.property(fc.anything(), (value) => {
-                    fc.pre(!UIntNumberSchema.safeParse(value).success)
+                    try {
+                        fc.pre(!UIntNumberSchema.safeParse(value).success)
+                    } catch {
+                        // If the parsing above fails (e.g. because the value is missing a toString or toValue methods),
+                        // we want to continue with the test since we want to check that an invalid value will fail
+                    }
 
                     // Here we expect that whatever we got, we'll not receive a SyntaxError
                     // (coming from a BigInt() constructor) but a ZodError

--- a/packages/devtools/test/omnigraph/schema.test.ts
+++ b/packages/devtools/test/omnigraph/schema.test.ts
@@ -135,12 +135,16 @@ describe('omnigraph/schema', () => {
         it('should throw a ZodError for invalid values', () => {
             fc.assert(
                 fc.property(fc.anything(), (value) => {
+                    let isValid = false
+
                     try {
-                        fc.pre(!UIntBigIntSchema.safeParse(value).success)
+                        isValid = UIntBigIntSchema.safeParse(value).success
                     } catch {
-                        // If the parsing above fails (e.g. because the value is missing a toString or toValue methods),
-                        // we want to continue with the test since we want to check that an invalid value will fail
+                        // This catch block is designed to catch errors caused by messed up standard methods
+                        // like toString or toValue that fast check throws at us
                     }
+
+                    fc.pre(!isValid)
 
                     // Here we expect that whatever we got, we'll not receive a SyntaxError
                     // (coming from a BigInt() constructor) but a ZodError
@@ -192,12 +196,16 @@ describe('omnigraph/schema', () => {
         it('should throw a ZodError for invalid values', () => {
             fc.assert(
                 fc.property(fc.anything(), (value) => {
+                    let isValid = false
+
                     try {
-                        fc.pre(!UIntNumberSchema.safeParse(value).success)
+                        isValid = UIntNumberSchema.safeParse(value).success
                     } catch {
-                        // If the parsing above fails (e.g. because the value is missing a toString or toValue methods),
-                        // we want to continue with the test since we want to check that an invalid value will fail
+                        // This catch block is designed to catch errors caused by messed up standard methods
+                        // like toString or toValue that fast check throws at us
                     }
+
+                    fc.pre(!isValid)
 
                     // Here we expect that whatever we got, we'll not receive a SyntaxError
                     // (coming from a BigInt() constructor) but a ZodError


### PR DESCRIPTION
### In this PR

- `fast-check`'s `anything` arbitrary sometimes throws in values with messed up standard object primitives - e.g. `toString` or `toValue` method is not a method. This broke a [recent test run on `main`](https://github.com/LayerZero-Labs/devtools/actions/runs/9004998600/job/24739305144)
- Since the test is checking whether an invalid value will not parse, the fix is to wrap the test precondition with `try`/`catch`
  - In case the `try` succeeds, the `fc.pre` is executed an potentially stops the test run
  - In case `try` fails, we know we have an invalid value on our hands so we continue the tes
