### PR TITLE
🗞️ Dry run mode for wire task

### DIFF
--- a/.changeset/grumpy-turtles-reply.md
+++ b/.changeset/grumpy-turtles-reply.md
@@ -1,0 +1,7 @@
+---
+"@layerzerolabs/ua-devtools-evm-hardhat-test": patch
+"@layerzerolabs/ua-devtools-evm-hardhat": patch
+"@layerzerolabs/toolbox-hardhat": patch
+---
+
+Add support for dry run mode in the wire task

--- a/tests/ua-devtools-evm-hardhat-test/test/task/oapp/wire.test.ts
+++ b/tests/ua-devtools-evm-hardhat-test/test/task/oapp/wire.test.ts
@@ -194,6 +194,17 @@ describe(`task ${TASK_LZ_OAPP_WIRE}`, () => {
             expect(promptToContinueMock).toHaveBeenCalledTimes(2)
         })
 
+        it('should return a list of pending transactions if running in dry run mode', async () => {
+            const oappConfig = configPathFixture('valid.config.connected.js')
+
+            const [successful, errors, pending] = await hre.run(TASK_LZ_OAPP_WIRE, { oappConfig, dryRun: true })
+
+            expect(successful).toEqual([])
+            expect(errors).toEqual([])
+            expect(pending).toHaveLength(2)
+            expect(promptToContinueMock).not.toHaveBeenCalled()
+        })
+
         it('should return a list of transactions if the user decides to continue', async () => {
             const oappConfig = configPathFixture('valid.config.connected.js')
 


### PR DESCRIPTION
### In this PR

- Add `--dry-run` flag to the wire task. This flag will make the task exit without signing any transactions