### PR TITLE
🧹 CLI: Add type exports to CLI package [2/N]

### DIFF
--- a/.changeset/ten-planets-promise.md
+++ b/.changeset/ten-planets-promise.md
@@ -1,0 +1,5 @@
+---
+"@layerzerolabs/devtools-cli": patch
+---
+
+Add exports to CLI package to expose types

--- a/packages/devtools-cli/README.md
+++ b/packages/devtools-cli/README.md
@@ -20,6 +20,18 @@
 
 This package provides a network-agnostic CLI interface for configuring LayerZero OApp contracts.
 
+---
+
+**Please note** that this package is in a **beta** state and backwards-incompatible changes might be introduced in future releases. The functionality is not yet on par with <a href="https://www.npmjs.com/package/@layerzerolabs/toolbox-hardhat"><code>@layerzerolabs/toolbox-hardhat</code></a>. While we strive to comply to [semver](https://semver.org/), we can not guarantee to avoid breaking changes in minor releases.
+
+---
+
+### Quick start
+
+#### Installation
+
+The CLI is distributed as an NPM package, we recommend the following ways of running it:
+
 ```bash
 npx @layerzerolabs/devtools-cli@latest
 # or
@@ -28,4 +40,46 @@ yarn @layerzerolabs/devtools-cli
 pnpm @layerzerolabs/devtools-cli
 # or
 bunx @layerzerolabs/devtools-cli
+```
+
+#### Configuration
+
+The configuration of the CLI consists of two parts:
+
+- **OApp configuration** that describes the desired state of your OApp (typically called `layerzero.config.ts`)
+- **CLI setup** that creates the necessary functionality for the CLI to run - SDKs, configuration functions, signing functions (typically called `layerzero.setup.ts`)
+
+The main difference between this CLI and `@layerzerolabs/toolbox-hardhat` is the `layerzero.setup.ts` file. While in `@layerzerolabs/toolbox-hardhat` lot of the functionality can be inferred based on `hardhat`, it is not possible to infer this functionality in a generic CLI environment.
+
+##### CLI setup
+
+The following is an example of a setup file that loads the EVM functionality based on `hardhat`.
+
+```typescript
+import {
+  createConnectedContractFactory,
+  createSignerFactory,
+  createDefaultContext,
+} from "@layerzerolabs/devtools-evm-hardhat";
+import { createOAppFactory } from "@layerzerolabs/ua-devtools-evm";
+
+import type { CLISetup } from "@layerzerolabs/devtools-cli";
+
+/**
+ * Since we are not in hardhat CLI, we'll need to create the context first
+ */
+createDefaultContext();
+
+/**
+ * This is a setup file for @layerzerolabs/devtools-cli.
+ *
+ * At the moment, @layerzerolabs/devtools-cli is in development
+ * and will be available
+ */
+const setup: CLISetup = {
+  createSdk: createOAppFactory(createConnectedContractFactory()),
+  createSigner: createSignerFactory(),
+};
+
+export default setup;
 ```

--- a/packages/devtools-cli/cli.js
+++ b/packages/devtools-cli/cli.js
@@ -1,3 +1,3 @@
 #!/usr/bin/env node
 
-import('./dist/index.js');
+import('./dist/cli.js');

--- a/packages/devtools-cli/package.json
+++ b/packages/devtools-cli/package.json
@@ -13,6 +13,16 @@
     "directory": "packages/devtools-cli"
   },
   "license": "MIT",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "require": "./dist/index.js",
+      "import": "./dist/index.mjs"
+    }
+  },
+  "main": "dist/index.js",
+  "module": "dist/index.mjs",
+  "types": "dist/index.d.ts",
   "bin": {
     "@layerzerolabs/devtools-cli": "./cli.js"
   },
