### PR TITLE
🪲 Fix deployment loading slowness for large deployment sets

### DIFF
--- a/.changeset/fuzzy-shirts-sleep.md
+++ b/.changeset/fuzzy-shirts-sleep.md
@@ -1,0 +1,6 @@
+---
+"@layerzerolabs/devtools-evm-hardhat": patch
+"@layerzerolabs/toolbox-hardhat": patch
+---
+
+Only load all deployments if a deployment could not be found


### PR DESCRIPTION
### In this PR

- Only call `deployments.all()` if we fail to get a deployment, then retry. The `deployments.all()` is particularly expensive for large deployment sets and can dramatically decrease the performance