### PR TITLE
🧹 Add devtools configurator for OFTWrapper.setCallerBpsCap(...)

### DIFF
--- a/.changeset/seven-coats-add.md
+++ b/.changeset/seven-coats-add.md
@@ -1,0 +1,9 @@
+---
+"@layerzerolabs/ua-devtools-evm-hardhat-test": patch
+"@layerzerolabs/ua-devtools-evm": patch
+"@layerzerolabs/ua-devtools": patch
+"@layerzerolabs/devtools": patch
+"@layerzerolabs/oapp-example": patch
+---
+
+Added configuration for setting callerBpsCap

--- a/examples/oapp/layerzero.config.ts
+++ b/examples/oapp/layerzero.config.ts
@@ -21,9 +21,14 @@ const config: OAppOmniGraphHardhat = {
     contracts: [
         {
             contract: fujiContract,
-            config: {
-                callerBpsCap: BigInt(300),
-            },
+            /**
+             * This config object is optional.
+             * The callerBpsCap refers to the maximum fee (in basis points) that the contract can charge.
+             */
+
+            // config: {
+            //     callerBpsCap: BigInt(300),
+            // },
         },
         {
             contract: sepoliaContract,

--- a/examples/oapp/layerzero.config.ts
+++ b/examples/oapp/layerzero.config.ts
@@ -22,7 +22,7 @@ const config: OAppOmniGraphHardhat = {
         {
             contract: fujiContract,
             config: {
-                callerBpsCap: BigInt(1000),
+                callerBpsCap: BigInt(300),
             },
         },
         {

--- a/examples/oapp/layerzero.config.ts
+++ b/examples/oapp/layerzero.config.ts
@@ -22,8 +22,7 @@ const config: OAppOmniGraphHardhat = {
         {
             contract: fujiContract,
             config: {
-                callerBpsCap: 1000, // this is example of how callerBpsCap can be configured when calling lz:oapp:wire
-                // QUESTION: is this accurate + should this be in edges or nodes?
+                callerBpsCap: BigInt(1000),
             },
         },
         {

--- a/examples/oapp/layerzero.config.ts
+++ b/examples/oapp/layerzero.config.ts
@@ -21,6 +21,10 @@ const config: OAppOmniGraphHardhat = {
     contracts: [
         {
             contract: fujiContract,
+            config: {
+                callerBpsCap: 1000, // this is example of how callerBpsCap can be configured when calling lz:oapp:wire
+                // QUESTION: is this accurate + should this be in edges or nodes?
+            },
         },
         {
             contract: sepoliaContract,

--- a/packages/devtools/src/omnigraph/config.ts
+++ b/packages/devtools/src/omnigraph/config.ts
@@ -98,7 +98,8 @@ export const createConfigureEdges =
  *   configureReceiveLibraryTimeouts
  *   configureSendConfig
  *   configureReceiveConfig
- *   configureEnforcedOptions
+ *   configureEnforcedOptions,
+ *   configureCallerBpsCap,
  *   configureOAppDelegates
  * )
  * ```

--- a/packages/ua-devtools-evm/src/oapp/sdk.ts
+++ b/packages/ua-devtools-evm/src/oapp/sdk.ts
@@ -139,7 +139,7 @@ export class OApp extends Ownable implements IOApp {
     }
 
     async setCallerBpsCap(callerBpsCap: bigint): Promise<OmniTransaction | undefined> {
-        if (this.contract.contract.interface.functions['setCallerBpsCap'] == null) {
+        if (this.contract.contract.interface.functions['setCallerBpsCap(uint256)'] == null) {
             return (
                 this.logger.warn(
                     `Cannot set callerBpsCap for ${this.label}: setCallerBpsCap function is not supported`

--- a/packages/ua-devtools-evm/src/oapp/sdk.ts
+++ b/packages/ua-devtools-evm/src/oapp/sdk.ts
@@ -10,7 +10,7 @@ import {
     makeBytes32,
     Bytes,
 } from '@layerzerolabs/devtools'
-import { type OmniContract, formatOmniContract } from '@layerzerolabs/devtools-evm'
+import { type OmniContract, formatOmniContract, BigNumberishBigIntSchema } from '@layerzerolabs/devtools-evm'
 import type { EndpointId } from '@layerzerolabs/lz-definitions'
 import type { EndpointV2Factory, IEndpointV2 } from '@layerzerolabs/protocol-devtools'
 import { printJson } from '@layerzerolabs/io-devtools'
@@ -136,6 +136,22 @@ export class OApp extends Ownable implements IOApp {
             ...this.createTransaction(data),
             description: `Setting enforced options to ${printJson(enforcedOptions)}`,
         }
+    }
+
+    async setCallerBpsCap(callerBpsCap: bigint): Promise<OmniTransaction> {
+        const data = this.contract.contract.interface.encodeFunctionData('setCallerBpsCap', [callerBpsCap])
+
+        return {
+            ...this.createTransaction(data),
+            description: `Setting caller BPS cap to ${callerBpsCap}`,
+        }
+    }
+
+    @AsyncRetriable()
+    async getCallerBpsCap(): Promise<bigint> {
+        const callerBpsCap = await this.contract.contract.callerBpsCap()
+
+        return BigNumberishBigIntSchema.parse(callerBpsCap)
     }
 
     /**

--- a/packages/ua-devtools-evm/src/oapp/sdk.ts
+++ b/packages/ua-devtools-evm/src/oapp/sdk.ts
@@ -138,7 +138,15 @@ export class OApp extends Ownable implements IOApp {
         }
     }
 
-    async setCallerBpsCap(callerBpsCap: bigint): Promise<OmniTransaction> {
+    async setCallerBpsCap(callerBpsCap: bigint): Promise<OmniTransaction | undefined> {
+        if (this.contract.contract.interface.functions['setCallerBpsCap'] == null) {
+            return (
+                this.logger.warn(
+                    `Cannot set callerBpsCap for ${this.label}: setCallerBpsCap function is not supported`
+                ),
+                undefined
+            )
+        }
         const data = this.contract.contract.interface.encodeFunctionData('setCallerBpsCap', [callerBpsCap])
 
         return {
@@ -148,7 +156,15 @@ export class OApp extends Ownable implements IOApp {
     }
 
     @AsyncRetriable()
-    async getCallerBpsCap(): Promise<bigint> {
+    async getCallerBpsCap(): Promise<bigint | undefined> {
+        // We want to return undefined if there is no callerBpsCap defined on the contract as opposed to throwing
+        // since throwing would trigger the async retriable
+        if (this.contract.contract.interface.functions['callerBpsCap()'] == null) {
+            return (
+                this.logger.warn(`Cannot get callerBpsCap for ${this.label}: callerBpsCap function is not supported`),
+                undefined
+            )
+        }
         const callerBpsCap = await this.contract.contract.callerBpsCap()
 
         return BigNumberishBigIntSchema.parse(callerBpsCap)

--- a/packages/ua-devtools/src/oapp/types.ts
+++ b/packages/ua-devtools/src/oapp/types.ts
@@ -25,6 +25,8 @@ export interface IOApp extends IOmniSDK, IOwnable {
     setDelegate(address: OmniAddress): Promise<OmniTransaction>
     getEnforcedOptions(eid: EndpointId, msgType: number): Promise<Bytes>
     setEnforcedOptions(enforcedOptions: OAppEnforcedOptionParam[]): Promise<OmniTransaction>
+    getCallerBpsCap(): Promise<bigint>
+    setCallerBpsCap(callerBpsCap: bigint): Promise<OmniTransaction>
 }
 
 export interface OAppReceiveLibraryConfig {

--- a/packages/ua-devtools/src/oapp/types.ts
+++ b/packages/ua-devtools/src/oapp/types.ts
@@ -45,6 +45,7 @@ export interface OAppReceiveConfig {
 
 export interface OAppNodeConfig extends OwnableNodeConfig {
     delegate?: OmniAddress | null
+    callerBpsCap?: bigint
 }
 
 export interface OAppEdgeConfig {

--- a/packages/ua-devtools/src/oapp/types.ts
+++ b/packages/ua-devtools/src/oapp/types.ts
@@ -25,8 +25,8 @@ export interface IOApp extends IOmniSDK, IOwnable {
     setDelegate(address: OmniAddress): Promise<OmniTransaction>
     getEnforcedOptions(eid: EndpointId, msgType: number): Promise<Bytes>
     setEnforcedOptions(enforcedOptions: OAppEnforcedOptionParam[]): Promise<OmniTransaction>
-    getCallerBpsCap(): Promise<bigint>
-    setCallerBpsCap(callerBpsCap: bigint): Promise<OmniTransaction>
+    getCallerBpsCap(): Promise<bigint | undefined>
+    setCallerBpsCap(callerBpsCap: bigint): Promise<OmniTransaction | undefined>
 }
 
 export interface OAppReceiveLibraryConfig {

--- a/tests/ua-devtools-evm-hardhat-test/contracts/DefaultOApp.sol
+++ b/tests/ua-devtools-evm-hardhat-test/contracts/DefaultOApp.sol
@@ -6,7 +6,17 @@ import { OApp, Origin } from "@layerzerolabs/lz-evm-oapp-v2/contracts/oapp/OApp.
 import { OAppOptionsType3 } from "@layerzerolabs/lz-evm-oapp-v2/contracts/oapp/libs/OAppOptionsType3.sol";
 
 contract DefaultOApp is OApp, OAppOptionsType3 {
+    uint256 public callerBpsCap; // TODO can move to a different contract for testing
+
     constructor(address _endpoint, address _delegate) OApp(_endpoint, _delegate) Ownable(_delegate) {}
 
     function _lzReceive(Origin calldata, bytes32, bytes calldata, address, bytes calldata) internal virtual override {}
+
+    /**
+        Copied from https://github.com/stargate-protocol/stargate-v2/blob/3556e333b197b4f3706c68aa2b5cb4060c9c3812/packages/stg-evm-v2/src/peripheral/oft-wrapper/OFTWrapper.sol#L38-L42
+        (except validations and event emitting)
+    */
+    function setCallerBpsCap(uint256 _callerBpsCap) external onlyOwner {
+        callerBpsCap = _callerBpsCap;
+    }
 }

--- a/tests/ua-devtools-evm-hardhat-test/contracts/DefaultOApp.sol
+++ b/tests/ua-devtools-evm-hardhat-test/contracts/DefaultOApp.sol
@@ -6,7 +6,9 @@ import { OApp, Origin } from "@layerzerolabs/lz-evm-oapp-v2/contracts/oapp/OApp.
 import { OAppOptionsType3 } from "@layerzerolabs/lz-evm-oapp-v2/contracts/oapp/libs/OAppOptionsType3.sol";
 
 contract DefaultOApp is OApp, OAppOptionsType3 {
-    uint256 public callerBpsCap; // TODO can move to a different contract for testing
+    event CallerBpsCapSet(uint256 callerBpsCap);
+
+    uint256 public callerBpsCap;
 
     constructor(address _endpoint, address _delegate) OApp(_endpoint, _delegate) Ownable(_delegate) {}
 
@@ -14,9 +16,10 @@ contract DefaultOApp is OApp, OAppOptionsType3 {
 
     /**
         Copied from https://github.com/stargate-protocol/stargate-v2/blob/3556e333b197b4f3706c68aa2b5cb4060c9c3812/packages/stg-evm-v2/src/peripheral/oft-wrapper/OFTWrapper.sol#L38-L42
-        (except validations and event emitting)
+        (except validations)
     */
     function setCallerBpsCap(uint256 _callerBpsCap) external onlyOwner {
         callerBpsCap = _callerBpsCap;
+        emit CallerBpsCapSet(_callerBpsCap);
     }
 }

--- a/tests/ua-devtools-evm-hardhat-test/test/oapp/config.test.ts
+++ b/tests/ua-devtools-evm-hardhat-test/test/oapp/config.test.ts
@@ -2365,9 +2365,8 @@ describe('oapp/config', () => {
                 }
 
                 const signAndSend = createSignAndSend(createSignerFactory())
-                if (avaxContract.contract.interface.functions['setCallerBpsCap(uint256)'] != null) {
-                    await signAndSend([(await avaxOAppSdk.setCallerBpsCap(avaxCallerBpsCap)) as OmniTransaction])
-                }
+                await signAndSend([await avaxOAppSdk.setCallerBpsCap(avaxCallerBpsCap)])
+                expect(await avaxOAppSdk.getCallerBpsCap()).toBe(avaxCallerBpsCap)
 
                 expect(await configureCallerBpsCap(graph, oappSdkFactory)).toEqual([])
             })
@@ -2397,6 +2396,16 @@ describe('oapp/config', () => {
                     await avaxOAppSdk.setCallerBpsCap(avaxCallerBpsCap),
                     await ethOAppSdk.setCallerBpsCap(ethCallerBpsCap),
                 ])
+
+                /**
+                 * Now we'll check if the callerBpsCap has been set correctly after above transactions are signed and sent
+                 */
+                const signAndSend = createSignAndSend(createSignerFactory())
+                await signAndSend([await avaxOAppSdk.setCallerBpsCap(avaxCallerBpsCap)])
+                expect(await avaxOAppSdk.getCallerBpsCap()).toBe(avaxCallerBpsCap)
+
+                await signAndSend([await ethOAppSdk.setCallerBpsCap(ethCallerBpsCap)])
+                expect(await ethOAppSdk.getCallerBpsCap()).toBe(ethCallerBpsCap)
             })
         })
     })

--- a/tests/ua-devtools-evm-hardhat-test/test/oapp/config.test.ts
+++ b/tests/ua-devtools-evm-hardhat-test/test/oapp/config.test.ts
@@ -2351,7 +2351,7 @@ describe('oapp/config', () => {
             })
 
             it('should not set callerBpsCap that has already been set', async () => {
-                const avaxCallerBpsCap = BigInt(1000)
+                const avaxCallerBpsCap = BigInt(100)
                 const graph: OAppOmniGraph = {
                     contracts: [
                         {
@@ -2377,7 +2377,7 @@ describe('oapp/config', () => {
                         {
                             point: bscPoint,
                             config: {
-                                callerBpsCap: BigInt(1000),
+                                callerBpsCap: BigInt(100),
                             },
                         },
                     ],
@@ -2388,8 +2388,8 @@ describe('oapp/config', () => {
             })
 
             it('should return all setCallerBpsCap transactions if callerBpsCap is specified', async () => {
-                const avaxCallerBpsCap = BigInt(1000)
-                const ethCallerBpsCap = BigInt(5000)
+                const avaxCallerBpsCap = BigInt(100)
+                const ethCallerBpsCap = BigInt(300)
                 const graph: OAppOmniGraph = {
                     contracts: [
                         {

--- a/tests/ua-devtools-evm-hardhat-test/test/oapp/config.test.ts
+++ b/tests/ua-devtools-evm-hardhat-test/test/oapp/config.test.ts
@@ -2351,7 +2351,7 @@ describe('oapp/config', () => {
             })
 
             it('should not set callerBpsCap that has already been set', async () => {
-                const avaxCallerBpsCap = 1000
+                const avaxCallerBpsCap = BigInt(1000)
                 const graph: OAppOmniGraph = {
                     contracts: [
                         {
@@ -2371,8 +2371,8 @@ describe('oapp/config', () => {
             })
 
             it('should return all setCallerBpsCap transactions if callerBpsCap is specified', async () => {
-                const avaxCallerBpsCap = 1000
-                const ethCallerBpsCap = 5000
+                const avaxCallerBpsCap = BigInt(1000)
+                const ethCallerBpsCap = BigInt(5000)
                 const graph: OAppOmniGraph = {
                     contracts: [
                         {

--- a/tests/ua-devtools-evm-hardhat-test/test/oapp/config.test.ts
+++ b/tests/ua-devtools-evm-hardhat-test/test/oapp/config.test.ts
@@ -2365,7 +2365,7 @@ describe('oapp/config', () => {
                 }
 
                 const signAndSend = createSignAndSend(createSignerFactory())
-                if (avaxContract.contract.interface.functions['setCallerBpsCap'] != null) {
+                if (avaxContract.contract.interface.functions['setCallerBpsCap(uint256)'] != null) {
                     await signAndSend([(await avaxOAppSdk.setCallerBpsCap(avaxCallerBpsCap)) as OmniTransaction])
                 }
 

--- a/tests/ua-devtools-evm-hardhat-test/test/oapp/config.test.ts
+++ b/tests/ua-devtools-evm-hardhat-test/test/oapp/config.test.ts
@@ -2301,5 +2301,9 @@ describe('oapp/config', () => {
                 expect(transactionsAgain).toEqual([])
             })
         })
+
+        describe('configureCallerBpsCap', () => {
+            // TODO
+        })
     })
 })

--- a/tests/ua-devtools-evm-hardhat-test/test/oapp/config.test.ts
+++ b/tests/ua-devtools-evm-hardhat-test/test/oapp/config.test.ts
@@ -2365,7 +2365,9 @@ describe('oapp/config', () => {
                 }
 
                 const signAndSend = createSignAndSend(createSignerFactory())
-                await signAndSend([await avaxOAppSdk.setCallerBpsCap(avaxCallerBpsCap)])
+                if (avaxContract.contract.interface.functions['setCallerBpsCap'] != null) {
+                    await signAndSend([(await avaxOAppSdk.setCallerBpsCap(avaxCallerBpsCap)) as OmniTransaction])
+                }
 
                 expect(await configureCallerBpsCap(graph, oappSdkFactory)).toEqual([])
             })


### PR DESCRIPTION
## In this PR:
- Adds getter and setter for `OFTWrapper.callerBpsCap` in `packages/ua-devtools-evm/src/oapp/sdk.ts`
- Calling above getter/setter in configurator
- Also have an example of how `callerBpsCap` can be configured in `layerzero.config.ts`