### PR TITLE
🗞️ Allow custom paths when loading external artifacts

### DIFF
--- a/.changeset/afraid-games-poke.md
+++ b/.changeset/afraid-games-poke.md
@@ -1,0 +1,6 @@
+---
+"@layerzerolabs/devtools-evm-hardhat": patch
+"@layerzerolabs/toolbox-hardhat": patch
+---
+
+Allow specifying filesystem paths for external artifacts

--- a/packages/devtools-evm-hardhat/src/type-extensions.ts
+++ b/packages/devtools-evm-hardhat/src/type-extensions.ts
@@ -3,6 +3,27 @@ import { EndpointId } from '@layerzerolabs/lz-definitions'
 import { ConnectSafeConfigWithSafeAddress } from '@safe-global/protocol-kit'
 import { SimulationUserConfig } from '@/simulation/types'
 
+/**
+ * Packages containing external artifacts can be specified either
+ *
+ * - By just their package name, in which case the artifacts will be loaded from the `./artifacts` path
+ * - By their package name and a specific path to the artifacts directory
+ * - By a filesystem path
+ */
+export type ArtifactPackage = ArtifactPackageName | ArtifactPackageWithPath | ArtifactPackagePath
+
+export type ArtifactPackageName = string
+
+export interface ArtifactPackageWithPath {
+    name: ArtifactPackageName
+    path?: string
+}
+
+export interface ArtifactPackagePath {
+    name?: never
+    path: string
+}
+
 declare module 'hardhat/types/config' {
     interface HardhatNetworkUserConfig {
         eid?: never
@@ -124,7 +145,7 @@ declare module 'hardhat/types/config' {
          *
          * @default ['@layerzerolabs/lz-evm-sdk-v2','@layerzerolabs/test-devtools-evm-hardhat']
          */
-        artifactSourcePackages?: string[]
+        artifactSourcePackages?: ArtifactPackage[]
 
         /**
          * Configuration of features that are not considered stable yet

--- a/packages/devtools-evm-hardhat/test/config.test.ts
+++ b/packages/devtools-evm-hardhat/test/config.test.ts
@@ -137,63 +137,197 @@ describe('config', () => {
     })
 
     describe('withLayerZeroArtifacts()', () => {
-        const resolvedLzEvmSdkPackageJson = dirname(
-            require.resolve(join('@layerzerolabs/lz-evm-sdk-v1', 'package.json'))
-        )
+        describe('with package names', () => {
+            const resolvedLzEvmSdkPackage = dirname(
+                require.resolve(join('@layerzerolabs/lz-evm-sdk-v1', 'package.json'))
+            )
 
-        it('should append external artifacts', () => {
-            const config = {
-                networks: {},
-            }
+            it('should append external artifacts from named', () => {
+                const config = {
+                    networks: {},
+                }
 
-            expect(withLayerZeroArtifacts('@layerzerolabs/lz-evm-sdk-v1')(config)).toEqual({
-                networks: {},
-                external: {
-                    contracts: [
-                        {
-                            artifacts: [`${resolvedLzEvmSdkPackageJson}/artifacts`],
-                        },
-                    ],
-                },
+                expect(withLayerZeroArtifacts('@layerzerolabs/lz-evm-sdk-v1')(config)).toEqual({
+                    networks: {},
+                    external: {
+                        contracts: [
+                            {
+                                artifacts: [`${resolvedLzEvmSdkPackage}/artifacts`],
+                            },
+                        ],
+                    },
+                })
+            })
+
+            it('should not append duplicate external artifacts', () => {
+                const config = {
+                    external: {
+                        contracts: [
+                            {
+                                artifacts: './my/external/artifact',
+                            },
+                            {
+                                artifacts: ['./my/other/external/artifact'],
+                            },
+                        ],
+                    },
+                    networks: {},
+                }
+
+                const configWithSomePath = withLayerZeroArtifacts(
+                    '@layerzerolabs/lz-evm-sdk-v1',
+                    '@layerzerolabs/lz-evm-sdk-v1'
+                )(config)
+                const configWithSomePathAgain =
+                    withLayerZeroArtifacts('@layerzerolabs/lz-evm-sdk-v1')(configWithSomePath)
+
+                expect(configWithSomePathAgain).toEqual({
+                    networks: {},
+                    external: {
+                        contracts: [
+                            {
+                                artifacts: './my/external/artifact',
+                            },
+                            {
+                                artifacts: ['./my/other/external/artifact'],
+                            },
+                            {
+                                artifacts: [`${resolvedLzEvmSdkPackage}/artifacts`],
+                            },
+                        ],
+                    },
+                })
             })
         })
 
-        it('should not append duplicate external artifacts', () => {
-            const config = {
-                external: {
-                    contracts: [
-                        {
-                            artifacts: './my/external/artifact',
-                        },
-                        {
-                            artifacts: ['./my/other/external/artifact'],
-                        },
-                    ],
-                },
-                networks: {},
-            }
+        describe('with package names & paths', () => {
+            const resolvedLzEvmSdkPackage = dirname(
+                require.resolve(join('@layerzerolabs/lz-evm-sdk-v1', 'package.json'))
+            )
 
-            const configWithSomePath = withLayerZeroArtifacts(
-                '@layerzerolabs/lz-evm-sdk-v1',
-                '@layerzerolabs/lz-evm-sdk-v1'
-            )(config)
-            const configWithSomePathAgain = withLayerZeroArtifacts('@layerzerolabs/lz-evm-sdk-v1')(configWithSomePath)
+            it('should append external artifacts from named', () => {
+                const config = {
+                    networks: {},
+                }
 
-            expect(configWithSomePathAgain).toEqual({
-                networks: {},
-                external: {
-                    contracts: [
-                        {
-                            artifacts: './my/external/artifact',
-                        },
-                        {
-                            artifacts: ['./my/other/external/artifact'],
-                        },
-                        {
-                            artifacts: [`${resolvedLzEvmSdkPackageJson}/artifacts`],
-                        },
-                    ],
-                },
+                expect(
+                    withLayerZeroArtifacts({ name: '@layerzerolabs/lz-evm-sdk-v1', path: 'custom/path' })(config)
+                ).toEqual({
+                    networks: {},
+                    external: {
+                        contracts: [
+                            {
+                                artifacts: [`${resolvedLzEvmSdkPackage}/custom/path`],
+                            },
+                        ],
+                    },
+                })
+            })
+
+            it('should not append duplicate external artifacts', () => {
+                const config = {
+                    external: {
+                        contracts: [
+                            {
+                                artifacts: './my/external/artifacts',
+                            },
+                            {
+                                artifacts: ['./my/other/external/artifacts'],
+                            },
+                        ],
+                    },
+                    networks: {},
+                }
+
+                const configWithSomePath = withLayerZeroArtifacts(
+                    { name: '@layerzerolabs/lz-evm-sdk-v1', path: 'custom/path' },
+                    { name: '@layerzerolabs/lz-evm-sdk-v1', path: 'custom/path' }
+                )(config)
+                const configWithSomePathAgain = withLayerZeroArtifacts({
+                    name: '@layerzerolabs/lz-evm-sdk-v1',
+                    path: 'custom/path',
+                })(configWithSomePath)
+
+                expect(configWithSomePathAgain).toEqual({
+                    networks: {},
+                    external: {
+                        contracts: [
+                            {
+                                artifacts: './my/external/artifacts',
+                            },
+                            {
+                                artifacts: ['./my/other/external/artifacts'],
+                            },
+                            {
+                                artifacts: [`${resolvedLzEvmSdkPackage}/custom/path`],
+                            },
+                        ],
+                    },
+                })
+            })
+        })
+
+        describe('with package paths', () => {
+            const resolvedLzEvmSdkPackage = dirname(
+                require.resolve(join('@layerzerolabs/lz-evm-sdk-v1', 'package.json'))
+            )
+
+            it('should append external artifacts from named', () => {
+                const config = {
+                    networks: {},
+                }
+
+                expect(withLayerZeroArtifacts({ path: join(resolvedLzEvmSdkPackage, 'artifacts') })(config)).toEqual({
+                    networks: {},
+                    external: {
+                        contracts: [
+                            {
+                                artifacts: [`${resolvedLzEvmSdkPackage}/artifacts`],
+                            },
+                        ],
+                    },
+                })
+            })
+
+            it('should not append duplicate external artifacts', () => {
+                const config = {
+                    external: {
+                        contracts: [
+                            {
+                                artifacts: './my/external/artifact',
+                            },
+                            {
+                                artifacts: ['./my/other/external/artifact'],
+                            },
+                        ],
+                    },
+                    networks: {},
+                }
+
+                const configWithSomePath = withLayerZeroArtifacts(
+                    { path: join(resolvedLzEvmSdkPackage, 'artifacts') },
+                    { path: join(resolvedLzEvmSdkPackage, 'artifacts') }
+                )(config)
+                const configWithSomePathAgain = withLayerZeroArtifacts({
+                    path: join(resolvedLzEvmSdkPackage, 'artifacts'),
+                })(configWithSomePath)
+
+                expect(configWithSomePathAgain).toEqual({
+                    networks: {},
+                    external: {
+                        contracts: [
+                            {
+                                artifacts: './my/external/artifact',
+                            },
+                            {
+                                artifacts: ['./my/other/external/artifact'],
+                            },
+                            {
+                                artifacts: [`${resolvedLzEvmSdkPackage}/artifacts`],
+                            },
+                        ],
+                    },
+                })
             })
         })
     })


### PR DESCRIPTION
### In this PR

- When loading external artifacts into hardhat, we now allow custom artifact paths
  - `path` alongside a package name will be appended to the resolved package filesystem path (for overriding the default `artifacts` path)
  - `path` without a package name will be used as a direct filesystem path to the artifacts folder