@@ -22,7 +32,7 @@
   ],
   "scripts": {
     "prebuild": "tsc -noEmit",
-    "build": "$npm_execpath tsup",
+    "build": "$npm_execpath tsup --clean",
     "clean": "rm -rf dist",
     "dev": "$npm_execpath tsup --watch",
     "lint": "$npm_execpath eslint '**/*.{js,ts,json}'",

--- a/packages/devtools-cli/src/cli.ts
+++ b/packages/devtools-cli/src/cli.ts
@@ -1,0 +1,5 @@
+import { Command } from 'commander'
+import { version, name } from '../package.json'
+import { oapp } from './commands/oapp'
+
+new Command(name).description('CLI for configuring LayerZero OApps').version(version).addCommand(oapp).parseAsync()

--- a/packages/devtools-cli/src/index.ts
+++ b/packages/devtools-cli/src/index.ts
@@ -1,5 +1,1 @@
-import { Command } from 'commander'
-import { version, name } from '../package.json'
-import { oapp } from './commands/oapp'
-
-new Command(name).description('CLI for configuring LayerZero OApps').version(version).addCommand(oapp).parseAsync()
+export * from './types'

--- a/packages/devtools-cli/src/setup/index.ts
+++ b/packages/devtools-cli/src/setup/index.ts
@@ -1,3 +1,3 @@
 export * from './loading'
 export * from './schema'
-export * from './types'
+export * from './typescript'

--- a/packages/devtools-cli/src/setup/loading.ts
+++ b/packages/devtools-cli/src/setup/loading.ts
@@ -1,6 +1,6 @@
 import { createModuleLogger, importDefault, isFile, isReadable, printZodErrors } from '@layerzerolabs/io-devtools'
 import { resolve } from 'path'
-import { CLISetup } from './types'
+import { CLISetup } from '@/types'
 import { CLISetupSchema } from './schema'
 
 export const createSetupLoader =

--- a/packages/devtools-cli/src/setup/schema.ts
+++ b/packages/devtools-cli/src/setup/schema.ts
@@ -1,8 +1,10 @@
 import { z } from 'zod'
-import type { CLISetup } from './types'
+import type { CLISetup } from '@/types'
 import { EndpointIdSchema, OmniPointSchema } from '@layerzerolabs/devtools'
 
 export const CLISetupSchema: z.ZodSchema<CLISetup, z.ZodTypeDef, unknown> = z.object({
     createSdk: z.function().args(OmniPointSchema).returns(z.any()),
     createSigner: z.function().args(EndpointIdSchema).returns(z.any()),
+    configure: z.function().args(z.any(), z.any()).returns(z.any()).optional(),
+    loadConfig: z.function().args(z.string()).returns(z.any()).optional(),
 })

--- a/packages/devtools-cli/src/setup/types.ts
+++ b/packages/devtools-cli/src/setup/types.ts
@@ -1,6 +1,0 @@
-import type { OmniSDKFactory, OmniSignerFactory } from '@layerzerolabs/devtools'
-
-export interface CLISetup {
-    createSdk: OmniSDKFactory
-    createSigner: OmniSignerFactory
-}

--- a/packages/devtools-cli/src/types.ts
+++ b/packages/devtools-cli/src/types.ts
@@ -1,0 +1,15 @@
+import type {
+    Configurator,
+    Factory,
+    IOmniSDK,
+    OmniGraph,
+    OmniSDKFactory,
+    OmniSignerFactory,
+} from '@layerzerolabs/devtools'
+
+export interface CLISetup<TOmniGraph extends OmniGraph = OmniGraph<unknown, unknown>, TOmniSDK = IOmniSDK> {
+    createSdk: OmniSDKFactory<TOmniSDK>
+    createSigner: OmniSignerFactory
+    configure?: Configurator<TOmniGraph, TOmniSDK>
+    loadConfig?: Factory<[configPath: string], TOmniGraph>
+}

--- a/packages/devtools-cli/tsup.config.ts
+++ b/packages/devtools-cli/tsup.config.ts
@@ -1,17 +1,27 @@
 import { defineConfig } from 'tsup'
 
-export default defineConfig({
-    entry: ['src/index.ts'],
-    outDir: './dist',
-    clean: true,
-    dts: false,
-    minify: true,
-    sourcemap: false,
-    splitting: false,
-    treeshake: true,
-    format: ['cjs'],
-    env: {
-        NODE_ENV: 'production',
+export default defineConfig([
+    {
+        entry: ['src/cli.ts'],
+        outDir: './dist',
+        dts: false,
+        minify: false,
+        sourcemap: false,
+        splitting: false,
+        treeshake: true,
+        format: ['cjs'],
+        env: {
+            NODE_ENV: 'production',
+        },
+        external: ['yoga-layout-prebuilt'],
     },
-    external: ['yoga-layout-prebuilt'],
-})
+    {
+        entry: ['src/index.ts'],
+        outDir: './dist',
+        dts: true,
+        sourcemap: true,
+        splitting: false,
+        treeshake: true,
+        format: ['cjs', 'esm'],
+    },
+])


### PR DESCRIPTION
### In this PR

- Add additional `exports` to `@layerzerolabs/devtools-cli` package to expose types that can be used in the client packages
  - The binary now lives in `cli.ts`
  - The type exports consumable by client packages live in `index.ts`
- Add a bit of `README` (to be continued)