### PR TITLE
🗞️ Stub of devtools-cli package

### DIFF
--- a/packages/devtools-cli/.eslintignore
+++ b/packages/devtools-cli/.eslintignore
@@ -1,0 +1,2 @@
+dist
+node_modules

--- a/packages/devtools-cli/.eslintrc.json
+++ b/packages/devtools-cli/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../.eslintrc.json"
+}

--- a/packages/devtools-cli/.prettierignore
+++ b/packages/devtools-cli/.prettierignore
@@ -1,0 +1,2 @@
+dist/
+node_modules/

--- a/packages/devtools-cli/README.md
+++ b/packages/devtools-cli/README.md
@@ -1,0 +1,31 @@
+<p align="center">
+  <a href="https://layerzero.network">
+    <img alt="LayerZero" style="max-width: 500px" src="https://d3a2dpnnrypp5h.cloudfront.net/bridge-app/lz.png"/>
+  </a>
+</p>
+
+<h1 align="center">@layerzerolabs/devtools-cli</h1>
+
+<!-- The badges section -->
+<p align="center">
+  <!-- Shields.io NPM published package version -->
+  <a href="https://www.npmjs.com/package/@layerzerolabs/devtools-cli"><img alt="NPM Version" src="https://img.shields.io/npm/v/@layerzerolabs/devtools-cli"/></a>
+  <!-- Shields.io NPM downloads -->
+  <a href="https://www.npmjs.com/package/@layerzerolabs/devtools-cli"><img alt="Downloads" src="https://img.shields.io/npm/dm/@layerzerolabs/devtools-cli"/></a>
+  <!-- Shields.io license badge -->
+  <a href="https://www.npmjs.com/package/@layerzerolabs/devtools-cli"><img alt="NPM License" src="https://img.shields.io/npm/l/@layerzerolabs/devtools-cli"/></a>
+</p>
+
+## LayerZero devtools CLI <img alt="Static Badge" src="https://img.shields.io/badge/status-work_in_progress-yellow">
+
+This package provides a network-agnostic CLI interface for configuring LayerZero OApp contracts.
+
+```bash
+npx @layerzerolabs/devtools-cli@latest
+# or
+yarn @layerzerolabs/devtools-cli
+# or
+pnpm @layerzerolabs/devtools-cli
+# or
+bunx @layerzerolabs/devtools-cli
+```

--- a/packages/devtools-cli/cli.js
+++ b/packages/devtools-cli/cli.js
@@ -1,0 +1,3 @@
+#!/usr/bin/env node
+
+import('./dist/index.js');

--- a/packages/devtools-cli/jest.config.js
+++ b/packages/devtools-cli/jest.config.js
@@ -1,0 +1,10 @@
+/** @type {import('ts-jest').JestConfigWithTsJest} */
+module.exports = {
+    preset: 'ts-jest',
+    reporters: [['github-actions', { silent: false }], 'default'],
+    testEnvironment: 'node',
+    testTimeout: 15000,
+    moduleNameMapper: {
+        '^@/(.*)$': '<rootDir>/src/$1',
+    },
+};

