### PR TITLE
🗞️ Add createDefaultContext utility

### DIFF
--- a/.changeset/olive-planes-double.md
+++ b/.changeset/olive-planes-double.md
@@ -1,0 +1,5 @@
+---
+"@layerzerolabs/devtools-evm-hardhat": patch
+---
+
+Add createDefaultContext utility for creating hardhat context outside of hardhat CLI


### PR DESCRIPTION
### In this PR

- Add `createDefaultContext` utility to `devtools-evm-hardhat`. This utility mirrors the hardhat initialization stage and allows us to create hardhat environment outside of the hardhat CLI