### PR TITLE
🧹 clean up documentation around safeUrl

### DIFF
--- a/packages/devtools-evm-hardhat/src/type-extensions.ts
+++ b/packages/devtools-evm-hardhat/src/type-extensions.ts
@@ -93,7 +93,7 @@ declare module 'hardhat/types/config' {
         safeConfig?: SafeConfig
     }
     interface SafeConfig extends ConnectSafeConfigWithSafeAddress {
-        safeUrl: string
+        safeUrl: string // Note:  This is the URL of the Safe API, not the safe itself
         safeAddress: string // override to make ConnectSafeConfig.safeAddress mandatory
     }
 


### PR DESCRIPTION
safeUrl is an ambiguous and misleading name.  The least we can do is document what it is supposed to mean.