--- a/packages/devtools-cli/package.json
+++ b/packages/devtools-cli/package.json
@@ -1,0 +1,58 @@
+{
+  "name": "@layerzerolabs/devtools-cli",
+  "version": "0.0.1",
+  "description": "CLI for configuring LayerZero OApp contracts",
+  "keywords": [
+    "LayerZero",
+    "OApp",
+    "CLI"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/LayerZero-Labs/devtools.git",
+    "directory": "packages/devtools-cli"
+  },
+  "license": "MIT",
+  "bin": {
+    "@layerzerolabs/devtools-cli": "./cli.js"
+  },
+  "files": [
+    "cli.js",
+    "dist"
+  ],
+  "scripts": {
+    "prebuild": "tsc -noEmit",
+    "build": "$npm_execpath tsup",
+    "clean": "rm -rf dist",
+    "dev": "$npm_execpath tsup --watch",
+    "lint": "$npm_execpath eslint '**/*.{js,ts,json}'",
+    "lint:fix": "eslint --fix '**/*.{js,ts,json}'",
+    "start": "./cli.js"
+  },
+  "dependencies": {
+    "yoga-layout-prebuilt": "^1.10.0"
+  },
+  "devDependencies": {
+    "@layerzerolabs/devtools": "~0.3.17",
+    "@layerzerolabs/io-devtools": "~0.1.11",
+    "@types/prompts": "^2.4.9",
+    "@types/react": "^17.0.74",
+    "commander": "^11.1.0",
+    "eslint-plugin-react": "^7.33.2",
+    "eslint-plugin-react-hooks": "^4.6.0",
+    "ink": "^3.2.0",
+    "ink-gradient": "^2.0.0",
+    "prompts": "^2.4.2",
+    "react": "^17.0.2",
+    "ts-node": "^10.9.2",
+    "tsup": "~8.0.1",
+    "typescript": "^5.3.3",
+    "zod": "^3.22.4"
+  },
+  "engines": {
+    "node": ">=18"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/devtools-cli/src/commands/oapp/index.ts
+++ b/packages/devtools-cli/src/commands/oapp/index.ts
@@ -1,0 +1,4 @@
+import { Command } from 'commander'
+import { wire } from './wire'
+
+export const oapp = new Command('oapp').description('OApp configuration commands').addCommand(wire)

--- a/packages/devtools-cli/src/commands/oapp/wire/index.ts
+++ b/packages/devtools-cli/src/commands/oapp/wire/index.ts
@@ -1,0 +1,21 @@
+import { Command } from 'commander'
+import { printLogo } from '@layerzerolabs/io-devtools/swag'
+import { createLogger, setDefaultLogLevel } from '@layerzerolabs/io-devtools'
+import { type WithLogLevelOption, type WithSetupOption, createSetupFileOption } from '@/commands/options'
+
+interface Args extends WithLogLevelOption, WithSetupOption {}
+
+export const wire = new Command('wire').addOption(createSetupFileOption()).action(async ({ setup, logLevel }: Args) => {
+    printLogo()
+
+    // We'll set the global logging level to get as much info as needed
+    setDefaultLogLevel(logLevel)
+
+    const logger = createLogger(logLevel)
+
+    logger.debug(`Loading setup from ${setup}`)
+
+    logger.warn(
+        `This command is just a placeholder. Please use @layerzerolabs/toolbox-hardhat package for the time being.`
+    )
+})

--- a/packages/devtools-cli/src/commands/options.ts
+++ b/packages/devtools-cli/src/commands/options.ts
@@ -1,0 +1,23 @@
+import { LogLevel, isLogLevel } from '@layerzerolabs/io-devtools'
+import { InvalidOptionArgumentError, Option } from 'commander'
+
+export interface WithSetupOption {
+    setup: string
+}
+
+export const createSetupFileOption = () => new Option('-s,--setup <path>', 'Path to a setup file').makeOptionMandatory()
+
+export interface WithLogLevelOption {
+    logLevel: LogLevel
+}
+
+export const createLogLevelOption = () =>
+    new Option('-l,--log-level <level>', 'Logging level. One of: error, warn, info, verbose, debug, silly')
+        .default('info')
+        .argParser((value) => {
+            if (!isLogLevel(value)) {
+                throw new InvalidOptionArgumentError(`Invalid log level value: ${value}`)
+            }
+
+            return value
+        })

--- a/packages/devtools-cli/src/index.ts
+++ b/packages/devtools-cli/src/index.ts
@@ -1,0 +1,5 @@
+import { Command } from 'commander'
+import { version, name } from '../package.json'
+import { oapp } from './commands/oapp'
+
+new Command(name).description('CLI for configuring LayerZero OApps').version(version).addCommand(oapp).parseAsync()

--- a/packages/devtools-cli/src/setup/index.ts
+++ b/packages/devtools-cli/src/setup/index.ts
@@ -1,0 +1,3 @@
+export * from './loading'
+export * from './schema'
+export * from './types'

--- a/packages/devtools-cli/src/setup/loading.ts
+++ b/packages/devtools-cli/src/setup/loading.ts
@@ -1,0 +1,70 @@
+import { createModuleLogger, importDefault, isFile, isReadable, printZodErrors } from '@layerzerolabs/io-devtools'
+import { resolve } from 'path'
+import { CLISetup } from './types'
+import { CLISetupSchema } from './schema'
+
+export const createSetupLoader =
+    (logger = createModuleLogger('setup loader')) =>
+    async (path: string): Promise<CLISetup> => {
+        const absolutePath = resolve(path)
+        logger.verbose(`Resolved setup file location for '${path}': '${absolutePath}'`)
+
+        // First we check that the config file is indeed there and we can read it
+        logger.verbose(`Checking setup file '${absolutePath}' for existence & readability`)
+        const isConfigReadable = isFile(absolutePath) && isReadable(absolutePath)
+        if (!isConfigReadable) {
+            throw new Error(
+                `Unable to read setup file '${path}'. Check that the file exists and is readable to your terminal user`
+            )
+        }
+
+        // Keep talking to the user
+        logger.verbose(`Setup file '${absolutePath}' exists & is readable`)
+
+        // Now let's see if we can load the config file
+        let rawSetup: unknown
+        try {
+            logger.verbose(`Loading setup file '${absolutePath}'`)
+
+            rawSetup = await importDefault(absolutePath)
+        } catch (error) {
+            throw new Error(`Unable to read setup file '${path}': ${error}`)
+        }
+
+        logger.verbose(`Loaded setup file '${absolutePath}'`)
+
+        // Now let's check whether the setup file contains a function
+        //
+        // If so, we'll execute this function and will expect a setup as a result
+        let rawSetupMaterialized: unknown
+        if (typeof rawSetup === 'function') {
+            logger.verbose(`Executing setup function from setup file '${absolutePath}'`)
+
+            try {
+                rawSetupMaterialized = await rawSetup()
+            } catch (error) {
+                throw new Error(`Got an exception while executing setup funtion from file '${path}': ${error}`)
+            }
+        } else {
+            logger.verbose(`Using exported value from setup file '${absolutePath}'`)
+            rawSetupMaterialized = rawSetup
+        }
+
+        // It's time to make sure that the setup file is not malformed
+        //
+        // At this stage we are only interested in the shape of the data,
+        // we are not checking whether the information makes sense (e.g.
+        // whether the functions return sensible values)
+        logger.verbose(`Validating the structure of setup file '${absolutePath}'`)
+
+        const setupParseResult = CLISetupSchema.safeParse(rawSetupMaterialized)
+        if (setupParseResult.success === false) {
+            const userFriendlyErrors = printZodErrors(setupParseResult.error)
+
+            throw new Error(
+                `Setup from file '${path}' is malformed. Please fix the following errors:\n\n${userFriendlyErrors}`
+            )
+        }
+
+        return setupParseResult.data
+    }

--- a/packages/devtools-cli/src/setup/schema.ts
+++ b/packages/devtools-cli/src/setup/schema.ts
@@ -1,0 +1,8 @@
+import { z } from 'zod'
+import type { CLISetup } from './types'
+import { EndpointIdSchema, OmniPointSchema } from '@layerzerolabs/devtools'
+
+export const CLISetupSchema: z.ZodSchema<CLISetup, z.ZodTypeDef, unknown> = z.object({
+    createSdk: z.function().args(OmniPointSchema).returns(z.any()),
+    createSigner: z.function().args(EndpointIdSchema).returns(z.any()),
+})

--- a/packages/devtools-cli/src/setup/types.ts
+++ b/packages/devtools-cli/src/setup/types.ts
@@ -1,0 +1,6 @@
+import type { OmniSDKFactory, OmniSignerFactory } from '@layerzerolabs/devtools'
+
+export interface CLISetup {
+    createSdk: OmniSDKFactory
+    createSigner: OmniSignerFactory
+}

--- a/packages/devtools-cli/tsconfig.json
+++ b/packages/devtools-cli/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "extends": "../../tsconfig",
+  "compilerOptions": {
+    "outDir": "dist",
+    "declaration": false,
+    "jsx": "react",
+    "lib": ["dom", "dom.Iterable", "es2022"],
+    "resolveJsonModule": true,
+    "types": ["node"],
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  },
+  "include": ["src", "test", "types"]
+}

--- a/packages/devtools-cli/tsconfig.test.json
+++ b/packages/devtools-cli/tsconfig.test.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "ESNext",
+    "moduleResolution": "Node10"
+  }
+}

