### PR TITLE
🗞️ Solana: Add signer & transaction serde methods

### DIFF
--- a/.changeset/little-foxes-sit.md
+++ b/.changeset/little-foxes-sit.md
@@ -1,0 +1,5 @@
+---
+"@layerzerolabs/devtools-solana": patch
+---
+
+Add a stub of a signer and serde utilities for Solana transactions

--- a/packages/devtools-solana/package.json
+++ b/packages/devtools-solana/package.json
@@ -46,6 +46,7 @@
     "@layerzerolabs/io-devtools": "~0.1.11",
     "@layerzerolabs/lz-definitions": "^2.3.25",
     "@layerzerolabs/test-devtools": "~0.2.6",
+    "@layerzerolabs/test-devtools-solana": "~0.0.1",
     "@solana/web3.js": "~1.95.0",
     "@swc/core": "^1.4.0",
     "@swc/jest": "^0.2.36",

--- a/packages/devtools-solana/src/index.ts
+++ b/packages/devtools-solana/src/index.ts
@@ -1,2 +1,3 @@
 export * from './connection'
 export * from './omnigraph'
+export * from './transactions'

--- a/packages/devtools-solana/src/omnigraph/sdk.ts
+++ b/packages/devtools-solana/src/omnigraph/sdk.ts
@@ -1,7 +1,8 @@
-import { Connection } from '@solana/web3.js'
+import { Connection, Transaction } from '@solana/web3.js'
 import { formatOmniPoint, type OmniPoint, type OmniTransaction } from '@layerzerolabs/devtools'
 import type { IOmniSDK } from './types'
 import { Logger, createModuleLogger } from '@layerzerolabs/io-devtools'
+import { serializeTransaction } from '@/transactions/serde'
 
 /**
  * Base class for all Solana SDKs, providing some common functionality
@@ -23,10 +24,10 @@ export abstract class OmniSDK implements IOmniSDK {
         return `Solana program @ ${formatOmniPoint(this.point)}`
     }
 
-    protected createTransaction(data: string): OmniTransaction {
+    protected createTransaction(transaction: Transaction): OmniTransaction {
         return {
             point: this.point,
-            data,
+            data: serializeTransaction(transaction),
         }
     }
 }

--- a/packages/devtools-solana/src/omnigraph/sdk.ts
+++ b/packages/devtools-solana/src/omnigraph/sdk.ts
@@ -1,8 +1,8 @@
-import { Connection, Transaction } from '@solana/web3.js'
+import { Connection, PublicKey, Transaction } from '@solana/web3.js'
 import { formatOmniPoint, type OmniPoint, type OmniTransaction } from '@layerzerolabs/devtools'
 import type { IOmniSDK } from './types'
 import { Logger, createModuleLogger } from '@layerzerolabs/io-devtools'
-import { serializeTransaction } from '@/transactions/serde'
+import { serializeTransactionMessage } from '@/transactions/serde'
 
 /**
  * Base class for all Solana SDKs, providing some common functionality
@@ -12,6 +12,7 @@ export abstract class OmniSDK implements IOmniSDK {
     constructor(
         public readonly connection: Connection,
         public readonly point: OmniPoint,
+        public readonly account: PublicKey,
         protected readonly logger: Logger = createModuleLogger(
             `Solana SDK ${new.target.name} @ ${formatOmniPoint(point)}`
         )
@@ -24,10 +25,16 @@ export abstract class OmniSDK implements IOmniSDK {
         return `Solana program @ ${formatOmniPoint(this.point)}`
     }
 
-    protected createTransaction(transaction: Transaction): OmniTransaction {
+    protected async createTransaction(transaction: Transaction): Promise<OmniTransaction> {
+        const { blockhash } = await this.connection.getLatestBlockhash('finalized')
+
+        // Transactions in Solana require a block hash and a fee payer account in order to be serialized
+        transaction.feePayer = this.account
+        transaction.recentBlockhash = blockhash
+
         return {
             point: this.point,
-            data: serializeTransaction(transaction),
+            data: serializeTransactionMessage(transaction),
         }
     }
 }

--- a/packages/devtools-solana/src/transactions/index.ts
+++ b/packages/devtools-solana/src/transactions/index.ts
@@ -1,0 +1,2 @@
+export * from './serde'
+export * from './signer'

--- a/packages/devtools-solana/src/transactions/serde.ts
+++ b/packages/devtools-solana/src/transactions/serde.ts
@@ -1,0 +1,11 @@
+import { Message, Transaction } from '@solana/web3.js'
+
+export const serializeTransactionMessage = (transaction: Transaction): string =>
+    serializeTransactionBuffer(transaction.serializeMessage())
+
+export const deserializeTransactionMessage = (data: string): Transaction =>
+    Transaction.populate(Message.from(deserializeTransactionBuffer(data)))
+
+export const serializeTransactionBuffer = (buffer: Buffer): string => buffer.toString('hex')
+
+export const deserializeTransactionBuffer = (data: string): Buffer => Buffer.from(data, 'hex')

--- a/packages/devtools-solana/src/transactions/serde.ts
+++ b/packages/devtools-solana/src/transactions/serde.ts
@@ -6,6 +6,26 @@ export const serializeTransactionMessage = (transaction: Transaction): string =>
 export const deserializeTransactionMessage = (data: string): Transaction =>
     Transaction.populate(Message.from(deserializeTransactionBuffer(data)))
 
+/**
+ * Helper utility to serialize a generic Solana buffer to string
+ *
+ * This encapsulates Buffer serialization for various uses
+ * to prevent it from creeping into more and more places
+ * and potentially getting out of sync.
+ *
+ * @param {Buffer} buffer
+ * @returns {string}
+ */
 export const serializeTransactionBuffer = (buffer: Buffer): string => buffer.toString('hex')
 
