### PR TITLE
🧹 CLI: Add TypeScript support; Fix missing --log-level CLI flag [4/N]

### DIFF
--- a/.changeset/sweet-oranges-sneeze.md
+++ b/.changeset/sweet-oranges-sneeze.md
@@ -1,0 +1,5 @@
+---
+"@layerzerolabs/devtools-cli": patch
+---
+
+Add TypeScript support

--- a/packages/devtools-cli/src/commands/oapp/wire/index.ts
+++ b/packages/devtools-cli/src/commands/oapp/wire/index.ts
@@ -1,21 +1,36 @@
 import { Command } from 'commander'
 import { printLogo } from '@layerzerolabs/io-devtools/swag'
 import { createLogger, setDefaultLogLevel } from '@layerzerolabs/io-devtools'
-import { type WithLogLevelOption, type WithSetupOption, createSetupFileOption } from '@/commands/options'
+import {
+    type WithLogLevelOption,
+    type WithSetupOption,
+    WithTsConfigOption,
+    createLogLevelOption,
+    createSetupFileOption,
+    createTsConfigFileOption,
+} from '@/commands/options'
+import { setupTypescript } from '@/setup'
 
-interface Args extends WithLogLevelOption, WithSetupOption {}
+interface Args extends WithLogLevelOption, WithSetupOption, WithTsConfigOption {}
 
-export const wire = new Command('wire').addOption(createSetupFileOption()).action(async ({ setup, logLevel }: Args) => {
-    printLogo()
+export const wire = new Command('wire')
+    .addOption(createSetupFileOption())
+    .addOption(createTsConfigFileOption())
+    .addOption(createLogLevelOption())
+    .action(async ({ setup, logLevel, tsConfig: tsConfigPath }: Args) => {
+        printLogo()
 
-    // We'll set the global logging level to get as much info as needed
-    setDefaultLogLevel(logLevel)
+        // We'll set the global logging level to get as much info as needed
+        setDefaultLogLevel(logLevel)
 
-    const logger = createLogger(logLevel)
+        // We'll setup TypeScript support so that we can dynamically load TypeScript config files
+        setupTypescript(tsConfigPath)
 
-    logger.debug(`Loading setup from ${setup}`)
+        const logger = createLogger(logLevel)
 
-    logger.warn(
-        `This command is just a placeholder. Please use @layerzerolabs/toolbox-hardhat package for the time being.`
-    )
-})
+        logger.debug(`Loading setup from ${setup}`)
+
+        logger.warn(
+            `This command is just a placeholder. Please use @layerzerolabs/toolbox-hardhat package for the time being.`
+        )
+    })

--- a/packages/devtools-cli/src/commands/options.ts
+++ b/packages/devtools-cli/src/commands/options.ts
@@ -21,3 +21,10 @@ export const createLogLevelOption = () =>
 
             return value
         })
+
+export interface WithTsConfigOption {
+    tsConfig?: string
+}
+
+export const createTsConfigFileOption = () =>
+    new Option('--ts-config <path>', 'Path to TypeScript config file (tsconfig.json)').default('tsconfig.json')

--- a/packages/devtools-cli/src/setup/typescript.ts
+++ b/packages/devtools-cli/src/setup/typescript.ts
@@ -7,13 +7,23 @@ export const setupTypescript = (tsConfigPath?: string): void => {
     try {
         require.resolve('typescript')
     } catch {
-        return logger.debug(`typescript module not available`), undefined
+        return (
+            logger.debug(
+                `typescript module not available. To enable TypeScript support for devtools, please install typescript NPM module`
+            ),
+            undefined
+        )
     }
 
     try {
         require.resolve('ts-node')
     } catch {
-        return logger.debug(`ts-node module not available`), undefined
+        return (
+            logger.debug(
+                `ts-node module not available. To enable TypeScript support for devtools, please install ts-node NPM module`
+            ),
+            undefined
+        )
     }
 
     // In case a custom tsconfig is required, we specify it using an env variable
@@ -35,7 +45,11 @@ export const setupTypescript = (tsConfigPath?: string): void => {
 
         require(tsNode)
     } catch (error) {
-        console.error(error)
-        return logger.debug(`Failed to register ts-node: ${error}`), undefined
+        return (
+            logger.debug(
+                `Failed to register ts-node. TypeScript support for devtools will not be available. Error:\n\n${error}`
+            ),
+            undefined
+        )
     }
 }

--- a/packages/devtools-cli/src/setup/typescript.ts
+++ b/packages/devtools-cli/src/setup/typescript.ts
@@ -1,0 +1,41 @@
+import { createModuleLogger } from '@layerzerolabs/io-devtools'
+import { resolve } from 'path'
+
+export const setupTypescript = (tsConfigPath?: string): void => {
+    const logger = createModuleLogger('TypeScript support')
+
+    try {
+        require.resolve('typescript')
+    } catch {
+        return logger.debug(`typescript module not available`), undefined
+    }
+
+    try {
+        require.resolve('ts-node')
+    } catch {
+        return logger.debug(`ts-node module not available`), undefined
+    }
+
+    // In case a custom tsconfig is required, we specify it using an env variable
+    if (tsConfigPath !== undefined) {
+        logger.debug(`Using tsconfig from ${tsConfigPath} (${resolve(tsConfigPath)})`)
+
+        process.env.TS_NODE_PROJECT = resolve(tsConfigPath)
+    }
+
+    if (process.env.TS_NODE_FILES === undefined) {
+        process.env.TS_NODE_FILES = 'true'
+    }
+
+    try {
+        // tsup will optimize requires if string lterals are used directly in require()
+        //
+        // So require('ts-node/register') would result in ts-node being bundled with the module
+        const tsNode = 'ts-node/register/transpile-only'
+
+        require(tsNode)
+    } catch (error) {
+        console.error(error)
+        return logger.debug(`Failed to register ts-node: ${error}`), undefined
+    }
+}


### PR DESCRIPTION
### In this PR

- Add support for TypeScript config files in `devtools-cli`
- Fix missing `--log-level` CLI option parser