### PR TITLE
🧹 Don't force a network to be defined in hardhat config when formatting transactions

### DIFF
--- a/.changeset/metal-dryers-share.md
+++ b/.changeset/metal-dryers-share.md
@@ -1,0 +1,6 @@
+---
+"@layerzerolabs/devtools-evm-hardhat": patch
+"@layerzerolabs/toolbox-hardhat": patch
+---
+
+Don't force network to be defined when formatting transactions

--- a/packages/devtools-evm-hardhat/src/runtime.ts
+++ b/packages/devtools-evm-hardhat/src/runtime.ts
@@ -198,6 +198,34 @@ export const getEidForNetworkName = (
  * Gets a network name with its `eid` property matching
  * a particular `eid`
  *
+ * Throws if there are multiple networks defined with the same `eid`.
+ *
+ * Returns `undefined` if there is no network with given `eid`
+ *
+ * @param {EndpointId} eid
+ * @param {HardhatRuntimeEnvironment | undefined} [hre]
+ * @returns {string | undefined}
+ */
+export const getNetworkNameForEidMaybe = (
+    eid: EndpointId,
+    hre: HardhatRuntimeEnvironment = getDefaultRuntimeEnvironment()
+): string | undefined => {
+    // We are using getEidsByNetworkName to get the nice validation of network config
+    const eidsByNetworkName = getEidsByNetworkName(hre)
+
+    for (const [networkName, networkEid] of Object.entries(eidsByNetworkName)) {
+        if (networkEid === eid) {
+            return networkName
+        }
+    }
+
+    return undefined
+}
+
+/**
+ * Gets a network name with its `eid` property matching
+ * a particular `eid`
+ *
  * Throws if there is no such network or if there are multiple
  * networks defined with the same `eid`
  *
@@ -209,17 +237,10 @@ export const getNetworkNameForEid = (
     eid: EndpointId,
     hre: HardhatRuntimeEnvironment = getDefaultRuntimeEnvironment()
 ): string => {
-    // We are using getEidsByNetworkName to get the nice validation of network config
-    const eidsByNetworkName = getEidsByNetworkName(hre)
-
-    for (const [networkName, networkEid] of Object.entries(eidsByNetworkName)) {
-        if (networkEid === eid) {
-            return networkName
-        }
-    }
+    const networkName = getNetworkNameForEidMaybe(eid, hre)
 
     // Here we error out if there are no networks with this eid
-    assert(false, `Could not find a network for eid ${eid} (${formatEid(eid)})`)
+    return assert(networkName != null, `Could not find a network for eid ${eid} (${formatEid(eid)})`), networkName
 }
 
 /**

--- a/packages/devtools-evm-hardhat/src/transactions/format.ts
+++ b/packages/devtools-evm-hardhat/src/transactions/format.ts
@@ -1,9 +1,9 @@
 import { formatOmniTransaction as formatOmniTransactionBase, type OmniTransaction } from '@layerzerolabs/devtools'
-import { getNetworkNameForEid } from '@/runtime'
+import { getNetworkNameForEidMaybe } from '@/runtime'
 
 export const formatOmniTransaction = (
     transaction: OmniTransaction
 ): Record<string, string | number | bigint | undefined> => ({
-    Network: getNetworkNameForEid(transaction.point.eid),
+    Network: getNetworkNameForEidMaybe(transaction.point.eid) ?? '[Not defined in hardhat config]',
     ...formatOmniTransactionBase(transaction),
 })


### PR DESCRIPTION
### In this PR

- When using `formatOmniTransaction` with a transaction whose network is not defined in `hardhat.config`, the function would throw. This is not great if we want to add e.g. Solana to our `layerzero.config`