### PR TITLE
🪲 UlnOptionsMock initialization in OptionsHelper

### DIFF
--- a/.changeset/plenty-fireants-help.md
+++ b/.changeset/plenty-fireants-help.md
@@ -1,0 +1,5 @@
+---
+"@layerzerolabs/test-devtools-evm-foundry": patch
+---
+
+Fix UlnOptionsMock initialization in OptionsHelper

--- a/packages/test-devtools-evm-foundry/contracts/OptionsHelper.sol
+++ b/packages/test-devtools-evm-foundry/contracts/OptionsHelper.sol
@@ -16,7 +16,13 @@ contract UlnOptionsMock {
 }
 
 contract OptionsHelper {
+    /// @dev For backwards compatibility reasons, we'll keep this initialization here
+    /// @dev Any new tests should use the _setUpUlnOptions function below
     UlnOptionsMock ulnOptions = new UlnOptionsMock();
+
+    function _setUpUlnOptions() internal {
+        ulnOptions = new UlnOptionsMock();
+    }
 
     function _parseExecutorLzReceiveOption(bytes memory _options) internal view returns (uint256 gas, uint256 value) {
         (bool exist, bytes memory option) = _getExecutorOptionByOptionType(

--- a/packages/test-devtools-evm-foundry/contracts/TestHelperOz5.sol
+++ b/packages/test-devtools-evm-foundry/contracts/TestHelperOz5.sol
@@ -65,7 +65,9 @@ contract TestHelperOz5 is Test, OptionsHelper {
     uint128 public executorValueCap = 0.1 ether;
 
     /// @dev Initializes test environment setup, to be overridden by specific tests.
-    function setUp() public virtual {}
+    function setUp() public virtual {
+        _setUpUlnOptions();
+    }
 
     /**
      * @dev set executorValueCap if more than 0.1 ether is necessary


### PR DESCRIPTION
### In this PR

- Add an internal method to initialize `UlnOptionsMock` in `OptionsHelper` to fix issues with fork testing in foundry
- Fixes #666 