### PR TITLE
🪲 Fix silly cases for UIntNumberSchema

### DIFF
--- a/.changeset/slow-walls-impress.md
+++ b/.changeset/slow-walls-impress.md
@@ -1,0 +1,5 @@
+---
+"@layerzerolabs/devtools": patch
+---
+
+Update UIntNumberSchema to handle silly cases (like invalid toString() implementation)

--- a/packages/devtools/src/omnigraph/schema.ts
+++ b/packages/devtools/src/omnigraph/schema.ts
@@ -27,7 +27,21 @@ export const UIntBigIntSchema = z
     })
     .pipe(z.bigint().nonnegative())
 
-export const UIntNumberSchema = z.coerce.number().nonnegative().int()
+export const UIntNumberSchema = z
+    .unknown()
+    .transform((value, ctx): number => {
+        try {
+            return Number(value)
+        } catch {
+            ctx.addIssue({
+                code: z.ZodIssueCode.custom,
+                message: `Invalid Number-like value`,
+            })
+
+            return z.NEVER
+        }
+    })
+    .pipe(z.number().nonnegative().int())
 
 export const AddressSchema = z.string()
 


### PR DESCRIPTION
### In this PR

- Fix silly cases (mostly for tests) for `UIntNumberSchema` (e.g. missing/invalid `toString` method implementation)