### PR TITLE
🪲 Catch reverts when the default libraries are missing

### DIFF
--- a/.changeset/heavy-tigers-bow.md
+++ b/.changeset/heavy-tigers-bow.md
@@ -4,4 +4,4 @@
 "@layerzerolabs/toolbox-hardhat": patch
 ---
 
-Check for LZ_DefaultReceiveLibUnavailable on EndpointV2 when configuring receive libraries
+Check for LZ_DefaultReceiveLibUnavailable/LZ_DefaultSendLibUnavailable on EndpointV2 when receive libraries

--- a/.changeset/heavy-tigers-bow.md
+++ b/.changeset/heavy-tigers-bow.md
@@ -1,0 +1,7 @@
+---
+"@layerzerolabs/protocol-devtools-evm": patch
+"@layerzerolabs/devtools-evm": patch
+"@layerzerolabs/toolbox-hardhat": patch
+---
+
+Check for LZ_DefaultReceiveLibUnavailable on EndpointV2 when configuring receive libraries

--- a/packages/devtools-evm/src/omnigraph/sdk.ts
+++ b/packages/devtools-evm/src/omnigraph/sdk.ts
@@ -12,7 +12,7 @@ import { formatOmniContract } from './format'
  * to reduce the boilerplate
  */
 export abstract class OmniSDK implements IOmniSDK {
-    static #errorParserFactory: OmniContractErrorParserFactory = createContractErrorParser
+    static errorParserFactory: OmniContractErrorParserFactory = createContractErrorParser
 
     /**
      * Registers a `OmniContractErrorParserFactory` function to be used when
@@ -26,7 +26,7 @@ export abstract class OmniSDK implements IOmniSDK {
      * @returns {void}
      */
     static registerErrorParserFactory(factory: OmniContractErrorParserFactory | undefined): void {
-        this.#errorParserFactory = factory ?? createContractErrorParser
+        this.errorParserFactory = factory ?? createContractErrorParser
     }
 
     /**
@@ -39,7 +39,7 @@ export abstract class OmniSDK implements IOmniSDK {
     static createErrorParser(
         contract: OmniContract | null | undefined
     ): OmniContractErrorParser | Promise<OmniContractErrorParser> {
-        return this.#errorParserFactory(contract)
+        return this.errorParserFactory(contract)
     }
 
     constructor(

--- a/packages/protocol-devtools-evm/src/endpointv2/schema.ts
+++ b/packages/protocol-devtools-evm/src/endpointv2/schema.ts
@@ -1,0 +1,7 @@
+import { AddressSchema, ignoreZero } from '@layerzerolabs/devtools'
+import { z } from 'zod'
+
+/**
+ * Schema for parsing receive library information coming from the contract
+ */
+export const ReceiveLibrarySchema = z.tuple([AddressSchema.transform(ignoreZero), z.boolean()])

--- a/packages/protocol-devtools-evm/test/endpoint/sdk.test.ts
+++ b/packages/protocol-devtools-evm/test/endpoint/sdk.test.ts
@@ -63,4 +63,95 @@ describe('endpoint/sdk', () => {
             )
         })
     })
