### PR TITLE
🧹 Don't overwrite the account configs in simulation

### DIFF
--- a/.changeset/spotty-pants-hear.md
+++ b/.changeset/spotty-pants-hear.md
@@ -1,0 +1,6 @@
+---
+"@layerzerolabs/devtools-evm-hardhat": patch
+"@layerzerolabs/toolbox-hardhat": patch
+---
+
+Don't overwrite hardhat network accounts for the simulation

--- a/packages/devtools-evm-hardhat/src/simulation/config.ts
+++ b/packages/devtools-evm-hardhat/src/simulation/config.ts
@@ -88,26 +88,6 @@ export const getHardhatNetworkOverrides = (
                 //
                 // This is the nginx server listening on the port we configured in the simulation configuration
                 url: new URL(networkName, `http://localhost:${config.port}`).toString(),
-                // For now the mnemonic in identical for all the networks and comes
-                // from the simulation configuration
-                //
-                // In future we could respect the mnemonics set in the original hardhat config
-                // but that comes with complexities:
-                //
-                // - Some networks / hardhat configs will not be using mnemonics
-                // - We don't want to be throwing production mnemonics around and storing them in json files
-                accounts: {
-                    mnemonic: config.anvil.mnemonic,
-                    // These need to be defaulted to the anvil options
-                    // (or the anvil defaults)
-                    //
-                    // See https://book.getfoundry.sh/reference/cli/anvil for anvil defaults
-                    count: config.anvil.count ?? 10,
-                    path: config.anvil.derivationPath ?? "m/44'/60'/0'/0/",
-                    // These will be hardcoded for now as anvil does not support setting these
-                    initialIndex: 0,
-                    passphrase: '',
-                },
             })
         )
     )

--- a/packages/devtools-evm-hardhat/test/simulation/config.test.ts
+++ b/packages/devtools-evm-hardhat/test/simulation/config.test.ts
@@ -6,6 +6,7 @@ import {
 import { mnemonicArbitrary } from '@layerzerolabs/test-devtools'
 import fc from 'fast-check'
 import hre from 'hardhat'
+import { HttpNetworkConfig } from 'hardhat/types'
 import { resolve } from 'path'
 
 describe('simulation/config', () => {
@@ -111,9 +112,19 @@ describe('simulation/config', () => {
 
         it('should return an object with networks mapped to anvil options if there are http networks', () => {
             const localhost = hre.config.networks.localhost
-            const networkA = { ...localhost, url: 'http://network.a' }
-            const networkB = { ...localhost, url: 'http://network.b' }
-            const networkC = { ...localhost, url: 'http://network.c' }
+            const networkA: HttpNetworkConfig = { ...localhost, url: 'http://network.a', accounts: [] }
+            const networkB: HttpNetworkConfig = {
+                ...localhost,
+                url: 'http://network.b',
+                accounts: {
+                    count: 10,
+                    initialIndex: 0,
+                    passphrase: '',
+                    path: "m/44'/60'/0'/0/",
+                    mnemonic: 'tomato potato',
+                },
+            }
+            const networkC: HttpNetworkConfig = { ...localhost, url: 'http://network.c', accounts: 'remote' }
             const simulationConfig = resolveSimulationConfig({}, hre.config)
 
             expect(
@@ -126,67 +137,14 @@ describe('simulation/config', () => {
                 networkA: {
                     ...networkA,
                     url: `http://localhost:${simulationConfig.port}/networkA`,
-                    accounts: {
-                        count: 10,
-                        initialIndex: 0,
-                        passphrase: '',
-                        path: "m/44'/60'/0'/0/",
-                        mnemonic: simulationConfig.anvil.mnemonic,
-                    },
                 },
                 networkB: {
                     ...networkB,
                     url: `http://localhost:${simulationConfig.port}/networkB`,
-                    accounts: {
-                        count: 10,
-                        initialIndex: 0,
-                        passphrase: '',
-                        path: "m/44'/60'/0'/0/",
-                        mnemonic: simulationConfig.anvil.mnemonic,
-                    },
                 },
                 networkC: {
                     ...networkC,
                     url: `http://localhost:${simulationConfig.port}/networkC`,
-                    accounts: {
-                        count: 10,
-                        initialIndex: 0,
-                        passphrase: '',
-                        path: "m/44'/60'/0'/0/",
-                        mnemonic: simulationConfig.anvil.mnemonic,
-                    },
-                },
-            })
-        })
-
-        it('should respect anvil accounts options', () => {
-            const localhost = hre.config.networks.localhost
-            const networkA = { ...localhost, url: 'http://network.a' }
-            const simulationConfig = resolveSimulationConfig(
-                {
-                    anvil: {
-                        count: 20,
-                        derivationPath: "m/44'/60'/0'/16/",
-                    },
-                },
-                hre.config
-            )
-
-            expect(
-                getHardhatNetworkOverrides(simulationConfig, {
-                    networkA,
-                })
-            ).toStrictEqual({
-                networkA: {
-                    ...networkA,
-                    url: `http://localhost:${simulationConfig.port}/networkA`,
-                    accounts: {
-                        count: simulationConfig.anvil.count,
-                        initialIndex: 0,
-                        passphrase: '',
-                        path: simulationConfig.anvil.derivationPath,
-                        mnemonic: simulationConfig.anvil.mnemonic,
-                    },
                 },
             })
         })


### PR DESCRIPTION
### In this PR

- Do not overwrite hardhat account configs for simulation. 
  - The simulation nodes will be started with the mnemonic configured in the `anvil` config
  - The network account configs will be kept the same

This allows users to run a _true_ simulation - with the accounts they would use on the actual networks.