--- a/packages/devtools-cli/tsup.config.ts
+++ b/packages/devtools-cli/tsup.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig } from 'tsup'
+
+export default defineConfig({
+    entry: ['src/index.ts'],
+    outDir: './dist',
+    clean: true,
+    dts: false,
+    minify: true,
+    sourcemap: false,
+    splitting: false,
+    treeshake: true,
+    format: ['cjs'],
+    env: {
+        NODE_ENV: 'production',
+    },
+    external: ['yoga-layout-prebuilt'],
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -447,7 +447,7 @@ importers:
         version: 10.9.2(@swc/core@1.4.0)(@types/node@18.18.14)(typescript@5.3.3)
       tsup:
         specifier: ~8.0.1
-        version: 8.0.1(@swc/core@1.4.0)(ts-node@10.9.2)(typescript@5.3.3)
+        version: 8.0.1(ts-node@10.9.2)(typescript@5.3.3)
       typescript:
         specifier: ^5.3.3
         version: 5.3.3
@@ -640,6 +640,58 @@ importers:
       typescript:
         specifier: ^5.3.3
         version: 5.3.3
+      zod:
+        specifier: ^3.22.4
+        version: 3.22.4
+
+  packages/devtools-cli:
+    dependencies:
+      yoga-layout-prebuilt:
+        specifier: ^1.10.0
+        version: 1.10.0
+    devDependencies:
+      '@layerzerolabs/devtools':
+        specifier: ~0.3.17
+        version: link:../devtools
+      '@layerzerolabs/io-devtools':
+        specifier: ~0.1.11
+        version: link:../io-devtools
+      '@types/prompts':
+        specifier: ^2.4.9
+        version: 2.4.9
+      '@types/react':
+        specifier: ^17.0.74
+        version: 17.0.75
+      commander:
+        specifier: ^11.1.0
+        version: 11.1.0
+      eslint-plugin-react:
+        specifier: ^7.33.2
+        version: 7.33.2(eslint@8.57.0)
+      eslint-plugin-react-hooks:
+        specifier: ^4.6.0
+        version: 4.6.0(eslint@8.57.0)
+      ink:
+        specifier: ^3.2.0
+        version: 3.2.0(@types/react@17.0.75)(react@17.0.2)
+      ink-gradient:
+        specifier: ^2.0.0
+        version: 2.0.0(ink@3.2.0)(react@17.0.2)
+      prompts:
+        specifier: ^2.4.2
+        version: 2.4.2
+      react:
+        specifier: ^17.0.2
+        version: 17.0.2
+      ts-node:
+        specifier: ^10.9.2
+        version: 10.9.2(@types/node@18.18.14)(typescript@5.5.3)
+      tsup:
+        specifier: ~8.0.1
+        version: 8.0.1(ts-node@10.9.2)(typescript@5.5.3)
+      typescript:
+        specifier: ^5.3.3
+        version: 5.5.3
       zod:
         specifier: ^3.22.4
         version: 3.22.4
@@ -867,7 +919,7 @@ importers:
         version: 29.7.0(@types/node@18.18.14)(ts-node@10.9.2)
       tsup:
         specifier: ~8.0.1
-        version: 8.0.1(@swc/core@1.4.0)(typescript@5.3.3)
+        version: 8.0.1(@swc/core@1.4.0)(ts-node@10.9.2)(typescript@5.3.3)
       zod:
         specifier: ^3.22.4
         version: 3.22.4
@@ -1291,7 +1343,7 @@ importers:
         version: 2.6.2
       tsup:
         specifier: ~8.0.1
-        version: 8.0.1(@swc/core@1.4.0)(ts-node@10.9.2)(typescript@5.3.3)
+        version: 8.0.1(ts-node@10.9.2)(typescript@5.3.3)
       typescript:
         specifier: ^5.3.3
         version: 5.3.3
@@ -1366,7 +1418,7 @@ importers:
         version: 2.6.2
       tsup:
         specifier: ~8.0.1
-        version: 8.0.1(@swc/core@1.4.0)(ts-node@10.9.2)(typescript@5.3.3)
+        version: 8.0.1(ts-node@10.9.2)(typescript@5.3.3)
       typescript:
         specifier: ^5.3.3
         version: 5.3.3
@@ -1771,7 +1823,7 @@ importers:
         version: 29.7.0(@types/node@18.18.14)(ts-node@10.9.2)
       tsup:
         specifier: ^8.0.1
-        version: 8.0.1(@swc/core@1.4.0)(typescript@5.3.3)
+        version: 8.0.1(@swc/core@1.4.0)(ts-node@10.9.2)(typescript@5.3.3)
       typescript:
         specifier: ^5.3.3
         version: 5.3.3
@@ -2772,7 +2824,7 @@ packages:
       outdent: 0.5.0
       prettier: 2.8.8
       resolve-from: 5.0.0
-      semver: 7.5.4
+      semver: 7.6.2
     dev: true
 
   /@changesets/assemble-release-plan@6.0.0:
@@ -2783,7 +2835,7 @@ packages:
       '@changesets/get-dependents-graph': 2.0.0
       '@changesets/types': 6.0.0
       '@manypkg/get-packages': 1.1.3
-      semver: 7.5.4
+      semver: 7.6.2
     dev: true
 
   /@changesets/changelog-git@0.2.0:
@@ -2855,7 +2907,7 @@ packages:
       '@manypkg/get-packages': 1.1.3
       chalk: 2.4.2
       fs-extra: 7.0.1
-      semver: 7.5.4
+      semver: 7.6.2
     dev: true
 
   /@changesets/get-release-plan@4.0.0:
@@ -5888,7 +5940,7 @@ packages:
       debug: 4.3.4(supports-color@8.1.1)
       globby: 11.1.0
       is-glob: 4.0.3
-      semver: 7.6.0
+      semver: 7.6.2
       tsutils: 3.21.0(typescript@5.3.3)
       typescript: 5.3.3
     transitivePeerDependencies:
@@ -5909,7 +5961,7 @@ packages:
       debug: 4.3.4(supports-color@8.1.1)
       globby: 11.1.0
       is-glob: 4.0.3
-      semver: 7.6.0
+      semver: 7.6.2
       tsutils: 3.21.0(typescript@5.4.5)
       typescript: 5.4.5
     transitivePeerDependencies:
@@ -5930,7 +5982,7 @@ packages:
       debug: 4.3.4(supports-color@8.1.1)
       globby: 11.1.0
       is-glob: 4.0.3
-      semver: 7.6.0
+      semver: 7.6.2
       tsutils: 3.21.0(typescript@5.5.3)
       typescript: 5.5.3
     transitivePeerDependencies:
@@ -5952,7 +6004,7 @@ packages:
       globby: 11.1.0
       is-glob: 4.0.3
       minimatch: 9.0.3
-      semver: 7.6.0
+      semver: 7.6.2
       ts-api-utils: 1.2.0(typescript@5.5.3)
       typescript: 5.5.3
     transitivePeerDependencies:
@@ -5974,7 +6026,7 @@ packages:
       globby: 11.1.0
       is-glob: 4.0.3
       minimatch: 9.0.4
-      semver: 7.6.0
+      semver: 7.6.2
       ts-api-utils: 1.3.0(typescript@5.3.3)
       typescript: 5.3.3
     transitivePeerDependencies:
@@ -5996,7 +6048,7 @@ packages:
       globby: 11.1.0
       is-glob: 4.0.3
       minimatch: 9.0.4
-      semver: 7.6.0
+      semver: 7.6.2
       ts-api-utils: 1.3.0(typescript@5.4.5)
       typescript: 5.4.5
     transitivePeerDependencies:
@@ -6076,7 +6128,7 @@ packages:
       '@typescript-eslint/types': 6.21.0
       '@typescript-eslint/typescript-estree': 6.21.0(typescript@5.5.3)
       eslint: 8.56.0
-      semver: 7.5.4
+      semver: 7.6.2
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -6095,7 +6147,7 @@ packages:
       '@typescript-eslint/types': 7.7.1
       '@typescript-eslint/typescript-estree': 7.7.1(typescript@5.3.3)
       eslint: 8.57.0
-      semver: 7.6.0
+      semver: 7.6.2
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -6114,7 +6166,7 @@ packages:
       '@typescript-eslint/types': 7.7.1
       '@typescript-eslint/typescript-estree': 7.7.1(typescript@5.4.5)
       eslint: 8.57.0
-      semver: 7.6.0
+      semver: 7.6.2
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -6762,7 +6814,7 @@ packages:
   /builtins@5.0.1:
     resolution: {integrity: sha512-qwVpFEHNfhYJIzNRBvd2C1kyo6jz3ZSMPyyuR47OPdiKWlbYnZNyDWuyR175qDnAJLiCo5fBBqPb3RiXgWlkOQ==}
     dependencies:
-      semver: 7.5.4
+      semver: 7.6.2
     dev: true
 
   /bundle-require@4.0.2(esbuild@0.19.11):
@@ -10365,7 +10417,7 @@ packages:
       '@babel/parser': 7.23.9
       '@istanbuljs/schema': 0.1.3
       istanbul-lib-coverage: 3.2.2
-      semver: 7.6.0
+      semver: 7.6.2
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -10383,7 +10435,7 @@ packages:
     resolution: {integrity: sha512-n3s8EwkdFIJCG3BPKBYvskgXGoy88ARzvegkitk60NxRdwltLOTaH7CUiMRXvwYorl0Q712iEjcWB+fK/MrWVw==}
     engines: {node: '>=10'}
     dependencies:
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.5
       istanbul-lib-coverage: 3.2.2
       source-map: 0.6.1
     transitivePeerDependencies:
@@ -10768,7 +10820,7 @@ packages:
       jest-util: 29.7.0
       natural-compare: 1.4.0
       pretty-format: 29.7.0
-      semver: 7.6.0
+      semver: 7.6.2
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -11204,7 +11256,7 @@ packages:
     resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
     engines: {node: '>=10'}
     dependencies:
-      semver: 7.6.0
+      semver: 7.6.2
     dev: true
 
   /make-error@1.3.6:
@@ -11927,7 +11979,7 @@ packages:
       got: 12.6.1
       registry-auth-token: 5.0.2
       registry-url: 6.0.1
-      semver: 7.6.0
+      semver: 7.6.2
     dev: true
 
   /parent-module@1.0.1:
@@ -13661,6 +13713,37 @@ packages:
       yn: 3.1.1
     dev: true
 
+  /ts-node@10.9.2(@types/node@18.18.14)(typescript@5.5.3):
+    resolution: {integrity: sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==}
+    hasBin: true
+    peerDependencies:
+      '@swc/core': '>=1.2.50'
+      '@swc/wasm': '>=1.2.50'
+      '@types/node': '*'
+      typescript: '>=2.7'
+    peerDependenciesMeta:
+      '@swc/core':
+        optional: true
+      '@swc/wasm':
+        optional: true
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      '@tsconfig/node10': 1.0.9
+      '@tsconfig/node12': 1.0.11
+      '@tsconfig/node14': 1.0.3
+      '@tsconfig/node16': 1.0.4
+      '@types/node': 18.18.14
+      acorn: 8.11.3
+      acorn-walk: 8.3.2
+      arg: 4.1.3
+      create-require: 1.1.1
+      diff: 4.0.2
+      make-error: 1.3.6
+      typescript: 5.5.3
+      v8-compile-cache-lib: 3.0.1
+      yn: 3.1.1
+    dev: true
+
   /tsconfig-paths@3.15.0:
     resolution: {integrity: sha512-2Ac2RgzDe/cn48GvOe3M+o82pEFewD3UPbyoUHHdKasHwJKjds4fLXWf/Ux5kATBKN20oaFGu+jbElp1pos0mg==}
     dependencies:
@@ -13706,7 +13789,7 @@ packages:
       bundle-require: 4.0.2(esbuild@0.19.11)
       cac: 6.7.14
       chokidar: 3.6.0
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.5
       esbuild: 0.19.11
       execa: 5.1.1
       globby: 11.1.0
@@ -13723,7 +13806,7 @@ packages:
       - ts-node
     dev: true
 
-  /tsup@8.0.1(@swc/core@1.4.0)(typescript@5.3.3):
+  /tsup@8.0.1(ts-node@10.9.2)(typescript@5.3.3):
     resolution: {integrity: sha512-hvW7gUSG96j53ZTSlT4j/KL0q1Q2l6TqGBFc6/mu/L46IoNWqLLUzLRLP1R8Q7xrJTmkDxxDoojV5uCVs1sVOg==}
     engines: {node: '>=18'}
     hasBin: true
@@ -13742,7 +13825,6 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@swc/core': 1.4.0
       bundle-require: 4.0.2(esbuild@0.19.11)
       cac: 6.7.14
       chokidar: 3.6.0
@@ -13785,7 +13867,7 @@ packages:
       bundle-require: 4.0.2(esbuild@0.19.11)
       cac: 6.7.14
       chokidar: 3.6.0
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.5
       esbuild: 0.19.11
       execa: 5.1.1
       globby: 11.1.0
@@ -13824,7 +13906,7 @@ packages:
       bundle-require: 4.0.2(esbuild@0.19.11)
       cac: 6.7.14
       chokidar: 3.6.0
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.5
       esbuild: 0.19.11
       execa: 5.1.1
       globby: 11.1.0
@@ -13836,6 +13918,45 @@ packages:
       sucrase: 3.35.0
       tree-kill: 1.2.2
       typescript: 5.4.5
+    transitivePeerDependencies:
+      - supports-color
+      - ts-node
+    dev: true
+
+  /tsup@8.0.1(ts-node@10.9.2)(typescript@5.5.3):
+    resolution: {integrity: sha512-hvW7gUSG96j53ZTSlT4j/KL0q1Q2l6TqGBFc6/mu/L46IoNWqLLUzLRLP1R8Q7xrJTmkDxxDoojV5uCVs1sVOg==}
+    engines: {node: '>=18'}
+    hasBin: true
+    peerDependencies:
+      '@microsoft/api-extractor': ^7.36.0
+      '@swc/core': ^1
+      postcss: ^8.4.12
+      typescript: '>=4.5.0'
+    peerDependenciesMeta:
+      '@microsoft/api-extractor':
+        optional: true
+      '@swc/core':
+        optional: true
+      postcss:
+        optional: true
+      typescript:
+        optional: true
+    dependencies:
+      bundle-require: 4.0.2(esbuild@0.19.11)
+      cac: 6.7.14
+      chokidar: 3.6.0
+      debug: 4.3.5
+      esbuild: 0.19.11
+      execa: 5.1.1
+      globby: 11.1.0
+      joycon: 3.1.1
+      postcss-load-config: 4.0.2(ts-node@10.9.2)
+      resolve-from: 5.0.0
+      rollup: 4.9.6
+      source-map: 0.8.0-beta.0
+      sucrase: 3.35.0
+      tree-kill: 1.2.2
+      typescript: 5.5.3
     transitivePeerDependencies:
       - supports-color
       - ts-node

--- a/tests-user/tests/devtools-cli.bats
+++ b/tests-user/tests/devtools-cli.bats
@@ -1,0 +1,34 @@
+
+
+# We'll setup an empty testing directory for this script and store its location in this variable
+PROJECTS_DIRECTORY=
+
+# This will be run at the start of this testing suite,
+# similar to beforeAll() in jest
+setup() {
+    # Load bats-assert and bats-support
+    load "../lib/bats-support/load.bash"
+    load "../lib/bats-assert/load.bash"
+
+    # For debugging purposes, we'll output the environment variables 
+    # that influence the behavior of create-lz-oapp
+    echo "create-lz-oapp:repository   $LAYERZERO_EXAMPLES_REPOSITORY_URL" 1>&2
+    echo "create-lz-oapp:ref          $LAYERZERO_EXAMPLES_REPOSITORY_REF" 1>&2
+
+    # Setup a directory for all the projects created by this test
+    PROJECTS_DIRECTORY=$(mktemp -d)
+}
+
+teardown() {
+    rm -rf "$PROJECTS_DIRECTORY"
+}
+
+@test "should work with pnpm & oapp example in CI mode" {
+    local DESTINATION="$PROJECTS_DIRECTORY/pnpm-oapp"
+
+    npx --yes create-lz-oapp --ci --example oapp --destination $DESTINATION --package-manager pnpm
+    cd "$DESTINATION"
+
+    run npx --yes @layerzerolabs/devtools-cli oapp wire --setup ./imaginary.layerzero.setup.ts
+    assert_output --partial "This command is just a placeholder. Please use @layerzerolabs/toolbox-hardhat package for the time being."
+}


### PR DESCRIPTION
### In this PR

- To support non-EVM chains without resorting to `hardhat`, we're adding a framework-agnostic CLI package that will eventually reach parity with the hardhat version (`@layerzerolabs/toolbox-hardhat`).
- Since we are no longer bound to the `hardhat` context, the consumers need to provide the parts that would otherwise be provided by `hardhat` - SDK & signer factories. This is achieved using a setup file