+
+    describe('getReceiveLibrary', () => {
+        const jestFunctionArbitrary = fc.anything().map(() => jest.fn())
+        const endpointContractArbitrary = fc.record({
+            address: evmAddressArbitrary,
+            getReceiveLibrary: jestFunctionArbitrary,
+            interface: fc.record({
+                parseError: jestFunctionArbitrary,
+            }),
+        }) as fc.Arbitrary<unknown> as fc.Arbitrary<Contract>
+
+        const omniContractArbitrary: fc.Arbitrary<OmniContract> = fc.record({
+            eid: endpointArbitrary,
+            contract: endpointContractArbitrary,
+        })
+
+        const uln302Factory = jest.fn().mockRejectedValue('No endpoint')
+
+        it('should return a tuple if the call succeeds', async () => {
+            await fc.assert(
+                fc.asyncProperty(
+                    omniContractArbitrary,
+                    endpointArbitrary,
+                    evmAddressArbitrary,
+                    evmAddressArbitrary,
+                    fc.boolean(),
+                    async (omniContract, eid, oappAddress, libraryAddress, isDefault) => {
+                        const sdk = new EndpointV2(omniContract, uln302Factory)
+
+                        omniContract.contract.getReceiveLibrary.mockResolvedValue([libraryAddress, isDefault])
+
+                        await expect(sdk.getReceiveLibrary(oappAddress, eid)).resolves.toEqual([
+                            libraryAddress,
+                            isDefault,
+                        ])
+                    }
+                )
+            )
+        })
+
+        it('should return an empty tuple if the call fails with LZ_DefaultReceiveLibUnavailable', async () => {
+            await fc.assert(
+                fc.asyncProperty(
+                    omniContractArbitrary,
+                    endpointArbitrary,
+                    evmAddressArbitrary,
+                    async (omniContract, eid, oappAddress) => {
+                        const sdk = new EndpointV2(omniContract, uln302Factory)
+                        const error = { data: '0x78e84d06' }
+
+                        // The LZ_DefaultReceiveLibUnavailable error
+                        omniContract.contract.getReceiveLibrary.mockRejectedValue(error)
+
+                        // Mock the contract interface since we don't have the ABI
+                        ;(omniContract.contract.interface.parseError as jest.Mock).mockReturnValue({
+                            name: 'LZ_DefaultReceiveLibUnavailable',
+                            args: [],
+                        })
+
+                        await expect(sdk.getReceiveLibrary(oappAddress, eid)).resolves.toEqual([undefined, false])
+
+                        expect(omniContract.contract.interface.parseError).toHaveBeenCalledWith(error.data)
+                    }
+                )
+            )
+        })
+
+        it('should reject if call fails but not with LZ_DefaultReceiveLibUnavailable', async () => {
+            await fc.assert(
+                fc.asyncProperty(
+                    omniContractArbitrary,
+                    endpointArbitrary,
+                    evmAddressArbitrary,
+                    async (omniContract, eid, oappAddress) => {
+                        const sdk = new EndpointV2(omniContract, uln302Factory)
+                        const error = { data: '0x86957466' }
+
+                        omniContract.contract.getReceiveLibrary.mockRejectedValue(error)
+                        ;(omniContract.contract.interface.parseError as jest.Mock).mockReturnValue({
+                            name: 'SomeOtherError',
+                            args: [],
+                        })
+
+                        await expect(sdk.getReceiveLibrary(oappAddress, eid)).rejects.toEqual(error)
+
+                        expect(omniContract.contract.interface.parseError).toHaveBeenCalledWith(error.data)
+                    }
+                )
+            )
+        })
+    })
 })

--- a/packages/protocol-devtools-evm/test/endpoint/sdk.test.ts
+++ b/packages/protocol-devtools-evm/test/endpoint/sdk.test.ts
@@ -103,7 +103,7 @@ describe('endpoint/sdk', () => {
             )
         })
 
