### PR TITLE
🧹 Ability to follow simulation logs

### DIFF
--- a/.changeset/red-toys-chew.md
+++ b/.changeset/red-toys-chew.md
@@ -1,0 +1,6 @@
+---
+"@layerzerolabs/devtools-evm-hardhat": patch
+"@layerzerolabs/toolbox-hardhat": patch
+---
+
+Add --follow flag to simulation logs task


### PR DESCRIPTION
### In this PR

- Add `--follow` CLI flag to `lz:test:simulation:logs` task that causes the logs command to follow the docker compose logs