### PR TITLE
🧹 Allow users to specify whether the simulation accounts should be overwritten

### DIFF
--- a/.changeset/lemon-shrimps-pay.md
+++ b/.changeset/lemon-shrimps-pay.md
@@ -1,0 +1,6 @@
+---
+"@layerzerolabs/devtools-evm-hardhat": patch
+"@layerzerolabs/toolbox-hardhat": patch
+---
+
+Allow users to specify whether the simulation accounts should be overriden

--- a/packages/devtools-evm-hardhat/src/simulation/config.ts
+++ b/packages/devtools-evm-hardhat/src/simulation/config.ts
@@ -18,6 +18,7 @@ export const resolveSimulationConfig = (
 ): SimulationConfig => ({
     port: userConfig.port ?? 8545,
     directory: resolve(hardhatConfig.paths.root, userConfig.directory ?? '.layerzero'),
+    overwriteAccounts: userConfig.overwriteAccounts ?? true,
     anvil: {
         // For now we'll hardcode the mnemonic we'll use to seed the accounts on the simulation networks
         mnemonic: 'test test test test test test test test test test test junk',
@@ -88,6 +89,22 @@ export const getHardhatNetworkOverrides = (
                 //
                 // This is the nginx server listening on the port we configured in the simulation configuration
                 url: new URL(networkName, `http://localhost:${config.port}`).toString(),
+                accounts: config.overwriteAccounts
+                    ? // When overwriting accounts, all the accounts will be switched to the anvil config
+                      // (or reasonable defaults if not provided)
+                      {
+                          mnemonic: config.anvil.mnemonic,
+                          // These need to be defaulted to the anvil options
+                          // (or the anvil defaults)
+                          //
+                          // See https://book.getfoundry.sh/reference/cli/anvil for anvil defaults
+                          count: config.anvil.count ?? 10,
+                          path: config.anvil.derivationPath ?? "m/44'/60'/0'/0/",
+                          // These will be hardcoded for now as anvil does not support setting these
+                          initialIndex: 0,
+                          passphrase: '',
+                      }
+                    : networkConfig.accounts,
             })
         )
     )