+/**
+ * Helper utility to deserialize a serialized generic Solana buffer back to a buffer
+ *
+ * This encapsulates Buffer serialization for various uses
+ * to prevent it from creeping into more and more places
+ * and potentially getting out of sync.
+ *
+ * @param {string} data Serialized Solana `Buffer`
+ * @returns {Buffer}
+ */
 export const deserializeTransactionBuffer = (data: string): Buffer => Buffer.from(data, 'hex')

--- a/packages/devtools-solana/src/transactions/signer.ts
+++ b/packages/devtools-solana/src/transactions/signer.ts
@@ -34,9 +34,6 @@ export class OmniSignerSolana extends OmniSignerBase implements OmniSigner {
 
         const solanaTransaction = deserializeTransactionMessage(transaction.data)
 
-        // Transactions in Solana require a fee payer
-        solanaTransaction.feePayer = this.signer.publicKey
-
         const signature = await sendAndConfirmTransaction(
             this.connection,
             solanaTransaction,
@@ -52,59 +49,3 @@ export class OmniSignerSolana extends OmniSignerBase implements OmniSigner {
         }
     }
 }
-
-// export const createSignerFactory = (
-//     definition?: SignerDefinition,
-//     connectionFactory = createConnectionFactory()
-// ): OmniSignerFactory<OmniSignerEVM> => {
-//     return pMemoize(async (eid) => {
-//         const provider = await providerFactory(eid)
-//         const addressOrIndex = await signerAddressorIndexFactory(eid)
-//         const signer = provider.getSigner(addressOrIndex)
-
-//         return new OmniSignerEVM(eid, signer)
-//     })
-// }
-
-// /**
-//  * Factory for signer address/index for a specific eid.
-//  *
-//  * Will take an optional signer definition and either:
-//  *
-//  * - Return static signer address or index for static signer configuration
-//  * - Look up named signer account in hardhat config and return its address
-//  *
-//  * @param {SignerDefinition} [definition]
-//  * @param {EndpointBasedFactory<HardhatRuntimeEnvironment>} [networkEnvironmentFactory]
-//  * @returns
-//  */
-// export const createSignerAddressOrIndexFactory =
-//     (
-//         definition?: SignerDefinition,
-//         networkEnvironmentFactory = createGetHreByEid()
-//     ): EndpointBasedFactory<string | number | undefined> =>
-//     async (eid) => {
-//         // If there is no definition provided, we return nothing
-//         if (definition == null) {
-//             return undefined
-//         }
-
-//         // The hardcoded address and/or index definitions are easy,
-//         // they need no resolution and can be used as they are
-//         if (definition.type === 'address') {
-//             return definition.address
-//         }
-
-//         if (definition.type === 'index') {
-//             return definition.index
-//         }
-
-//         // The named definitions need to be resolved using hre
-//         const hre = await networkEnvironmentFactory(eid)
-//         const accounts = await hre.getNamedAccounts()
-//         const account = accounts[definition.name]
-
-//         assert(account != null, `Missing named account '${definition.name}' for eid ${formatEid(eid)}`)
-
-//         return account
-//     }

