### PR TITLE
🧹 Solana: Move common signer functionality into devtools

### DIFF
--- a/.changeset/fuzzy-fans-give.md
+++ b/.changeset/fuzzy-fans-give.md
@@ -1,0 +1,6 @@
+---
+"@layerzerolabs/devtools-evm": patch
+"@layerzerolabs/devtools": patch
+---
+
+Move common signer functionality into devtools

--- a/packages/devtools-evm/src/signer/sdk.ts
+++ b/packages/devtools-evm/src/signer/sdk.ts
@@ -5,8 +5,7 @@ import SafeApiKit from '@safe-global/api-kit'
 import { MetaTransactionData, OperationType, SafeTransaction } from '@safe-global/safe-core-sdk-types'
 import type { EndpointId } from '@layerzerolabs/lz-definitions'
 import {
-    formatEid,
-    formatOmniPoint,
+    OmniSignerBase,
     type OmniTransactionResponse,
     type OmniSigner,
     type OmniTransaction,
@@ -15,19 +14,12 @@ import assert from 'assert'
 
 import { ethers } from 'ethers'
 
-export abstract class OmniSignerEVMBase implements OmniSigner {
+export abstract class OmniSignerEVMBase extends OmniSignerBase implements OmniSigner {
     protected constructor(
         public readonly eid: EndpointId,
         public readonly signer: Signer
-    ) {}
-
-    protected assertTransaction(transaction: OmniTransaction) {
-        assert(
-            transaction.point.eid === this.eid,
-            `Could not use signer for ${formatEid(this.eid)} to sign a transaction for ${formatOmniPoint(
-                transaction.point
-            )}`
-        )
+    ) {
+        super()
     }
 
     abstract sign(transaction: OmniTransaction): Promise<string>

--- a/packages/devtools-evm/src/signer/sdk.ts
+++ b/packages/devtools-evm/src/signer/sdk.ts
@@ -16,14 +16,11 @@ import { ethers } from 'ethers'
 
 export abstract class OmniSignerEVMBase extends OmniSignerBase implements OmniSigner {
     protected constructor(
-        public readonly eid: EndpointId,
+        eid: EndpointId,
         public readonly signer: Signer
     ) {
-        super()
+        super(eid)
     }
-
-    abstract sign(transaction: OmniTransaction): Promise<string>
-    abstract signAndSend(transaction: OmniTransaction): Promise<OmniTransactionResponse>
 }
 
 /**

--- a/packages/devtools/src/transactions/signer.ts
+++ b/packages/devtools/src/transactions/signer.ts
@@ -3,6 +3,7 @@ import type {
     OmniSigner,
     OmniSignerFactory,
     OmniTransaction,
+    OmniTransactionResponse,
     OmniTransactionWithError,
     OmniTransactionWithReceipt,
     OmniTransactionWithResponse,
@@ -10,6 +11,25 @@ import type {
 import { formatEid, formatOmniPoint } from '@/omnigraph/format'
 import { groupTransactionsByEid } from './utils'
 import { EndpointId } from '@layerzerolabs/lz-definitions'
+import assert from 'assert'
+
+/**
+ * Base class for all signers containing common functionality
+ */
+export abstract class OmniSignerBase implements OmniSigner {
+    abstract eid: EndpointId
+    abstract sign(transaction: OmniTransaction): Promise<string>
+    abstract signAndSend(transaction: OmniTransaction): Promise<OmniTransactionResponse>
+
+    protected assertTransaction(transaction: OmniTransaction) {
+        assert(
+            transaction.point.eid === this.eid,
+            `Could not use signer for ${formatEid(this.eid)} to sign a transaction for ${formatOmniPoint(
+                transaction.point
+            )}`
+        )
+    }
+}
 
 export type SignAndSendResult = [
     // All the successful transactions

--- a/packages/devtools/src/transactions/signer.ts
+++ b/packages/devtools/src/transactions/signer.ts
@@ -17,10 +17,17 @@ import assert from 'assert'
  * Base class for all signers containing common functionality
  */
 export abstract class OmniSignerBase implements OmniSigner {
-    abstract eid: EndpointId
+    protected constructor(public readonly eid: EndpointId) {}
+
     abstract sign(transaction: OmniTransaction): Promise<string>
+
     abstract signAndSend(transaction: OmniTransaction): Promise<OmniTransactionResponse>
 
+    /**
+     * helper method to ensure that the transaction we are trying to sign is on a correct network
+     *
+     * @param {OmniTransaction} transaction
+     */
     protected assertTransaction(transaction: OmniTransaction) {
         assert(
             transaction.point.eid === this.eid,

--- a/packages/devtools/src/transactions/types.ts
+++ b/packages/devtools/src/transactions/types.ts
@@ -1,5 +1,6 @@
 import { OmniPoint } from '@/omnigraph/types'
 import { EndpointBasedFactory } from '@/types'
+import { EndpointId } from '@layerzerolabs/lz-definitions'
 
 export interface OmniTransaction {
     point: OmniPoint
@@ -34,6 +35,8 @@ export interface OmniTransactionReceipt {
 }
 
 export interface OmniSigner<TResponse extends OmniTransactionResponse = OmniTransactionResponse> {
+    eid: EndpointId
+
     sign: (transaction: OmniTransaction) => Promise<string>
     signAndSend: (transaction: OmniTransaction) => Promise<TResponse>
 


### PR DESCRIPTION
### In this PR

- Since we are introducing Solana, we can utilize the common signer functionality for the Solana signer as well