--- a/packages/devtools-evm-hardhat/src/simulation/types.ts
+++ b/packages/devtools-evm-hardhat/src/simulation/types.ts
@@ -26,6 +26,17 @@ export interface SimulationUserConfig {
     directory?: string
 
     /**
+     * Simulation will by default overwrite the network accounts by values
+     * provided in Anvil config (or defaults if not present).
+     *
+     * The mnemonic will default to "test test test test test test test test test test test junk"
+     * and the number of funded accounts to 10.
+     *
+     * @default true
+     */
+    overwriteAccounts?: boolean
+
+    /**
      * Anvil overrides for the underlying EVM nodes.
      */
     anvil?: SimulationAnvilUserConfig
@@ -37,6 +48,7 @@ export interface SimulationUserConfig {
 export interface SimulationConfig {
     port: number
     directory: string
+    overwriteAccounts: boolean
     anvil: SimulationAnvilConfig
 }
 

--- a/packages/devtools-evm-hardhat/test/simulation/config.test.ts
+++ b/packages/devtools-evm-hardhat/test/simulation/config.test.ts
@@ -15,6 +15,7 @@ describe('simulation/config', () => {
             expect(resolveSimulationConfig({}, hre.config)).toEqual({
                 port: 8545,
                 directory: resolve(hre.config.paths.root, '.layerzero'),
+                overwriteAccounts: true,
                 anvil: {
                     host: '0.0.0.0',
                     port: 8545,
@@ -25,17 +26,29 @@ describe('simulation/config', () => {
 
         it('should not override user values if provided', () => {
             fc.assert(
-                fc.property(fc.integer(), fc.string(), mnemonicArbitrary, (port, directory, mnemonic) => {
-                    expect(resolveSimulationConfig({ port, directory, anvil: { mnemonic } }, hre.config)).toEqual({
-                        port,
-                        directory: resolve(hre.config.paths.root, directory),
-                        anvil: {
-                            host: '0.0.0.0',
-                            port: 8545,
-                            mnemonic,
-                        },
-                    })
-                })
+                fc.property(
+                    fc.integer(),
+                    fc.string(),
+                    mnemonicArbitrary,
+                    fc.boolean(),
+                    (port, directory, mnemonic, overwriteAccounts) => {
+                        expect(
+                            resolveSimulationConfig(
+                                { port, directory, overwriteAccounts, anvil: { mnemonic } },
+                                hre.config
+                            )
+                        ).toEqual({
+                            port,
+                            directory: resolve(hre.config.paths.root, directory),
+                            overwriteAccounts,
+                            anvil: {
+                                host: '0.0.0.0',
+                                port: 8545,
+                                mnemonic,
+                            },
+                        })
+                    }
+                )
             )
         })
     })

--- a/packages/devtools-evm-hardhat/test/simulation/config.test.ts
+++ b/packages/devtools-evm-hardhat/test/simulation/config.test.ts
@@ -110,42 +110,129 @@ describe('simulation/config', () => {
             ).toStrictEqual({})
         })
 
-        it('should return an object with networks mapped to anvil options if there are http networks', () => {
-            const localhost = hre.config.networks.localhost
-            const networkA: HttpNetworkConfig = { ...localhost, url: 'http://network.a', accounts: [] }
-            const networkB: HttpNetworkConfig = {
-                ...localhost,
-                url: 'http://network.b',
-                accounts: {
-                    count: 10,
-                    initialIndex: 0,
-                    passphrase: '',
-                    path: "m/44'/60'/0'/0/",
-                    mnemonic: 'tomato potato',
-                },
-            }
-            const networkC: HttpNetworkConfig = { ...localhost, url: 'http://network.c', accounts: 'remote' }
-            const simulationConfig = resolveSimulationConfig({}, hre.config)
+        describe('if overrideAccounts is set to false', () => {
+            it('should return an object with networks mapped to anvil options if there are http networks', () => {
+                const localhost = hre.config.networks.localhost
+                const networkA: HttpNetworkConfig = { ...localhost, url: 'http://network.a', accounts: [] }
+                const networkB: HttpNetworkConfig = {
+                    ...localhost,
+                    url: 'http://network.b',
+                    accounts: {
+                        count: 10,
+                        initialIndex: 0,
+                        passphrase: '',
+                        path: "m/44'/60'/0'/0/",
+                        mnemonic: 'tomato potato',
+                    },
+                }
+                const networkC: HttpNetworkConfig = { ...localhost, url: 'http://network.c', accounts: 'remote' }
+                const simulationConfig = resolveSimulationConfig({ overwriteAccounts: false }, hre.config)
 
-            expect(
-                getHardhatNetworkOverrides(simulationConfig, {
-                    networkA,
-                    networkB,
-                    networkC,
+                expect(
+                    getHardhatNetworkOverrides(simulationConfig, {
+                        networkA,
+                        networkB,
+                        networkC,
+                    })
+                ).toStrictEqual({
+                    networkA: {
+                        ...networkA,
+                        url: `http://localhost:${simulationConfig.port}/networkA`,
+                    },
+                    networkB: {
+                        ...networkB,
+                        url: `http://localhost:${simulationConfig.port}/networkB`,
+                    },
+                    networkC: {
+                        ...networkC,
+                        url: `http://localhost:${simulationConfig.port}/networkC`,
+                    },
                 })
-            ).toStrictEqual({
-                networkA: {
-                    ...networkA,
-                    url: `http://localhost:${simulationConfig.port}/networkA`,
-                },
-                networkB: {
-                    ...networkB,
-                    url: `http://localhost:${simulationConfig.port}/networkB`,
-                },
-                networkC: {
-                    ...networkC,
-                    url: `http://localhost:${simulationConfig.port}/networkC`,
-                },
+            })
+        })
+
+        describe('if overrideAccounts is set to true', () => {
+            it('should return an object with networks mapped to anvil options if there are http networks', () => {
+                const localhost = hre.config.networks.localhost
+                const networkA = { ...localhost, url: 'http://network.a' }
+                const networkB = { ...localhost, url: 'http://network.b' }
+                const networkC = { ...localhost, url: 'http://network.c' }
+                const simulationConfig = resolveSimulationConfig({ overwriteAccounts: true }, hre.config)
+
+                expect(
+                    getHardhatNetworkOverrides(simulationConfig, {
+                        networkA,
+                        networkB,
+                        networkC,
+                    })
+                ).toStrictEqual({
+                    networkA: {
+                        ...networkA,
+                        url: `http://localhost:${simulationConfig.port}/networkA`,
+                        accounts: {
+                            count: 10,
+                            initialIndex: 0,
+                            passphrase: '',
+                            path: "m/44'/60'/0'/0/",
+                            mnemonic: simulationConfig.anvil.mnemonic,
+                        },
+                    },
+                    networkB: {
+                        ...networkB,
+                        url: `http://localhost:${simulationConfig.port}/networkB`,
+                        accounts: {
+                            count: 10,
+                            initialIndex: 0,
+                            passphrase: '',
+                            path: "m/44'/60'/0'/0/",
+                            mnemonic: simulationConfig.anvil.mnemonic,
+                        },
+                    },
+                    networkC: {
+                        ...networkC,
+                        url: `http://localhost:${simulationConfig.port}/networkC`,
+                        accounts: {
+                            count: 10,
+                            initialIndex: 0,
+                            passphrase: '',
+                            path: "m/44'/60'/0'/0/",
+                            mnemonic: simulationConfig.anvil.mnemonic,
+                        },
+                    },
+                })
+            })
+
+            it('should respect anvil accounts options', () => {
+                const localhost = hre.config.networks.localhost
+                const networkA = { ...localhost, url: 'http://network.a' }
+                const simulationConfig = resolveSimulationConfig(
+                    {
+                        overwriteAccounts: true,
+                        anvil: {
+                            count: 20,
+                            derivationPath: "m/44'/60'/0'/16/",
+                        },
+                    },
+                    hre.config
+                )
+
+                expect(
+                    getHardhatNetworkOverrides(simulationConfig, {
+                        networkA,
+                    })
+                ).toStrictEqual({
+                    networkA: {
+                        ...networkA,
+                        url: `http://localhost:${simulationConfig.port}/networkA`,
+                        accounts: {
+                            count: simulationConfig.anvil.count,
+                            initialIndex: 0,
+                            passphrase: '',
+                            path: simulationConfig.anvil.derivationPath,
+                            mnemonic: simulationConfig.anvil.mnemonic,
+                        },
+                    },
+                })
             })
         })
     })


### PR DESCRIPTION
### In this PR

- To make #642 not affect the existing behavior, it has been adjusted with a flag that turns the account overwrites on/off
- The default value is `true` (which matches the previous behavior), setting it to an explicit `false` will turn the overwrites off