### PR TITLE
🧹 Add a test for an external contract in connections

### DIFF
--- a/tests/ua-devtools-evm-hardhat-test/test/task/oapp/__data__/configs/valid.config.connected.external.connection.js
+++ b/tests/ua-devtools-evm-hardhat-test/test/task/oapp/__data__/configs/valid.config.connected.external.connection.js
@@ -1,0 +1,47 @@
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { makeBytes32 } = require('@layerzerolabs/devtools');
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { EndpointId } = require('@layerzerolabs/lz-definitions');
+
+const ethContract = {
+    eid: EndpointId.ETHEREUM_V2_MAINNET,
+    contractName: 'DefaultOApp',
+};
+
+const avaxContract = {
+    eid: EndpointId.AVALANCHE_V2_MAINNET,
+    contractName: 'DefaultOApp',
+};
+
+// This contract points to a Solana contract that is not present in the hardhat config
+//
+// Since it's only used as a `to` in a connection, the scripts should still work
+const solContract = {
+    eid: EndpointId.SEPOLIA_V2_MAINNET,
+    address: makeBytes32('0x7a4WjyR8VZ7yZz5XJAKm39BUGn5iT9CKcv2pmG9tdXVH'),
+};
+
+module.exports = {
+    contracts: [
+        {
+            contract: avaxContract,
+        },
+        {
+            contract: ethContract,
+        },
+    ],
+    connections: [
+        {
+            from: avaxContract,
+            to: ethContract,
+        },
+        {
+            from: ethContract,
+            to: avaxContract,
+        },
+        {
+            from: ethContract,
+            to: solContract,
+        },
+    ],
+};

--- a/tests/ua-devtools-evm-hardhat-test/test/task/oapp/__data__/configs/valid.config.connected.external.connection.js
+++ b/tests/ua-devtools-evm-hardhat-test/test/task/oapp/__data__/configs/valid.config.connected.external.connection.js
@@ -1,6 +1,4 @@
 // eslint-disable-next-line @typescript-eslint/no-var-requires
-const { makeBytes32 } = require('@layerzerolabs/devtools');
-// eslint-disable-next-line @typescript-eslint/no-var-requires
 const { EndpointId } = require('@layerzerolabs/lz-definitions');
 
 const ethContract = {
@@ -17,8 +15,8 @@ const avaxContract = {
 //
 // Since it's only used as a `to` in a connection, the scripts should still work
 const solContract = {
-    eid: EndpointId.SEPOLIA_V2_MAINNET,
-    address: makeBytes32('0x7a4WjyR8VZ7yZz5XJAKm39BUGn5iT9CKcv2pmG9tdXVH'),
+    eid: EndpointId.SOLANA_V2_MAINNET,
+    address: '0x708687b6133d4eff7fdfe1adb237dfa01d3671f924f9991c5676729cedce9efd',
 };
 
 module.exports = {

--- a/tests/ua-devtools-evm-hardhat-test/test/task/oapp/wire.test.ts
+++ b/tests/ua-devtools-evm-hardhat-test/test/task/oapp/wire.test.ts
@@ -378,6 +378,21 @@ describe(`task ${TASK_LZ_OAPP_WIRE}`, () => {
             )
         })
 
+        it('should work if an external contract is used in `to` of a connection', async () => {
+            const oappConfig = configPathFixture('valid.config.connected.external.connection.js')
+
+            promptToContinueMock.mockResolvedValue(false)
+
+            const result = await hre.run(TASK_LZ_OAPP_WIRE, { oappConfig, ci: true })
+
+            expect(result).toEqual([
+                [expectTransactionWithReceipt, expectTransactionWithReceipt, expectTransactionWithReceipt],
+                [],
+                [],
+            ])
+            expect(promptToContinueMock).not.toHaveBeenCalled()
+        })
+
         describe('if a transaction fails', () => {
             let sendTransactionMock: jest.SpyInstance
 


### PR DESCRIPTION
### In this PR

- Add a test case for the wire task that involves an external contract set as a `to` for a connection