### PR TITLE
🧹  Refactoring configureSendLibraries

### DIFF
--- a/.changeset/old-pens-yawn.md
+++ b/.changeset/old-pens-yawn.md
@@ -1,0 +1,5 @@
+---
+"@layerzerolabs/ua-devtools": patch
+---
+
+Added logging to configureSendLibraries

--- a/packages/ua-devtools/src/oapp/config.ts
+++ b/packages/ua-devtools/src/oapp/config.ts
@@ -109,12 +109,12 @@ export const configureSendLibraries: OAppConfigurator = withOAppLogger(
 
                 if (!isDefaultLibrary && currentSendLibrary === config.sendLibrary) {
                     logger.verbose(
-                        `Current sendLibrary is not default library and is already set to config.sendLibrary for ${formatOmniVector({ from, to })}, skipping`
+                        `Current sendLibrary is not default library and is already set to ${config.sendLibrary} for ${formatOmniVector({ from, to })}, skipping`
                     )
                     return []
                 }
 
-                logger.verbose(`Setting sendLibrary for ${formatOmniVector({ from, to })}`)
+                logger.verbose(`Setting sendLibrary ${config.sendLibrary} for ${formatOmniVector({ from, to })}`)
                 return [await endpointSdk.setSendLibrary(from.address, to.eid, config.sendLibrary)]
             },
             {

--- a/packages/ua-devtools/src/oapp/config.ts
+++ b/packages/ua-devtools/src/oapp/config.ts
@@ -96,7 +96,10 @@ export const configureSendLibraries: OAppConfigurator = withOAppLogger(
     createConfigureEdges(
         withOAppLogger(
             async ({ vector: { from, to }, config }, sdk): Promise<OmniTransaction[]> => {
+                const logger = createOAppLogger()
+
                 if (!config?.sendLibrary) {
+                    logger.verbose(`sendLibrary configuration not set for ${formatOmniVector({ from, to })}, skipping`)
                     return []
                 }
 
@@ -105,8 +108,13 @@ export const configureSendLibraries: OAppConfigurator = withOAppLogger(
                 const currentSendLibrary = await endpointSdk.getSendLibrary(from.address, to.eid)
 
                 if (!isDefaultLibrary && currentSendLibrary === config.sendLibrary) {
+                    logger.verbose(
+                        `Current sendLibrary is not default library and is already set to config.sendLibrary for ${formatOmniVector({ from, to })}, skipping`
+                    )
                     return []
                 }
+
+                logger.verbose(`Setting sendLibrary for ${formatOmniVector({ from, to })}`)
                 return [await endpointSdk.setSendLibrary(from.address, to.eid, config.sendLibrary)]
             },
             {


### PR DESCRIPTION
## In this PR:
- Refactored `configureSendLibraries` in `ua-devtools > src > oapp > config.ts` to use `createConfigureEdges` pattern and added logging