### PR TITLE
🧹 Improve errors for missing deployments

### DIFF
--- a/.changeset/twenty-paws-tease.md
+++ b/.changeset/twenty-paws-tease.md
@@ -1,0 +1,6 @@
+---
+"@layerzerolabs/devtools-evm-hardhat": patch
+"@layerzerolabs/toolbox-hardhat": patch
+---
+
+Add better errors for missing deployments

--- a/packages/devtools-evm-hardhat/src/omnigraph/coordinates.ts
+++ b/packages/devtools-evm-hardhat/src/omnigraph/coordinates.ts
@@ -20,10 +20,11 @@ export const omniDeploymentToContract = ({ eid, deployment }: OmniDeployment): O
 
 export const createContractFactory = (environmentFactory = createGetHreByEid()): OmniContractFactoryHardhat => {
     return pMemoize(async ({ eid, address, contractName }) => {
-        const logger = createModuleLogger(`Contract factory @ ${formatEid(eid)}`)
-
         const env = await environmentFactory(eid)
         assertHardhatDeploy(env)
+
+        const networkLabel = `${formatEid(eid)} (${env.network.name})`
+        const logger = createModuleLogger(`Contract factory @ ${networkLabel}`)
 
         // If we have both the contract name & address, we go off artifacts
         if (contractName != null && address != null) {
@@ -46,7 +47,7 @@ export const createContractFactory = (environmentFactory = createGetHreByEid()):
             logger.verbose(`Looking for contract ${contractName} in deployments`)
 
             const deployment = await env.deployments.getOrNull(contractName)
-            assert(deployment != null, `Could not find a deployment for contract '${contractName}'`)
+            assert(deployment != null, `Could not find a deployment for contract '${contractName}' on ${networkLabel}`)
 
             return omniDeploymentToContract({ eid, deployment })
         }
@@ -71,7 +72,7 @@ export const createContractFactory = (environmentFactory = createGetHreByEid()):
 
                 return await env.deployments.getDeploymentsFromAddress(address)
             })
-            assert(deployments.length > 0, `Could not find a deployment for address '${address}'`)
+            assert(deployments.length > 0, `Could not find a deployment for address '${address}' on ${networkLabel}`)
 
             const mergedAbis = deployments.flatMap((deployment) => deployment.abi)
 
@@ -84,6 +85,6 @@ export const createContractFactory = (environmentFactory = createGetHreByEid()):
             return { eid, contract: new Contract(address, deduplicatedAbi) }
         }
 
-        assert(false, 'At least one of contractName, address must be specified for OmniPointHardhat')
+        assert(false, 'At least one of contractName, address must be specified for OmniPointHardhat on ${networkLabel}')
     })
 }

--- a/tests/ua-devtools-evm-hardhat-test/test/task/oapp/__snapshots__/wire.test.ts.snap
+++ b/tests/ua-devtools-evm-hardhat-test/test/task/oapp/__snapshots__/wire.test.ts.snap
@@ -14,7 +14,7 @@ Property 'contracts.1.contract': Invalid input
 Property 'connections': Required]
 `;
 
-exports[`task lz:oapp:wire with invalid configs should fail with a misconfigured file (001) 1`] = `[Error: Config from file 'test/task/oapp/__data__/configs/valid.config.misconfigured.001.js' is invalid: AssertionError [ERR_ASSERTION]: Could not find a deployment for contract 'NonExistent']`;
+exports[`task lz:oapp:wire with invalid configs should fail with a misconfigured file (001) 1`] = `[Error: Config from file 'test/task/oapp/__data__/configs/valid.config.misconfigured.001.js' is invalid: AssertionError [ERR_ASSERTION]: Could not find a deployment for contract 'NonExistent' on AVALANCHE_V2_MAINNET (britney)]`;
 
 exports[`task lz:oapp:wire with invalid configs should fail with an empty JS file 1`] = `
 [Error: Config from file 'test/task/oapp/__data__/configs/invalid.config.empty.js' is malformed. Please fix the following errors:


### PR DESCRIPTION
### In this PR

- Improve errors for missing deployments - the error now contains the network name & the endpoint ID of the missing deployment