### PR TITLE
🗞️ Solana: Add test-devtools-solana package

### DIFF
--- a/packages/test-devtools-solana/.eslintignore
+++ b/packages/test-devtools-solana/.eslintignore
@@ -1,0 +1,2 @@
+dist
+node_modules

--- a/packages/test-devtools-solana/.eslintrc.json
+++ b/packages/test-devtools-solana/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../.eslintrc.json"
+}

--- a/packages/test-devtools-solana/.gitignore
+++ b/packages/test-devtools-solana/.gitignore
@@ -1,0 +1,3 @@
+artifacts
+cache
+deployments

--- a/packages/test-devtools-solana/.prettierignore
+++ b/packages/test-devtools-solana/.prettierignore
@@ -1,0 +1,2 @@
+dist/
+node_modules/

--- a/packages/test-devtools-solana/README.md
+++ b/packages/test-devtools-solana/README.md
@@ -1,0 +1,19 @@
+<p align="center">
+  <a href="https://layerzero.network">
+    <img alt="LayerZero" style="max-width: 500px" src="https://d3a2dpnnrypp5h.cloudfront.net/bridge-app/lz.png"/>
+  </a>
+</p>
+
+<h1 align="center">@layerzerolabs/test-devtools-solana</h1>
+
+<!-- The badges section -->
+<p align="center">
+  <!-- Shields.io NPM published package version -->
+  <a href="https://www.npmjs.com/package/@layerzerolabs/test-devtools-solana"><img alt="NPM Version" src="https://img.shields.io/npm/v/@layerzerolabs/test-devtools-solana"/></a>
+  <!-- Shields.io NPM downloads -->
+  <a href="https://www.npmjs.com/package/@layerzerolabs/test-devtools-solana"><img alt="Downloads" src="https://img.shields.io/npm/dm/@layerzerolabs/test-devtools-solana"/></a>
+  <!-- Shields.io license badge -->
+  <a href="https://www.npmjs.com/package/@layerzerolabs/test-devtools-solana"><img alt="NPM License" src="https://img.shields.io/npm/l/@layerzerolabs/test-devtools-solana"/></a>
+</p>
+
+Collection of internal helpers for testing LayerZero Solana packages

--- a/packages/test-devtools-solana/package.json
+++ b/packages/test-devtools-solana/package.json
@@ -1,0 +1,48 @@
+{
+  "name": "@layerzerolabs/test-devtools-solana",
+  "version": "0.0.1",
+  "description": "Helpers for testing LayerZero Solana packages",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/LayerZero-Labs/devtools.git",
+    "directory": "packages/test-devtools-solana"
+  },
+  "license": "MIT",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "require": "./dist/index.js",
+      "import": "./dist/index.mjs"
+    },
+    "./package.json": "./package.json"
+  },
+  "main": "dist/index.js",
+  "module": "dist/index.mjs",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "prebuild": "tsc -noEmit",
+    "build": "$npm_execpath tsup --clean",
+    "clean": "rm -rf dist",
+    "dev": "$npm_execpath tsup --watch",
+    "lint": "$npm_execpath eslint '**/*.{js,ts,json}'",
+    "lint:fix": "eslint --fix '**/*.{js,ts,json}'"
+  },
+  "devDependencies": {
+    "@solana/web3.js": "~1.95.0",
+    "fast-check": "^3.15.1",
+    "ts-node": "^10.9.2",
+    "tslib": "~2.6.2",
+    "tsup": "~8.0.1",
+    "typescript": "^5.3.3"
+  },
+  "peerDependencies": {
+    "@solana/web3.js": "~1.95.0",
+    "fast-check": "^3.14.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/test-devtools-solana/src/arbitraries.ts
+++ b/packages/test-devtools-solana/src/arbitraries.ts
@@ -4,3 +4,5 @@ import { Keypair } from '@solana/web3.js'
 export const seedArbitrary = fc.uint8Array({ minLength: 32, maxLength: 32 })
 
 export const keypairArbitrary = seedArbitrary.map((seed) => Keypair.fromSeed(seed))
+
+export const solanaAddressArbitrary = keypairArbitrary.map((keypair) => keypair.publicKey.toBase58())

--- a/packages/test-devtools-solana/src/arbitraries.ts
+++ b/packages/test-devtools-solana/src/arbitraries.ts
@@ -1,0 +1,6 @@
+import fc from 'fast-check'
+import { Keypair } from '@solana/web3.js'
+
+export const seedArbitrary = fc.uint8Array({ minLength: 32, maxLength: 32 })
+
+export const keypairArbitrary = seedArbitrary.map((seed) => Keypair.fromSeed(seed))

--- a/packages/test-devtools-solana/src/index.ts
+++ b/packages/test-devtools-solana/src/index.ts
@@ -1,0 +1,1 @@
+export * from './arbitraries'

--- a/packages/test-devtools-solana/tsconfig.json
+++ b/packages/test-devtools-solana/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.json",
+  "exclude": ["dist", "node_modules"],
+  "include": ["src"],
+  "compilerOptions": {
+    "module": "commonjs",
+    "types": ["node"],
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  }
+}

--- a/packages/test-devtools-solana/tsup.config.ts
+++ b/packages/test-devtools-solana/tsup.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from 'tsup'
+
+export default defineConfig({
+    entry: ['src/index.ts'],
+    outDir: './dist',
+    clean: true,
+    dts: true,
+    sourcemap: true,
+    splitting: false,
+    treeshake: true,
+    format: ['esm', 'cjs'],
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1575,6 +1575,27 @@ importers:
         specifier: ^5.3.3
         version: 5.3.3
 
+  packages/test-devtools-solana:
+    devDependencies:
+      '@solana/web3.js':
+        specifier: ~1.95.0
+        version: 1.95.0
+      fast-check:
+        specifier: ^3.15.1
+        version: 3.15.1
+      ts-node:
+        specifier: ^10.9.2
+        version: 10.9.2(@swc/core@1.4.0)(@types/node@18.18.14)(typescript@5.5.3)
+      tslib:
+        specifier: ~2.6.2
+        version: 2.6.3
+      tsup:
+        specifier: ~8.0.1
+        version: 8.0.1(@swc/core@1.4.0)(ts-node@10.9.2)(typescript@5.5.3)
+      typescript:
+        specifier: ^5.3.3
+        version: 5.5.3
+
   packages/toolbox-foundry:
     devDependencies:
       '@swc/core':
@@ -5000,7 +5021,7 @@ packages:
   /@manypkg/find-root@1.1.0:
     resolution: {integrity: sha512-mki5uBvhHzO8kYYix/WRy2WX8S3B5wdVSc9D6KcU5lQNglP2yt58/VfLuAK49glRXChosY8ap2oJ1qgma3GUVA==}
     dependencies:
-      '@babel/runtime': 7.23.8
+      '@babel/runtime': 7.24.8
       '@types/node': 12.20.55
       find-up: 4.1.0
       fs-extra: 8.1.0


### PR DESCRIPTION
### In this PR

- Add `@layerzerolabs/test-devtools-solana` package with testing utilities for Solana-based packages. At the moment the package only contains arbitrariness for seeds, `Keypair` objects and public addresses