--- a/packages/devtools-solana/src/transactions/signer.ts
+++ b/packages/devtools-solana/src/transactions/signer.ts
@@ -1,0 +1,110 @@
+import {
+    type OmniSigner,
+    type OmniTransaction,
+    type OmniTransactionReceipt,
+    type OmniTransactionResponse,
+    OmniSignerBase,
+} from '@layerzerolabs/devtools'
+import { ConfirmOptions, Connection, sendAndConfirmTransaction, Signer } from '@solana/web3.js'
+import { EndpointId } from '@layerzerolabs/lz-definitions'
+import { deserializeTransactionMessage, serializeTransactionBuffer } from './serde'
+
+export class OmniSignerSolana extends OmniSignerBase implements OmniSigner {
+    constructor(
+        eid: EndpointId,
+        public readonly connection: Connection,
+        public readonly signer: Signer,
+        public readonly confirmOptions: ConfirmOptions = { commitment: 'finalized' }
+    ) {
+        super(eid)
+    }
+
+    async sign(transaction: OmniTransaction): Promise<string> {
+        this.assertTransaction(transaction)
+
+        const solanaTransaction = deserializeTransactionMessage(transaction.data)
+
+        solanaTransaction.sign(this.signer)
+
+        return serializeTransactionBuffer(solanaTransaction.serialize())
+    }
+
+    async signAndSend(transaction: OmniTransaction): Promise<OmniTransactionResponse<OmniTransactionReceipt>> {
+        this.assertTransaction(transaction)
+
+        const solanaTransaction = deserializeTransactionMessage(transaction.data)
+
+        // Transactions in Solana require a fee payer
+        solanaTransaction.feePayer = this.signer.publicKey
+
+        const signature = await sendAndConfirmTransaction(
+            this.connection,
+            solanaTransaction,
+            [this.signer],
+            this.confirmOptions
+        )
+
+        return {
+            transactionHash: signature,
+            wait: async () => ({
+                transactionHash: signature,
+            }),
+        }
+    }
+}
+
+// export const createSignerFactory = (
+//     definition?: SignerDefinition,
+//     connectionFactory = createConnectionFactory()
+// ): OmniSignerFactory<OmniSignerEVM> => {
+//     return pMemoize(async (eid) => {
+//         const provider = await providerFactory(eid)
+//         const addressOrIndex = await signerAddressorIndexFactory(eid)
+//         const signer = provider.getSigner(addressOrIndex)
+
+//         return new OmniSignerEVM(eid, signer)
+//     })
+// }
+
+// /**
+//  * Factory for signer address/index for a specific eid.
+//  *
+//  * Will take an optional signer definition and either:
+//  *
+//  * - Return static signer address or index for static signer configuration
+//  * - Look up named signer account in hardhat config and return its address
+//  *
+//  * @param {SignerDefinition} [definition]
+//  * @param {EndpointBasedFactory<HardhatRuntimeEnvironment>} [networkEnvironmentFactory]
+//  * @returns
+//  */
+// export const createSignerAddressOrIndexFactory =
+//     (
+//         definition?: SignerDefinition,
+//         networkEnvironmentFactory = createGetHreByEid()
+//     ): EndpointBasedFactory<string | number | undefined> =>
+//     async (eid) => {
+//         // If there is no definition provided, we return nothing
+//         if (definition == null) {
+//             return undefined
+//         }
+
+//         // The hardcoded address and/or index definitions are easy,
+//         // they need no resolution and can be used as they are
+//         if (definition.type === 'address') {
+//             return definition.address
+//         }
+
+//         if (definition.type === 'index') {
+//             return definition.index
+//         }
+
+//         // The named definitions need to be resolved using hre
+//         const hre = await networkEnvironmentFactory(eid)
+//         const accounts = await hre.getNamedAccounts()
+//         const account = accounts[definition.name]
+
+//         assert(account != null, `Missing named account '${definition.name}' for eid ${formatEid(eid)}`)
+
+//         return account
+//     }

--- a/packages/devtools-solana/test/connection/factory.test.ts
+++ b/packages/devtools-solana/test/connection/factory.test.ts
@@ -5,10 +5,6 @@ import { Connection } from '@solana/web3.js'
 import { EndpointId } from '@layerzerolabs/lz-definitions'
 import { formatEid } from '@layerzerolabs/devtools'
 
