### PR TITLE
🧹 Add --prune-history to AnvilOptions

### DIFF
--- a/.changeset/stale-lemons-hide.md
+++ b/.changeset/stale-lemons-hide.md
@@ -1,0 +1,6 @@
+---
+"@layerzerolabs/devtools-evm": patch
+"@layerzerolabs/toolbox-hardhat": patch
+---
+
+Add --prune-history flag to AnvilOptions for simulation

--- a/packages/devtools-evm/src/simulation/anvil.ts
+++ b/packages/devtools-evm/src/simulation/anvil.ts
@@ -1,4 +1,4 @@
-import { pipe } from 'fp-ts/lib/function'
+import { identity, pipe } from 'fp-ts/lib/function'
 import * as A from 'fp-ts/Array'
 import * as O from 'fp-ts/Option'
 
@@ -39,6 +39,12 @@ export interface AnvilOptions {
 
     state?: string
     stateInterval?: number
+
+    //
+    // History
+    //
+
+    pruneHistory?: boolean
 }
 
 /**
@@ -61,6 +67,7 @@ export const createAnvilCliOptions = ({
     derivationPath,
     state,
     stateInterval,
+    pruneHistory,
 }: AnvilOptions): string[] =>
     pipe(
         [
@@ -111,6 +118,11 @@ export const createAnvilCliOptions = ({
             pipe(
                 O.fromNullable(stateInterval),
                 O.map((stateInterval) => ['--state-interval', String(stateInterval)])
+            ),
+            pipe(
+                O.fromNullable(pruneHistory),
+                O.filter(identity),
+                O.map(() => ['--prune-history'])
             ),
         ],
         A.compact,

--- a/packages/devtools-evm/test/simulation/__snapshots__/anvil.test.ts.snap
+++ b/packages/devtools-evm/test/simulation/__snapshots__/anvil.test.ts.snap
@@ -9,6 +9,13 @@ exports[`simulation/anvil createAnvilCliOptions() it should work for {"forkUrl":
 ]
 `;
 
+exports[`simulation/anvil createAnvilCliOptions() it should work for {"forkUrl":"http://hotmail.com/mainnet","pruneHistory":false} 1`] = `
+[
+  "--fork-url",
+  "http://hotmail.com/mainnet",
+]
+`;
+
 exports[`simulation/anvil createAnvilCliOptions() it should work for {"host":"0.0.0.0"} 1`] = `
 [
   "--host",
@@ -45,5 +52,11 @@ exports[`simulation/anvil createAnvilCliOptions() it should work for {"port":777
 [
   "--port",
   "7777",
+]
+`;
+
+exports[`simulation/anvil createAnvilCliOptions() it should work for {"pruneHistory":true} 1`] = `
+[
+  "--prune-history",
 ]
 `;

--- a/packages/devtools-evm/test/simulation/anvil.test.ts
+++ b/packages/devtools-evm/test/simulation/anvil.test.ts
@@ -49,6 +49,13 @@ describe('simulation/anvil', () => {
                 forkUrl: 'http://hotmail.com/mainnet',
                 blockTime: 1,
             },
+            {
+                forkUrl: 'http://hotmail.com/mainnet',
+                pruneHistory: false,
+            },
+            {
+                pruneHistory: true,
+            },
         ]
 
         TEST_CASES.forEach((testCase) => {


### PR DESCRIPTION
### In this PR

- For massive simulations on machines with limited resources the `anvil` nodes can quickly run out of space. Adding `pruneHistory` to `AnvilOptions` should take care of that