### PR TITLE
🧹 export tests from oft-evm

### DIFF
--- a/.changeset/heavy-cars-push.md
+++ b/.changeset/heavy-cars-push.md
@@ -1,0 +1,5 @@
+---
+"@layerzerolabs/oft-evm": patch
+---
+
+export tests for reuse

--- a/packages/oft-evm/package.json
+++ b/packages/oft-evm/package.json
@@ -27,7 +27,8 @@
     "artifacts/OFT.sol/OFT.json",
     "artifacts/OFTAdapter.sol/OFTAdapter.json",
     "artifacts/OFTCore.sol/OFTCore.json",
-    "contracts/**/*"
+    "contracts/**/*",
+    "test/**/*"
   ],
   "scripts": {
     "build": "$npm_execpath compile",


### PR DESCRIPTION
We plan to inherit OFT.t.sol in other npm packages.  I would argue, every OFT should be able to pass the OFT.t.sol test suite, albeit with some modifications based on implementation details.  For example, a Fee-based OFT should be able to pass such tests.