-// We'll use the fake timers to work around the fact that JsonRpcProvider uses setTimeout
-// to schedule a task in the queue in its constructor
-jest.useFakeTimers()
-
 describe('provider/factory', () => {
     describe('createConnectionFactory', () => {
         const errorArbitrary = fc.anything()

--- a/packages/devtools-solana/test/omnigraph/sdk.test.ts
+++ b/packages/devtools-solana/test/omnigraph/sdk.test.ts
@@ -1,0 +1,64 @@
+import fc from 'fast-check'
+import { Connection, sendAndConfirmTransaction, SystemProgram, Transaction } from '@solana/web3.js'
+import { keypairArbitrary, solanaAddressArbitrary, solanaBlockhashArbitrary } from '@layerzerolabs/test-devtools-solana'
+import { endpointArbitrary } from '@layerzerolabs/test-devtools'
+import { OmniSDK } from '@/omnigraph'
+
+jest.mock('@solana/web3.js', () => {
+    const original = jest.requireActual('@solana/web3.js')
+
+    return {
+        ...original,
+        sendAndConfirmTransaction: jest.fn(),
+    }
+})
+
+const sendAndConfirmTransactionMock = sendAndConfirmTransaction as jest.Mock
+
+describe('omnigraph/sdk', () => {
+    beforeEach(() => {
+        sendAndConfirmTransactionMock.mockReset()
+    })
+
+    describe('createTransaction', () => {
+        it('should add a feePayer and the latest block hash to the transaction', async () => {
+            await fc.assert(
+                fc.asyncProperty(
+                    endpointArbitrary,
+                    solanaAddressArbitrary,
+                    keypairArbitrary,
+                    keypairArbitrary,
+                    solanaBlockhashArbitrary,
+                    async (eid, address, sender, recipient, blockhash) => {
+                        class TestOmniSDK extends OmniSDK {
+                            test() {
+                                const transfer = SystemProgram.transfer({
+                                    fromPubkey: sender.publicKey,
+                                    toPubkey: recipient.publicKey,
+                                    lamports: 49,
+                                })
+                                const transaction = new Transaction().add(transfer)
+
+                                return this.createTransaction(transaction)
+                            }
+                        }
+
+                        const connection = new Connection('http://soyllama.com')
+                        jest.spyOn(connection, 'getLatestBlockhash').mockResolvedValue({
+                            blockhash,
+                            lastValidBlockHeight: NaN,
+                        })
+
+                        const sdk = new TestOmniSDK(connection, { eid, address }, sender.publicKey)
+                        const omniTransaction = await sdk.test()
+
+                        expect(omniTransaction).toEqual({
+                            data: expect.any(String),
+                            point: { eid, address },
+                        })
+                    }
+                )
+            )
+        })
+    })
+})

--- a/packages/devtools-solana/test/transactions/serde.test.ts
+++ b/packages/devtools-solana/test/transactions/serde.test.ts
@@ -1,0 +1,44 @@
+import fc from 'fast-check'
+import { SystemProgram, Transaction } from '@solana/web3.js'
+import { serializeTransactionMessage, deserializeTransactionMessage } from '@/transactions'
+import { keypairArbitrary } from '@layerzerolabs/test-devtools-solana'
+
+describe('transactions/serde', () => {
+    describe('serializeTransactionMessage / deserializeTransactionMessage', () => {
+        it('should work', async () => {
+            await fc.assert(
+                fc.asyncProperty(keypairArbitrary, keypairArbitrary, async (sender, recipient) => {
+                    const transfer = SystemProgram.transfer({
+                        fromPubkey: sender.publicKey,
+                        toPubkey: recipient.publicKey,
+                        lamports: 49,
+                    })
+
+                    const transaction = new Transaction().add(transfer)
+
+                    // Transaction in Solana require a recent block hash to be set in order for them to be serialized
+                    transaction.recentBlockhash = 'EETubP5AKHgjPAhzPAFcb8BAY1hMH639CWCFTqi3hq1k'
+
+                    // Transactions in Solana require a fee payer to be set in order for them to be serialized
+                    transaction.feePayer = sender.publicKey
+
+                    // First we serialize the transaction
+                    const serializedTransaction = serializeTransactionMessage(transaction)
+                    // Then we deserialize it
+                    const deserializedTransaction = deserializeTransactionMessage(serializedTransaction)
+                    // And check that the fields match the original transaction
+                    //
+                    // The reason why we don't compare the transactions directly is that the signers will not match
+                    // after deserialization (the signers get stripped out of the original transaction)
+                    expect(deserializedTransaction.instructions).toEqual(transaction.instructions)
+                    expect(deserializedTransaction.recentBlockhash).toEqual(transaction.recentBlockhash)
+                    expect(deserializedTransaction.feePayer).toEqual(transaction.feePayer)
+
+                    // Now we serialize the deserialized transaction again and check that it fully matches the serialized transaction
+                    const reserializedTransaction = serializeTransactionMessage(deserializedTransaction)
+                    expect(reserializedTransaction).toEqual(serializedTransaction)
+                })
+            )
+        })
+    })
+})

--- a/packages/devtools-solana/test/transactions/signer.test.ts
+++ b/packages/devtools-solana/test/transactions/signer.test.ts
@@ -76,7 +76,7 @@ describe('transactions/signer', () => {
                             lamports: 49,
                         })
 
-                        const connection = new Connection('http://solana.lz-localnet.org:8899')
+                        const connection = new Connection('http://soyllama.com')
                         const omniSigner = new OmniSignerSolana(eid, connection, sender)
 
                         const transaction = new Transaction().add(transfer)

--- a/packages/devtools-solana/test/transactions/signer.test.ts
+++ b/packages/devtools-solana/test/transactions/signer.test.ts
@@ -1,0 +1,103 @@
+import fc from 'fast-check'
+import { Connection, sendAndConfirmTransaction, SystemProgram, Transaction } from '@solana/web3.js'
+import { serializeTransactionMessage, OmniSignerSolana, deserializeTransactionBuffer } from '@/transactions'
+import { keypairArbitrary, solanaAddressArbitrary } from '@layerzerolabs/test-devtools-solana'
+import { OmniTransaction } from '@layerzerolabs/devtools'
+import { endpointArbitrary } from '@layerzerolabs/test-devtools'
+
+jest.mock('@solana/web3.js', () => {
+    const original = jest.requireActual('@solana/web3.js')
+
+    return {
+        ...original,
+        sendAndConfirmTransaction: jest.fn(),
+    }
+})
+
+const sendAndConfirmTransactionMock = sendAndConfirmTransaction as jest.Mock
+
+describe('transactions/signer', () => {
+    beforeEach(() => {
+        sendAndConfirmTransactionMock.mockReset()
+    })
+
+    describe('sign', () => {
+        it('should sign a transaction', async () => {
+            await fc.assert(
+                fc.asyncProperty(
+                    endpointArbitrary,
+                    solanaAddressArbitrary,
+                    keypairArbitrary,
+                    keypairArbitrary,
+                    async (eid, address, sender, recipient) => {
+                        const transfer = SystemProgram.transfer({
+                            fromPubkey: sender.publicKey,
+                            toPubkey: recipient.publicKey,
+                            lamports: 49,
+                        })
+
+                        const connection = new Connection('http://soyllama.com')
+                        const omniSigner = new OmniSignerSolana(eid, connection, sender)
+
+                        const transaction = new Transaction().add(transfer)
+                        transaction.recentBlockhash = 'EETubP5AKHgjPAhzPAFcb8BAY1hMH639CWCFTqi3hq1k'
+                        transaction.feePayer = sender.publicKey
+
+                        const omniTransaction: OmniTransaction = {
+                            point: { eid, address },
+                            data: serializeTransactionMessage(transaction),
+                        }
+
+                        const signature = await omniSigner.sign(omniTransaction)
+                        const serializedTransaction = (transaction.sign(sender), transaction.serialize())
+
+                        expect(deserializeTransactionBuffer(signature)).toEqual(serializedTransaction)
+                    }
+                )
+            )
+        })
+    })
+
+    describe('signAndSend', () => {
+        it('should sign and send a transaction', async () => {
+            await fc.assert(
+                fc.asyncProperty(
+                    endpointArbitrary,
+                    solanaAddressArbitrary,
+                    keypairArbitrary,
+                    keypairArbitrary,
+                    fc.string(),
+                    async (eid, address, sender, recipient, transactionHash) => {
+                        sendAndConfirmTransactionMock.mockResolvedValue(transactionHash)
+
+                        const transfer = SystemProgram.transfer({
+                            fromPubkey: sender.publicKey,
+                            toPubkey: recipient.publicKey,
+                            lamports: 49,
+                        })
+
+                        const connection = new Connection('http://solana.lz-localnet.org:8899')
+                        const omniSigner = new OmniSignerSolana(eid, connection, sender)
+
+                        const transaction = new Transaction().add(transfer)
+                        transaction.recentBlockhash = 'EETubP5AKHgjPAhzPAFcb8BAY1hMH639CWCFTqi3hq1k'
+                        transaction.feePayer = sender.publicKey
+
+                        const omniTransaction: OmniTransaction = {
+                            point: { eid, address },
+                            data: serializeTransactionMessage(transaction),
+                        }
+
+                        const response = await omniSigner.signAndSend(omniTransaction)
+                        expect(response).toEqual({
+                            transactionHash,
+                            wait: expect.any(Function),
+                        })
+
+                        expect(await response.wait()).toEqual({ transactionHash })
+                    }
+                )
+            )
+        })
+    })
+})

--- a/packages/test-devtools-solana/package.json
+++ b/packages/test-devtools-solana/package.json
@@ -32,6 +32,7 @@
   },
   "devDependencies": {
     "@solana/web3.js": "~1.95.0",
+    "bs58": "~6.0.0",
     "fast-check": "^3.15.1",
     "ts-node": "^10.9.2",
     "tslib": "~2.6.2",

--- a/packages/test-devtools-solana/src/arbitraries.ts
+++ b/packages/test-devtools-solana/src/arbitraries.ts
@@ -1,8 +1,14 @@
 import fc from 'fast-check'
 import { Keypair } from '@solana/web3.js'
+import { createHash } from 'crypto'
+import bs58 from 'bs58'
 
 export const seedArbitrary = fc.uint8Array({ minLength: 32, maxLength: 32 })
 
 export const keypairArbitrary = seedArbitrary.map((seed) => Keypair.fromSeed(seed))
 
 export const solanaAddressArbitrary = keypairArbitrary.map((keypair) => keypair.publicKey.toBase58())
+
+export const solanaBlockhashArbitrary = fc
+    .string()
+    .map((value) => bs58.encode(Uint8Array.from(createHash('sha256').update(value).digest())))

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1589,6 +1589,9 @@ importers:
       '@solana/web3.js':
         specifier: ~1.95.0
         version: 1.95.0
+      bs58:
+        specifier: ~6.0.0
+        version: 6.0.0
       fast-check:
         specifier: ^3.15.1
         version: 3.15.1
@@ -7362,6 +7365,10 @@ packages:
   /base-x@4.0.0:
     resolution: {integrity: sha512-FuwxlW4H5kh37X/oW59pwTzzTKRzfrrQwhmyspRM7swOEZcHtDZSCt45U6oKgtuFE+WYPblePMVIPR4RZrh/hw==}
 
+  /base-x@5.0.0:
+    resolution: {integrity: sha512-sMW3VGSX1QWVFA6l8U62MLKz29rRfpTlYdCqLdpLo1/Yd4zZwSbnUaDfciIAowAqvq7YFnWq9hrhdg1KYgc1lQ==}
+    dev: true
+
   /base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
 
@@ -7538,6 +7545,12 @@ packages:
     resolution: {integrity: sha512-r+ihvQJvahgYT50JD05dyJNKlmmSlMoOGwn1lCcEzanPglg7TxYjioQUYehQ9mAR/+hOSd2jRc/Z2y5UxBymvQ==}
     dependencies:
       base-x: 4.0.0
+
+  /bs58@6.0.0:
+    resolution: {integrity: sha512-PD0wEnEYg6ijszw/u8s+iI3H17cTymlrwkKhDhPZq+Sokl3AU4htyBFTjAeNAlCCmg0f53g6ih3jATyCKftTfw==}
+    dependencies:
+      base-x: 5.0.0
+    dev: true
 
   /bs58check@2.1.2:
     resolution: {integrity: sha512-0TS1jicxdU09dwJMNZtVAfzPi6Q6QeN0pM1Fkzrjn+XYHvzMKPU3pHVpva+769iNVSfIYWf7LJ6WR+BuuMf8cA==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -917,6 +917,9 @@ importers:
       '@layerzerolabs/test-devtools':
         specifier: ~0.2.6
         version: link:../test-devtools
+      '@layerzerolabs/test-devtools-solana':
+        specifier: ~0.0.1
+        version: link:../test-devtools-solana
       '@solana/web3.js':
         specifier: ~1.95.0
         version: 1.95.0


### PR DESCRIPTION
### In this PR

- Add `OmniSignerSolana`
- Add `feePayer` and `recentBlockHash` when creating transactions in the SDK. This is where Solana differs from EVM in that SDK and accounts can no longer be separated easily
- Add serialization / deserialization methods for Solana transactions
- Add `solanaBlockhashArbitrary` for testing purposes