-        it('should return an empty tuple if the call fails with LZ_DefaultReceiveLibUnavailable', async () => {
+        it('should return undefined as the default lib if the call fails with LZ_DefaultReceiveLibUnavailable', async () => {
             await fc.assert(
                 fc.asyncProperty(
                     omniContractArbitrary,
@@ -122,7 +122,7 @@ describe('endpoint/sdk', () => {
                             args: [],
                         })
 
-                        await expect(sdk.getReceiveLibrary(oappAddress, eid)).resolves.toEqual([undefined, false])
+                        await expect(sdk.getReceiveLibrary(oappAddress, eid)).resolves.toEqual([undefined, true])
 
                         expect(omniContract.contract.interface.parseError).toHaveBeenCalledWith(error.data)
                     }
@@ -147,6 +147,93 @@ describe('endpoint/sdk', () => {
                         })
 
                         await expect(sdk.getReceiveLibrary(oappAddress, eid)).rejects.toEqual(error)
+
+                        expect(omniContract.contract.interface.parseError).toHaveBeenCalledWith(error.data)
+                    }
+                )
+            )
+        })
+    })
+
+    describe('getSendLibrary', () => {
+        const jestFunctionArbitrary = fc.anything().map(() => jest.fn())
+        const endpointContractArbitrary = fc.record({
+            address: evmAddressArbitrary,
+            getSendLibrary: jestFunctionArbitrary,
+            interface: fc.record({
+                parseError: jestFunctionArbitrary,
+            }),
+        }) as fc.Arbitrary<unknown> as fc.Arbitrary<Contract>
+
+        const omniContractArbitrary: fc.Arbitrary<OmniContract> = fc.record({
+            eid: endpointArbitrary,
+            contract: endpointContractArbitrary,
+        })
+
+        const uln302Factory = jest.fn().mockRejectedValue('No endpoint')
+
+        it('should return an address if the call succeeds', async () => {
+            await fc.assert(
+                fc.asyncProperty(
+                    omniContractArbitrary,
+                    endpointArbitrary,
+                    evmAddressArbitrary,
+                    evmAddressArbitrary,
+                    async (omniContract, eid, oappAddress, libraryAddress) => {
+                        const sdk = new EndpointV2(omniContract, uln302Factory)
+
+                        omniContract.contract.getSendLibrary.mockResolvedValue(libraryAddress)
+
+                        await expect(sdk.getSendLibrary(oappAddress, eid)).resolves.toEqual(libraryAddress)
+                    }
+                )
+            )
+        })
+
+        it('should return undefined if the call fails with LZ_DefaultSendLibUnavailable', async () => {
+            await fc.assert(
+                fc.asyncProperty(
+                    omniContractArbitrary,
+                    endpointArbitrary,
+                    evmAddressArbitrary,
+                    async (omniContract, eid, oappAddress) => {
+                        const sdk = new EndpointV2(omniContract, uln302Factory)
+                        const error = { data: '0x6c1ccdb5' }
+
+                        // The LZ_DefaultReceiveLibUnavailable error
+                        omniContract.contract.getSendLibrary.mockRejectedValue(error)
+
+                        // Mock the contract interface since we don't have the ABI
+                        ;(omniContract.contract.interface.parseError as jest.Mock).mockReturnValue({
+                            name: 'LZ_DefaultSendLibUnavailable',
+                            args: [],
+                        })
+
+                        await expect(sdk.getSendLibrary(oappAddress, eid)).resolves.toEqual(undefined)
+
+                        expect(omniContract.contract.interface.parseError).toHaveBeenCalledWith(error.data)
+                    }
+                )
+            )
+        })
+
+        it('should reject if call fails but not with LZ_DefaultSendLibUnavailable', async () => {
+            await fc.assert(
+                fc.asyncProperty(
+                    omniContractArbitrary,
+                    endpointArbitrary,
+                    evmAddressArbitrary,
+                    async (omniContract, eid, oappAddress) => {
+                        const sdk = new EndpointV2(omniContract, uln302Factory)
+                        const error = { data: '0x86957466' }
+
+                        omniContract.contract.getSendLibrary.mockRejectedValue(error)
+                        ;(omniContract.contract.interface.parseError as jest.Mock).mockReturnValue({
+                            name: 'SomeOtherError',
+                            args: [],
+                        })
+
+                        await expect(sdk.getSendLibrary(oappAddress, eid)).rejects.toEqual(error)
 
                         expect(omniContract.contract.interface.parseError).toHaveBeenCalledWith(error.data)
                     }


### PR DESCRIPTION
### In this PR

- Catch `LZ_DefaultSendLibUnavailable` and `LZ_DefaultReceiveLibUnavailable` errors when getting send/receive libraries from the endpoint.
- In case of a missing receive library, `[address: undefined, isDefault: true]` will be returned
- In case of a missing send library, `undefined` will be returned

The visibility of static `errorParserFactory` needed to be changed since descendant classes could not read this private static property.