### PR TITLE
🗞️ Solana: Generic peer logic [6/N]

### DIFF
--- a/.changeset/clever-pianos-flash.md
+++ b/.changeset/clever-pianos-flash.md
@@ -1,0 +1,9 @@
+---
+"@layerzerolabs/ua-devtools-evm-hardhat-test": patch
+"@layerzerolabs/test-devtools-solana": patch
+"@layerzerolabs/ua-devtools-evm": patch
+"@layerzerolabs/test-devtools": patch
+"@layerzerolabs/devtools": patch
+---
+
+Add non-EVM bytes logic

--- a/.changeset/gorgeous-ladybugs-swim.md
+++ b/.changeset/gorgeous-ladybugs-swim.md
@@ -1,0 +1,5 @@
+---
+"@layerzerolabs/test-devtools": patch
+---
+
+Add network-specific address arbitraries

--- a/packages/devtools-solana/test/omnigraph/sdk.test.ts
+++ b/packages/devtools-solana/test/omnigraph/sdk.test.ts
@@ -1,7 +1,7 @@
 import fc from 'fast-check'
 import { Connection, sendAndConfirmTransaction, SystemProgram, Transaction } from '@solana/web3.js'
-import { keypairArbitrary, solanaAddressArbitrary, solanaBlockhashArbitrary } from '@layerzerolabs/test-devtools-solana'
-import { endpointArbitrary } from '@layerzerolabs/test-devtools'
+import { keypairArbitrary, solanaBlockhashArbitrary } from '@layerzerolabs/test-devtools-solana'
+import { endpointArbitrary, solanaAddressArbitrary } from '@layerzerolabs/test-devtools'
 import { OmniSDK } from '@/omnigraph'
 
 jest.mock('@solana/web3.js', () => {

--- a/packages/devtools-solana/test/transactions/signer.test.ts
+++ b/packages/devtools-solana/test/transactions/signer.test.ts
@@ -1,9 +1,9 @@
 import fc from 'fast-check'
 import { Connection, sendAndConfirmTransaction, SystemProgram, Transaction } from '@solana/web3.js'
 import { serializeTransactionMessage, OmniSignerSolana, deserializeTransactionBuffer } from '@/transactions'
-import { keypairArbitrary, solanaAddressArbitrary } from '@layerzerolabs/test-devtools-solana'
+import { keypairArbitrary } from '@layerzerolabs/test-devtools-solana'
 import { OmniTransaction } from '@layerzerolabs/devtools'
-import { endpointArbitrary } from '@layerzerolabs/test-devtools'
+import { endpointArbitrary, solanaAddressArbitrary } from '@layerzerolabs/test-devtools'
 
 jest.mock('@solana/web3.js', () => {
     const original = jest.requireActual('@solana/web3.js')

--- a/packages/devtools/package.json
+++ b/packages/devtools/package.json
@@ -31,6 +31,7 @@
     "test": "jest --ci --forceExit"
   },
   "dependencies": {
+    "bs58": "^6.0.0",
     "exponential-backoff": "~3.1.1",
     "js-yaml": "~4.1.0"
   },

--- a/packages/devtools/src/common/bytes.ts
+++ b/packages/devtools/src/common/bytes.ts
@@ -10,10 +10,10 @@ import bs58 from 'bs58'
  *
  * It will return zero bytes if passed `null`, `undefined` or an empty string.
  *
- * @param {PossiblyBytes | null | undefined} address
+ * @param {PossiblyBytes | null | undefined} bytes
  * @returns {string}
  */
-export const makeBytes32 = (address?: PossiblyBytes | null | undefined): string => hexZeroPad(address || '0x0', 32)
+export const makeBytes32 = (bytes?: PossiblyBytes | null | undefined): string => hexZeroPad(bytes || '0x0', 32)
 
 /**
  * Compares two Bytes32-like values by value (i.e. ignores casing on strings
@@ -88,7 +88,11 @@ export const compareBytes32Ascending = (a: PossiblyBytes, b: PossiblyBytes): num
  * @param {EndpointId} eid
  * @returns {Uint8Array}
  */
-export const normalizePeer = (address: OmniAddress, eid: EndpointId): Uint8Array => {
+export const normalizePeer = (address: OmniAddress | null | undefined, eid: EndpointId): Uint8Array => {
+    if (address == null) {
+        return new Uint8Array(32)
+    }
+
     const chainType = endpointIdToChainType(eid)
 
     switch (chainType) {
@@ -111,7 +115,11 @@ export const normalizePeer = (address: OmniAddress, eid: EndpointId): Uint8Array
  * @param {EndpointId} eid
  * @returns {OmniAddress}
  */
-export const denormalizePeer = (bytes: Uint8Array, eid: EndpointId): OmniAddress => {
+export const denormalizePeer = (bytes: Uint8Array | null | undefined, eid: EndpointId): OmniAddress | undefined => {
+    if (bytes == null || isZero(bytes)) {
+        return undefined
+    }
+
     const chainType = endpointIdToChainType(eid)
 
     switch (chainType) {

--- a/packages/devtools/src/types.ts
+++ b/packages/devtools/src/types.ts
@@ -10,7 +10,7 @@ export type PossiblyBigInt = string | number | bigint
 
 export type OmniAddress = Bytes32 | Bytes20
 
-export type PossiblyBytes = Bytes | Bytes32 | Bytes20
+export type PossiblyBytes = Bytes | Bytes32 | Bytes20 | Uint8Array
 
 /**
  * Generic type for a hybrid (sync / async) factory

--- a/packages/devtools/test/bytes.test.ts
+++ b/packages/devtools/test/bytes.test.ts
@@ -97,6 +97,50 @@ describe('bytes', () => {
                 })
             )
         })
+
+        it('should return true for identical UInt8Arrays', () => {
+            fc.assert(
+                fc.property(fc.uint8Array({ minLength: 1 }), (bytes) => {
+                    expect(areBytes32Equal(bytes, bytes)).toBe(true)
+                })
+            )
+        })
+
+        it('should return true for a UInt8Array & its hex representation', () => {
+            fc.assert(
+                fc.property(fc.uint8Array({ minLength: 1, maxLength: 32 }), (bytes) => {
+                    expect(areBytes32Equal(bytes, makeBytes32(bytes))).toBe(true)
+                })
+            )
+        })
+
+        it('should return false two non-matching UInt8Array instances', () => {
+            fc.assert(
+                fc.property(
+                    fc.uint8Array({ minLength: 1, maxLength: 32 }),
+                    fc.uint8Array({ minLength: 1, maxLength: 32 }),
+                    (a, b) => {
+                        fc.pre(a.length !== b.length || a.some((v, i) => v !== b[i]) || b.some((v, i) => v !== a[i]))
+
+                        expect(areBytes32Equal(a, b)).toBe(false)
+                    }
+                )
+            )
+        })
+
+        it('should return false two a UInt8Array & non-matching hex string', () => {
+            fc.assert(
+                fc.property(
+                    fc.uint8Array({ minLength: 1, maxLength: 32 }),
+                    fc.uint8Array({ minLength: 1, maxLength: 32 }),
+                    (a, b) => {
+                        fc.pre(a.length !== b.length || a.some((v, i) => v !== b[i]) || b.some((v, i) => v !== a[i]))
+
+                        expect(areBytes32Equal(a, makeBytes32(b))).toBe(false)
+                    }
+                )
+            )
+        })
     })
 
     describe('isZero', () => {
@@ -136,6 +180,28 @@ describe('bytes', () => {
                     fc.pre(address !== ZERO_BYTES)
 
                     expect(isZero(address)).toBe(false)
+                })
+            )
+        })
+
+        it('should return true with an empty UInt8Array', () => {
+            expect(isZero(new Uint8Array(0))).toBe(true)
+        })
+
+        it('should return true with a zero-only UInt8Array', () => {
+            fc.assert(
+                fc.property(fc.uint8Array({ min: 0, max: 0 }), (bytes) => {
+                    expect(isZero(bytes)).toBe(true)
+                })
+            )
+        })
+
+        it('should return false with a non-zero UInt8Array', () => {
+            fc.assert(
+                fc.property(fc.uint8Array({ minLength: 1 }), (bytes) => {
+                    fc.pre(bytes.some((byte) => byte !== 0))
+
+                    expect(isZero(bytes)).toBe(false)
                 })
             )
         })

--- a/packages/devtools/test/common/bytes.test.ts
+++ b/packages/devtools/test/common/bytes.test.ts
@@ -1,17 +1,31 @@
-import { denormalizePeer, normalizePeer } from '@/common/bytes'
+import { denormalizePeer, isZero, normalizePeer } from '@/common/bytes'
 import { ChainType, endpointIdToChainType } from '@layerzerolabs/lz-definitions'
 import {
     aptosAddressArbitrary,
     endpointArbitrary,
     evmAddressArbitrary,
+    nullishArbitrary,
     solanaAddressArbitrary,
 } from '@layerzerolabs/test-devtools'
 import fc from 'fast-check'
 
 describe('common/bytes', () => {
-    describe('normalizePeer', () => {
+    describe('normalizePeer/denormalizePeer', () => {
         describe('for EVM', () => {
             const evmEndpointArbitrary = endpointArbitrary.filter((eid) => endpointIdToChainType(eid) === ChainType.EVM)
+
+            it('should normalize a nullish value to empty bytes', () => {
+                fc.assert(
+                    fc.property(evmEndpointArbitrary, nullishArbitrary, (eid, address) => {
+                        const normalized = normalizePeer(address, eid)
+                        const denormalized = denormalizePeer(normalized, eid)
+
+                        expect(normalized).toEqual(new Uint8Array(32))
+                        expect(isZero(normalized)).toBe(true)
+                        expect(isZero(denormalized)).toBe(true)
+                    })
+                )
+            })
 
             it('should normalize a peer correctly', () => {
                 fc.assert(
@@ -30,6 +44,19 @@ describe('common/bytes', () => {
                 (eid) => endpointIdToChainType(eid) === ChainType.APTOS
             )
 
+            it('should normalize a nullish value to empty bytes', () => {
+                fc.assert(
+                    fc.property(aptosEndpointArbitrary, nullishArbitrary, (eid, address) => {
+                        const normalized = normalizePeer(address, eid)
+                        const denormalized = denormalizePeer(normalized, eid)
+
+                        expect(normalized).toEqual(new Uint8Array(32))
+                        expect(isZero(normalized)).toBe(true)
+                        expect(isZero(denormalized)).toBe(true)
+                    })
+                )
+            })
+
             it('should normalize a peer correctly', () => {
                 fc.assert(
                     fc.property(aptosEndpointArbitrary, aptosAddressArbitrary, (eid, address) => {
@@ -46,6 +73,19 @@ describe('common/bytes', () => {
             const solanaEndpointArbitrary = endpointArbitrary.filter(
                 (eid) => endpointIdToChainType(eid) === ChainType.SOLANA
             )
+
+            it('should normalize a nullish value to empty bytes', () => {
+                fc.assert(
+                    fc.property(solanaEndpointArbitrary, nullishArbitrary, (eid, address) => {
+                        const normalized = normalizePeer(address, eid)
+                        const denormalized = denormalizePeer(normalized, eid)
+
+                        expect(normalized).toEqual(new Uint8Array(32))
+                        expect(isZero(normalized)).toBe(true)
+                        expect(isZero(denormalized)).toBe(true)
+                    })
+                )
+            })
 
             it('should normalize a peer correctly', () => {
                 fc.assert(

--- a/packages/devtools/test/common/bytes.test.ts
+++ b/packages/devtools/test/common/bytes.test.ts
@@ -1,0 +1,62 @@
+import { denormalizePeer, normalizePeer } from '@/common/bytes'
+import { ChainType, endpointIdToChainType } from '@layerzerolabs/lz-definitions'
+import {
+    aptosAddressArbitrary,
+    endpointArbitrary,
+    evmAddressArbitrary,
+    solanaAddressArbitrary,
+} from '@layerzerolabs/test-devtools'
+import fc from 'fast-check'
+
+describe('common/bytes', () => {
+    describe('normalizePeer', () => {
+        describe('for EVM', () => {
+            const evmEndpointArbitrary = endpointArbitrary.filter((eid) => endpointIdToChainType(eid) === ChainType.EVM)
+
+            it('should normalize a peer correctly', () => {
+                fc.assert(
+                    fc.property(evmEndpointArbitrary, evmAddressArbitrary, (eid, address) => {
+                        const normalized = normalizePeer(address, eid)
+                        const denormalized = denormalizePeer(normalized, eid)
+
+                        expect(denormalized).toBe(address)
+                    })
+                )
+            })
+        })
+
+        describe('for APTOS', () => {
+            const aptosEndpointArbitrary = endpointArbitrary.filter(
+                (eid) => endpointIdToChainType(eid) === ChainType.APTOS
+            )
+
+            it('should normalize a peer correctly', () => {
+                fc.assert(
+                    fc.property(aptosEndpointArbitrary, aptosAddressArbitrary, (eid, address) => {
+                        const normalized = normalizePeer(address, eid)
+                        const denormalized = denormalizePeer(normalized, eid)
+
+                        expect(denormalized).toBe(address)
+                    })
+                )
+            })
+        })
+
+        describe('for SOLANA', () => {
+            const solanaEndpointArbitrary = endpointArbitrary.filter(
+                (eid) => endpointIdToChainType(eid) === ChainType.SOLANA
+            )
+
+            it('should normalize a peer correctly', () => {
+                fc.assert(
+                    fc.property(solanaEndpointArbitrary, solanaAddressArbitrary, (eid, address) => {
+                        const normalized = normalizePeer(address, eid)
+                        const denormalized = denormalizePeer(normalized, eid)
+
+                        expect(denormalized).toBe(address)
+                    })
+                )
+            })
+        })
+    })
+})

--- a/packages/devtools/test/common/bytes.test.ts
+++ b/packages/devtools/test/common/bytes.test.ts
@@ -1,19 +1,18 @@
 import { denormalizePeer, isZero, normalizePeer } from '@/common/bytes'
-import { ChainType, endpointIdToChainType } from '@layerzerolabs/lz-definitions'
 import {
     aptosAddressArbitrary,
-    endpointArbitrary,
+    aptosEndpointArbitrary,
     evmAddressArbitrary,
+    evmEndpointArbitrary,
     nullishArbitrary,
     solanaAddressArbitrary,
+    solanaEndpointArbitrary,
 } from '@layerzerolabs/test-devtools'
 import fc from 'fast-check'
 
 describe('common/bytes', () => {
     describe('normalizePeer/denormalizePeer', () => {
         describe('for EVM', () => {
-            const evmEndpointArbitrary = endpointArbitrary.filter((eid) => endpointIdToChainType(eid) === ChainType.EVM)
-
             it('should normalize a nullish value to empty bytes', () => {
                 fc.assert(
                     fc.property(evmEndpointArbitrary, nullishArbitrary, (eid, address) => {
@@ -40,10 +39,6 @@ describe('common/bytes', () => {
         })
 
         describe('for APTOS', () => {
-            const aptosEndpointArbitrary = endpointArbitrary.filter(
-                (eid) => endpointIdToChainType(eid) === ChainType.APTOS
-            )
-
             it('should normalize a nullish value to empty bytes', () => {
                 fc.assert(
                     fc.property(aptosEndpointArbitrary, nullishArbitrary, (eid, address) => {
@@ -70,10 +65,6 @@ describe('common/bytes', () => {
         })
 
         describe('for SOLANA', () => {
-            const solanaEndpointArbitrary = endpointArbitrary.filter(
-                (eid) => endpointIdToChainType(eid) === ChainType.SOLANA
-            )
-
             it('should normalize a nullish value to empty bytes', () => {
                 fc.assert(
                     fc.property(solanaEndpointArbitrary, nullishArbitrary, (eid, address) => {

--- a/packages/test-devtools-solana/src/arbitraries.ts
+++ b/packages/test-devtools-solana/src/arbitraries.ts
@@ -7,8 +7,6 @@ export const seedArbitrary = fc.uint8Array({ minLength: 32, maxLength: 32 })
 
 export const keypairArbitrary = seedArbitrary.map((seed) => Keypair.fromSeed(seed))
 
-export const solanaAddressArbitrary = keypairArbitrary.map((keypair) => keypair.publicKey.toBase58())
-
 export const solanaBlockhashArbitrary = fc
     .string()
     .map((value) => bs58.encode(Uint8Array.from(createHash('sha256').update(value).digest())))

--- a/packages/test-devtools/package.json
+++ b/packages/test-devtools/package.json
@@ -34,6 +34,7 @@
   },
   "devDependencies": {
     "@layerzerolabs/lz-definitions": "^2.3.25",
+    "bs58": "^6.0.0",
     "fast-check": "^3.15.1",
     "ts-node": "^10.9.2",
     "tslib": "~2.6.2",
@@ -42,6 +43,7 @@
   },
   "peerDependencies": {
     "@layerzerolabs/lz-definitions": "^2.3.3",
+    "bs58": "^6.0.0",
     "fast-check": "^3.14.0"
   },
   "publishConfig": {

--- a/packages/test-devtools/src/arbitraries.ts
+++ b/packages/test-devtools/src/arbitraries.ts
@@ -1,5 +1,5 @@
 import fc from 'fast-check'
-import { EndpointId, Stage } from '@layerzerolabs/lz-definitions'
+import { ChainType, EndpointId, endpointIdToChainType, Stage } from '@layerzerolabs/lz-definitions'
 import { BIP39_WORDLIST, ENDPOINT_IDS } from './constants'
 import { entropyToMnemonic } from '@scure/bip39'
 import bs58 from 'bs58'
@@ -23,6 +23,14 @@ export const aptosAddressArbitrary = fc.hexaString({ minLength: 64, maxLength: 6
 export const solanaAddressArbitrary = fc.uint8Array({ minLength: 32, maxLength: 32 }).map((bytes) => bs58.encode(bytes))
 
 export const endpointArbitrary: fc.Arbitrary<EndpointId> = fc.constantFrom(...ENDPOINT_IDS)
+
+export const evmEndpointArbitrary = endpointArbitrary.filter((eid) => endpointIdToChainType(eid) === ChainType.EVM)
+
+export const aptosEndpointArbitrary = endpointArbitrary.filter((eid) => endpointIdToChainType(eid) === ChainType.APTOS)
+
+export const solanaEndpointArbitrary = endpointArbitrary.filter(
+    (eid) => endpointIdToChainType(eid) === ChainType.SOLANA
+)
 
 export const stageArbitrary: fc.Arbitrary<Stage> = fc.constantFrom(Stage.MAINNET, Stage.TESTNET, Stage.SANDBOX)
 

--- a/packages/test-devtools/src/arbitraries.ts
+++ b/packages/test-devtools/src/arbitraries.ts
@@ -2,6 +2,7 @@ import fc from 'fast-check'
 import { EndpointId, Stage } from '@layerzerolabs/lz-definitions'
 import { BIP39_WORDLIST, ENDPOINT_IDS } from './constants'
 import { entropyToMnemonic } from '@scure/bip39'
+import bs58 from 'bs58'
 
 export const nullishArbitrary = fc.constantFrom(null, undefined)
 
@@ -16,6 +17,10 @@ export const addressArbitrary = fc.string()
 export const evmAddressArbitrary = fc.hexaString({ minLength: 40, maxLength: 40 }).map((address) => `0x${address}`)
 
 export const evmBytes32Arbitrary = fc.hexaString({ minLength: 64, maxLength: 64 }).map((address) => `0x${address}`)
+
+export const aptosAddressArbitrary = fc.hexaString({ minLength: 64, maxLength: 64 }).map((address) => `0x${address}`)
+
+export const solanaAddressArbitrary = fc.uint8Array({ minLength: 32, maxLength: 32 }).map((bytes) => bs58.encode(bytes))
 
 export const endpointArbitrary: fc.Arbitrary<EndpointId> = fc.constantFrom(...ENDPOINT_IDS)
 

--- a/packages/ua-devtools-evm/src/oapp/sdk.ts
+++ b/packages/ua-devtools-evm/src/oapp/sdk.ts
@@ -62,7 +62,7 @@ export class OApp extends Ownable implements IOApp {
         // We run the hex string we got through a normalization/denormalization process
         // that will ensure that zero addresses will get stripped
         // and any network-specific logic will be applied
-        return denormalizePeer(normalizePeer(peer, eid), eid)
+        return denormalizePeer(normalizePeer(peer, this.contract.eid), eid)
     }
 
     async hasPeer(eid: EndpointId, address: OmniAddress | null | undefined): Promise<boolean> {

--- a/packages/ua-devtools-evm/src/oapp/sdk.ts
+++ b/packages/ua-devtools-evm/src/oapp/sdk.ts
@@ -6,9 +6,10 @@ import {
     formatEid,
     isZero,
     areBytes32Equal,
-    ignoreZero,
     makeBytes32,
     Bytes,
+    normalizePeer,
+    denormalizePeer,
 } from '@layerzerolabs/devtools'
 import { type OmniContract, formatOmniContract, BigNumberishBigIntSchema } from '@layerzerolabs/devtools-evm'
 import type { EndpointId } from '@layerzerolabs/lz-definitions'
@@ -58,17 +59,25 @@ export class OApp extends Ownable implements IOApp {
             (error) => new Error(`Failed to get peer for ${eidLabel} for OApp ${this.label}: ${error}`)
         )
 
-        return ignoreZero(peer)
+        // We run the hex string we got through a normalization/denormalization process
+        // that will ensure that zero addresses will get stripped
+        // and any network-specific logic will be applied
+        return denormalizePeer(normalizePeer(peer, eid), eid)
     }
 
     async hasPeer(eid: EndpointId, address: OmniAddress | null | undefined): Promise<boolean> {
-        return areBytes32Equal(await this.getPeer(eid), address)
+        const peer = await this.getPeer(eid)
+
+        return areBytes32Equal(normalizePeer(peer, eid), normalizePeer(address, eid))
     }
 
     async setPeer(eid: EndpointId, address: OmniAddress | null | undefined): Promise<OmniTransaction> {
-        this.logger.debug(`Setting peer for eid ${eid} (${formatEid(eid)}) to address ${makeBytes32(address)}`)
+        const normalizedPeer = normalizePeer(address, eid)
+        const peerAsBytes32 = makeBytes32(normalizedPeer)
 
-        const data = this.contract.contract.interface.encodeFunctionData('setPeer', [eid, makeBytes32(address)])
+        this.logger.debug(`Setting peer for eid ${eid} (${formatEid(eid)}) to address ${peerAsBytes32}`)
+
+        const data = this.contract.contract.interface.encodeFunctionData('setPeer', [eid, peerAsBytes32])
         return {
             ...this.createTransaction(data),
             description: `Setting peer for eid ${eid} (${formatEid(eid)}) to address ${makeBytes32(address)}`,

--- a/packages/ua-devtools-evm/src/oapp/sdk.ts
+++ b/packages/ua-devtools-evm/src/oapp/sdk.ts
@@ -80,7 +80,7 @@ export class OApp extends Ownable implements IOApp {
         const data = this.contract.contract.interface.encodeFunctionData('setPeer', [eid, peerAsBytes32])
         return {
             ...this.createTransaction(data),
-            description: `Setting peer for eid ${eid} (${formatEid(eid)}) to address ${makeBytes32(address)}`,
+            description: `Setting peer for eid ${eid} (${formatEid(eid)}) to address ${peerAsBytes32}`,
         }
     }
 

--- a/packages/ua-devtools-evm/test/oapp/sdk.test.ts
+++ b/packages/ua-devtools-evm/test/oapp/sdk.test.ts
@@ -11,7 +11,7 @@ import {
 import { Contract } from '@ethersproject/contracts'
 import { OApp } from '@/oapp/sdk'
 import { OmniContract, makeZeroAddress } from '@layerzerolabs/devtools-evm'
-import { denormalizePeer, isZero, makeBytes32, normalizePeer } from '@layerzerolabs/devtools'
+import { areBytes32Equal, isZero, makeBytes32, normalizePeer } from '@layerzerolabs/devtools'
 import { formatEid } from '@layerzerolabs/devtools'
 
 describe('oapp/sdk', () => {
@@ -28,7 +28,7 @@ describe('oapp/sdk', () => {
     }) as fc.Arbitrary<unknown> as fc.Arbitrary<Contract>
 
     const omniContractArbitrary: fc.Arbitrary<OmniContract> = fc.record({
-        eid: endpointArbitrary,
+        eid: evmEndpointArbitrary,
         contract: oappOmniContractArbitrary,
     })
 
@@ -117,7 +117,7 @@ describe('oapp/sdk', () => {
                             // We do this by normalizing the value into a UInt8Array,
                             // then denormalizing it using an EVM eid
                             const peerBytes = normalizePeer(peer, peerEid)
-                            const peerHex = denormalizePeer(peerBytes, eid)
+                            const peerHex = makeBytes32(peerBytes)
 
                             fc.pre(!isZero(peerHex))
 
@@ -173,156 +173,344 @@ describe('oapp/sdk', () => {
 
     describe('hasPeer', () => {
         describe('when called with zeroish address', () => {
-            it('should return true if peers returns a zero address', async () => {
-                await fc.assert(
-                    fc.asyncProperty(
-                        omniContractArbitrary,
-                        endpointArbitrary,
-                        nullishAddressArbitrary,
-                        nullishAddressArbitrary,
-                        async (omniContract, peerEid, peer, probePeer) => {
-                            omniContract.contract.peers.mockResolvedValue(peer)
+            describe('for EVM', () => {
+                it('should return true if peers returns a zero address', async () => {
+                    await fc.assert(
+                        fc.asyncProperty(
+                            omniContractArbitrary,
+                            evmEndpointArbitrary,
+                            nullishAddressArbitrary,
+                            nullishAddressArbitrary,
+                            async (omniContract, peerEid, peer, probePeer) => {
+                                omniContract.contract.peers.mockResolvedValue(peer)
 
-                            const sdk = new OApp(omniContract, EndpointV2Factory)
+                                const sdk = new OApp(omniContract, EndpointV2Factory)
 
-                            await expect(sdk.hasPeer(peerEid, probePeer)).resolves.toBe(true)
-                        }
+                                await expect(sdk.hasPeer(peerEid, probePeer)).resolves.toBe(true)
+                            }
+                        )
                     )
-                )
+                })
+
+                it('should return false if peers returns a non-zero address', async () => {
+                    await fc.assert(
+                        fc.asyncProperty(
+                            omniContractArbitrary,
+                            evmEndpointArbitrary,
+                            nullishAddressArbitrary,
+                            evmAddressArbitrary,
+                            async (omniContract, peerEid, peer, probePeer) => {
+                                fc.pre(!isZero(probePeer))
+
+                                omniContract.contract.peers.mockResolvedValue(peer)
+
+                                const sdk = new OApp(omniContract, EndpointV2Factory)
+
+                                await expect(sdk.hasPeer(peerEid, probePeer)).resolves.toBe(false)
+                            }
+                        )
+                    )
+                })
+
+                it('should return true if peers() returns a matching bytes32', async () => {
+                    await fc.assert(
+                        fc.asyncProperty(
+                            omniContractArbitrary,
+                            evmEndpointArbitrary,
+                            evmAddressArbitrary,
+                            async (omniContract, peerEid, peer) => {
+                                omniContract.contract.peers.mockResolvedValue(makeBytes32(peer))
+
+                                const sdk = new OApp(omniContract, EndpointV2Factory)
+
+                                await expect(sdk.hasPeer(peerEid, peer)).resolves.toBe(true)
+                                await expect(sdk.hasPeer(peerEid, makeBytes32(peer))).resolves.toBe(true)
+                            }
+                        )
+                    )
+                })
             })
 
-            it('should return false if peers returns a non-zero address', async () => {
-                await fc.assert(
-                    fc.asyncProperty(
-                        omniContractArbitrary,
-                        endpointArbitrary,
-                        nullishAddressArbitrary,
-                        evmAddressArbitrary,
-                        async (omniContract, peerEid, peer, probePeer) => {
-                            fc.pre(!isZero(probePeer))
+            describe('for Solana', () => {
+                it('should return true if peers returns a zero address', async () => {
+                    await fc.assert(
+                        fc.asyncProperty(
+                            omniContractArbitrary,
+                            solanaEndpointArbitrary,
+                            nullishAddressArbitrary,
+                            async (omniContract, peerEid, peer) => {
+                                omniContract.contract.peers.mockResolvedValue(peer)
 
-                            omniContract.contract.peers.mockResolvedValue(peer)
+                                const sdk = new OApp(omniContract, EndpointV2Factory)
 
-                            const sdk = new OApp(omniContract, EndpointV2Factory)
-
-                            await expect(sdk.hasPeer(peerEid, probePeer)).resolves.toBe(false)
-                        }
+                                await expect(sdk.hasPeer(peerEid, undefined)).resolves.toBe(true)
+                            }
+                        )
                     )
-                )
+                })
+
+                it('should return false if peers returns a different value', async () => {
+                    await fc.assert(
+                        fc.asyncProperty(
+                            omniContractArbitrary,
+                            solanaEndpointArbitrary,
+                            solanaAddressArbitrary,
+                            solanaAddressArbitrary,
+                            async (omniContract, peerEid, peer, probePeer) => {
+                                fc.pre(
+                                    !areBytes32Equal(normalizePeer(peer, peerEid), normalizePeer(probePeer, peerEid))
+                                )
+
+                                const peerHex = makeBytes32(normalizePeer(peer, peerEid))
+
+                                omniContract.contract.peers.mockResolvedValue(peerHex)
+
+                                const sdk = new OApp(omniContract, EndpointV2Factory)
+
+                                await expect(sdk.hasPeer(peerEid, probePeer)).resolves.toBe(false)
+                            }
+                        )
+                    )
+                })
+
+                it('should return true if peers() returns a matching value', async () => {
+                    await fc.assert(
+                        fc.asyncProperty(
+                            omniContractArbitrary,
+                            solanaEndpointArbitrary,
+                            solanaAddressArbitrary,
+                            async (omniContract, peerEid, peer) => {
+                                const peerHex = makeBytes32(normalizePeer(peer, peerEid))
+
+                                omniContract.contract.peers.mockResolvedValue(peerHex)
+
+                                const sdk = new OApp(omniContract, EndpointV2Factory)
+
+                                await expect(sdk.hasPeer(peerEid, peer)).resolves.toBe(true)
+                            }
+                        )
+                    )
+                })
             })
-        })
 
-        describe('when called non-zeroish address', () => {
-            it('should return false if peers() returns a zero address, null or undefined', async () => {
-                await fc.assert(
-                    fc.asyncProperty(
-                        omniContractArbitrary,
-                        endpointArbitrary,
-                        evmAddressArbitrary,
-                        nullishAddressArbitrary,
-                        async (omniContract, peerEid, peer, probePeer) => {
-                            fc.pre(!isZero(peer))
+            describe('for Aptos', () => {
+                it('should return true if peers returns a zero address', async () => {
+                    await fc.assert(
+                        fc.asyncProperty(
+                            omniContractArbitrary,
+                            aptosEndpointArbitrary,
+                            nullishAddressArbitrary,
+                            nullishAddressArbitrary,
+                            async (omniContract, peerEid, peer, probePeer) => {
+                                omniContract.contract.peers.mockResolvedValue(peer)
 
-                            omniContract.contract.peers.mockResolvedValue(peer)
+                                const sdk = new OApp(omniContract, EndpointV2Factory)
 
-                            const sdk = new OApp(omniContract, EndpointV2Factory)
-
-                            await expect(sdk.hasPeer(peerEid, probePeer)).resolves.toBe(false)
-                            await expect(sdk.hasPeer(peerEid, makeBytes32(probePeer))).resolves.toBe(false)
-                        }
+                                await expect(sdk.hasPeer(peerEid, probePeer)).resolves.toBe(true)
+                            }
+                        )
                     )
-                )
-            })
+                })
 
-            it('should return true if peers() returns a matching address', async () => {
-                await fc.assert(
-                    fc.asyncProperty(
-                        omniContractArbitrary,
-                        endpointArbitrary,
-                        evmAddressArbitrary,
-                        async (omniContract, peerEid, peer) => {
-                            fc.pre(!isZero(peer))
+                it('should return false if peers returns a non-zero address', async () => {
+                    await fc.assert(
+                        fc.asyncProperty(
+                            omniContractArbitrary,
+                            aptosEndpointArbitrary,
+                            nullishAddressArbitrary,
+                            aptosAddressArbitrary,
+                            async (omniContract, peerEid, peer, probePeer) => {
+                                fc.pre(!isZero(probePeer))
 
-                            omniContract.contract.peers.mockResolvedValue(peer)
+                                omniContract.contract.peers.mockResolvedValue(peer)
 
-                            const sdk = new OApp(omniContract, EndpointV2Factory)
+                                const sdk = new OApp(omniContract, EndpointV2Factory)
 
-                            await expect(sdk.hasPeer(peerEid, peer)).resolves.toBe(true)
-                            await expect(sdk.hasPeer(peerEid, makeBytes32(peer))).resolves.toBe(true)
-                        }
+                                await expect(sdk.hasPeer(peerEid, probePeer)).resolves.toBe(false)
+                            }
+                        )
                     )
-                )
-            })
+                })
 
-            it('should return true if peers() returns a matching bytes32', async () => {
-                await fc.assert(
-                    fc.asyncProperty(
-                        omniContractArbitrary,
-                        endpointArbitrary,
-                        evmAddressArbitrary,
-                        async (omniContract, peerEid, peer) => {
-                            fc.pre(!isZero(peer))
+                it('should return true if peers() returns a matching bytes32', async () => {
+                    await fc.assert(
+                        fc.asyncProperty(
+                            omniContractArbitrary,
+                            aptosEndpointArbitrary,
+                            aptosAddressArbitrary,
+                            async (omniContract, peerEid, peer) => {
+                                omniContract.contract.peers.mockResolvedValue(makeBytes32(peer))
 
-                            omniContract.contract.peers.mockResolvedValue(makeBytes32(peer))
+                                const sdk = new OApp(omniContract, EndpointV2Factory)
 
-                            const sdk = new OApp(omniContract, EndpointV2Factory)
-
-                            await expect(sdk.hasPeer(peerEid, peer)).resolves.toBe(true)
-                            await expect(sdk.hasPeer(peerEid, makeBytes32(peer))).resolves.toBe(true)
-                        }
+                                await expect(sdk.hasPeer(peerEid, peer)).resolves.toBe(true)
+                                await expect(sdk.hasPeer(peerEid, makeBytes32(peer))).resolves.toBe(true)
+                            }
+                        )
                     )
-                )
+                })
             })
         })
     })
 
     describe('setPeer', () => {
-        it('should encode data for a setPeer call', async () => {
-            await fc.assert(
-                fc.asyncProperty(
-                    omniContractArbitrary,
-                    endpointArbitrary,
-                    evmAddressArbitrary,
-                    async (omniContract, peerEid, peerAddress) => {
-                        const sdk = new OApp(omniContract, EndpointV2Factory)
-                        const encodeFunctionData = omniContract.contract.interface.encodeFunctionData
+        describe('for EVM', () => {
+            it('should encode data for a setPeer call', async () => {
+                await fc.assert(
+                    fc.asyncProperty(
+                        omniContractArbitrary,
+                        evmEndpointArbitrary,
+                        evmAddressArbitrary,
+                        async (omniContract, peerEid, peerAddress) => {
+                            const sdk = new OApp(omniContract, EndpointV2Factory)
+                            const encodeFunctionData = omniContract.contract.interface.encodeFunctionData
 
-                        ;(encodeFunctionData as jest.Mock).mockClear()
+                            ;(encodeFunctionData as jest.Mock).mockClear()
 
-                        await sdk.setPeer(peerEid, peerAddress)
+                            await sdk.setPeer(peerEid, peerAddress)
 
-                        expect(encodeFunctionData).toHaveBeenCalledTimes(1)
-                        expect(encodeFunctionData).toHaveBeenCalledWith('setPeer', [peerEid, makeBytes32(peerAddress)])
-                    }
+                            expect(encodeFunctionData).toHaveBeenCalledTimes(1)
+                            expect(encodeFunctionData).toHaveBeenCalledWith('setPeer', [
+                                peerEid,
+                                makeBytes32(peerAddress),
+                            ])
+                        }
+                    )
                 )
-            )
+            })
+
+            it('should return an OmniTransaction', async () => {
+                await fc.assert(
+                    fc.asyncProperty(
+                        omniContractArbitrary,
+                        evmEndpointArbitrary,
+                        evmAddressArbitrary,
+                        fc.string(),
+                        async (omniContract, peerEid, peerAddress, data) => {
+                            const encodeFunctionData = omniContract.contract.interface.encodeFunctionData as jest.Mock
+                            encodeFunctionData.mockReturnValue(data)
+
+                            const sdk = new OApp(omniContract, EndpointV2Factory)
+                            const transaction = await sdk.setPeer(peerEid, peerAddress)
+
+                            expect(transaction).toEqual({
+                                data,
+                                description: `Setting peer for eid ${peerEid} (${formatEid(peerEid)}) to address ${makeBytes32(peerAddress)}`,
+                                point: {
+                                    eid: omniContract.eid,
+                                    address: omniContract.contract.address,
+                                },
+                            })
+                        }
+                    )
+                )
+            })
         })
 
-        it('should return an OmniTransaction', async () => {
-            await fc.assert(
-                fc.asyncProperty(
-                    omniContractArbitrary,
-                    endpointArbitrary,
-                    evmAddressArbitrary,
-                    fc.string(),
-                    async (omniContract, peerEid, peerAddress, data) => {
-                        const encodeFunctionData = omniContract.contract.interface.encodeFunctionData as jest.Mock
-                        encodeFunctionData.mockReturnValue(data)
+        describe('for Solana', () => {
+            it('should encode data for a setPeer call', async () => {
+                await fc.assert(
+                    fc.asyncProperty(
+                        omniContractArbitrary,
+                        solanaEndpointArbitrary,
+                        solanaAddressArbitrary,
+                        async (omniContract, peerEid, peerAddress) => {
+                            const sdk = new OApp(omniContract, EndpointV2Factory)
+                            const encodeFunctionData = omniContract.contract.interface.encodeFunctionData
 
-                        const sdk = new OApp(omniContract, EndpointV2Factory)
-                        const transaction = await sdk.setPeer(peerEid, peerAddress)
+                            ;(encodeFunctionData as jest.Mock).mockClear()
 
-                        expect(transaction).toEqual({
-                            data,
-                            description: `Setting peer for eid ${peerEid} (${formatEid(peerEid)}) to address ${makeBytes32(peerAddress)}`,
-                            point: {
-                                eid: omniContract.eid,
-                                address: omniContract.contract.address,
-                            },
-                        })
-                    }
+                            await sdk.setPeer(peerEid, peerAddress)
+
+                            expect(encodeFunctionData).toHaveBeenCalledTimes(1)
+                            expect(encodeFunctionData).toHaveBeenCalledWith('setPeer', [
+                                peerEid,
+                                makeBytes32(normalizePeer(peerAddress, peerEid)),
+                            ])
+                        }
+                    )
                 )
-            )
+            })
+
+            it('should return an OmniTransaction', async () => {
+                await fc.assert(
+                    fc.asyncProperty(
+                        omniContractArbitrary,
+                        solanaEndpointArbitrary,
+                        solanaAddressArbitrary,
+                        fc.string(),
+                        async (omniContract, peerEid, peerAddress, data) => {
+                            const encodeFunctionData = omniContract.contract.interface.encodeFunctionData as jest.Mock
+                            encodeFunctionData.mockReturnValue(data)
+
+                            const sdk = new OApp(omniContract, EndpointV2Factory)
+                            const transaction = await sdk.setPeer(peerEid, peerAddress)
+
+                            expect(transaction).toEqual({
+                                data,
+                                description: `Setting peer for eid ${peerEid} (${formatEid(peerEid)}) to address ${makeBytes32(normalizePeer(peerAddress, peerEid))}`,
+                                point: {
+                                    eid: omniContract.eid,
+                                    address: omniContract.contract.address,
+                                },
+                            })
+                        }
+                    )
+                )
+            })
+        })
+
+        describe('for Aptos', () => {
+            it('should encode data for a setPeer call', async () => {
+                await fc.assert(
+                    fc.asyncProperty(
+                        omniContractArbitrary,
+                        aptosEndpointArbitrary,
+                        aptosAddressArbitrary,
+                        async (omniContract, peerEid, peerAddress) => {
+                            const sdk = new OApp(omniContract, EndpointV2Factory)
+                            const encodeFunctionData = omniContract.contract.interface.encodeFunctionData
+
+                            ;(encodeFunctionData as jest.Mock).mockClear()
+
+                            await sdk.setPeer(peerEid, peerAddress)
+
+                            expect(encodeFunctionData).toHaveBeenCalledTimes(1)
+                            expect(encodeFunctionData).toHaveBeenCalledWith('setPeer', [
+                                peerEid,
+                                makeBytes32(peerAddress),
+                            ])
+                        }
+                    )
+                )
+            })
+
+            it('should return an OmniTransaction', async () => {
+                await fc.assert(
+                    fc.asyncProperty(
+                        omniContractArbitrary,
+                        aptosEndpointArbitrary,
+                        aptosAddressArbitrary,
+                        fc.string(),
+                        async (omniContract, peerEid, peerAddress, data) => {
+                            const encodeFunctionData = omniContract.contract.interface.encodeFunctionData as jest.Mock
+                            encodeFunctionData.mockReturnValue(data)
+
+                            const sdk = new OApp(omniContract, EndpointV2Factory)
+                            const transaction = await sdk.setPeer(peerEid, peerAddress)
+
+                            expect(transaction).toEqual({
+                                data,
+                                description: `Setting peer for eid ${peerEid} (${formatEid(peerEid)}) to address ${makeBytes32(peerAddress)}`,
+                                point: {
+                                    eid: omniContract.eid,
+                                    address: omniContract.contract.address,
+                                },
+                            })
+                        }
+                    )
+                )
+            })
         })
     })
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -699,6 +699,9 @@ importers:
 
   packages/devtools:
     dependencies:
+      bs58:
+        specifier: ^6.0.0
+        version: 6.0.0
       exponential-backoff:
         specifier: ~3.1.1
         version: 3.1.1
@@ -1601,6 +1604,9 @@ importers:
       '@layerzerolabs/lz-definitions':
         specifier: ^2.3.25
         version: 2.3.25
+      bs58:
+        specifier: ^6.0.0
+        version: 6.0.0
       fast-check:
         specifier: ^3.15.1
         version: 3.15.1
@@ -7574,7 +7580,6 @@ packages:
 
   /base-x@5.0.0:
     resolution: {integrity: sha512-sMW3VGSX1QWVFA6l8U62MLKz29rRfpTlYdCqLdpLo1/Yd4zZwSbnUaDfciIAowAqvq7YFnWq9hrhdg1KYgc1lQ==}
-    dev: true
 
   /base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
@@ -7757,7 +7762,6 @@ packages:
     resolution: {integrity: sha512-PD0wEnEYg6ijszw/u8s+iI3H17cTymlrwkKhDhPZq+Sokl3AU4htyBFTjAeNAlCCmg0f53g6ih3jATyCKftTfw==}
     dependencies:
       base-x: 5.0.0
-    dev: true
 
   /bs58check@2.1.2:
     resolution: {integrity: sha512-0TS1jicxdU09dwJMNZtVAfzPi6Q6QeN0pM1Fkzrjn+XYHvzMKPU3pHVpva+769iNVSfIYWf7LJ6WR+BuuMf8cA==}

--- a/tests/ua-devtools-evm-hardhat-test/test/oapp/config.test.ts
+++ b/tests/ua-devtools-evm-hardhat-test/test/oapp/config.test.ts
@@ -123,6 +123,7 @@ describe('oapp/config', () => {
             ]
             expect(transactions).toEqual(expectedTransactions)
         })
+
         it('should exclude setPeer transactions for peers that have been set', async () => {
             // Before we configure the OApp, we'll set some peers
             const signerFactory = createSignerFactory()
@@ -2423,6 +2424,30 @@ describe('oapp/config', () => {
                 await signAndSend([(await ethOAppSdk.setCallerBpsCap(ethCallerBpsCap)) as OmniTransaction])
                 expect(await ethOAppSdk.getCallerBpsCap()).toBe(ethCallerBpsCap)
             })
+        })
+    })
+
+    describe('configureOAppPeers with Solana', () => {
+        it('should set the peers', async () => {
+            const solanaPoint: OmniPoint = {
+                eid: EndpointId.SOLANA_V2_MAINNET,
+                address: 'Ag28jYmND83RnwcSFq2vwWxThSya55etjWJwubd8tRXs',
+            }
+            const graph: OAppOmniGraph = {
+                contracts: [
+                    {
+                        point: avaxPoint,
+                    },
+                ],
+                connections: [
+                    {
+                        vector: { from: avaxPoint, to: solanaPoint },
+                    },
+                ],
+            }
+            const transactions = await configureOApp(graph, oappSdkFactory)
+            const expectedTransactions = [await avaxOAppSdk.setPeer(solanaPoint.eid, solanaPoint.address)]
+            expect(transactions).toEqual(expectedTransactions)
         })
     })
 })

--- a/tests/ua-devtools-evm-hardhat-test/test/oapp/config.test.ts
+++ b/tests/ua-devtools-evm-hardhat-test/test/oapp/config.test.ts
@@ -2445,9 +2445,15 @@ describe('oapp/config', () => {
                     },
                 ],
             }
+
             const transactions = await configureOApp(graph, oappSdkFactory)
             const expectedTransactions = [await avaxOAppSdk.setPeer(solanaPoint.eid, solanaPoint.address)]
             expect(transactions).toEqual(expectedTransactions)
+
+            const signAndSend = createSignAndSend(createSignerFactory())
+            await signAndSend(transactions)
+
+            expect(await configureOApp(graph, oappSdkFactory)).toEqual([])
         })
     })
 })

--- a/tests/ua-devtools-evm-hardhat-test/test/task/oapp/__data__/configs/valid.config.connected.external.connection.js
+++ b/tests/ua-devtools-evm-hardhat-test/test/task/oapp/__data__/configs/valid.config.connected.external.connection.js
@@ -16,7 +16,7 @@ const avaxContract = {
 // Since it's only used as a `to` in a connection, the scripts should still work
 const solContract = {
     eid: EndpointId.SOLANA_V2_MAINNET,
-    address: '0x708687b6133d4eff7fdfe1adb237dfa01d3671f924f9991c5676729cedce9efd',
+    address: 'Ag28jYmND83RnwcSFq2vwWxThSya55etjWJwubd8tRXs',
 };
 
 module.exports = {


### PR DESCRIPTION
### In this PR

- Low-level peer address logic around the `peer` address. This is one special case of an address-like value that cannot be encapsulated in a specific chain implementation of an SDK - the look & feel of this value does not depend on the source chain but rather on the target chain. For example, EVM SDK should return a value that resembles a Solana address if asked for a peer on `SOLANA_V2_MAINNET` and vice versa.
  - The logic in the SDK's `getPeer`/`setPeer`/`hasPeer` should always follow a normalization pattern:
    - Remote chain address address is converted to a normalized value (32 items long `UInt8Array`)
    - Normalized value is converted into a local chain value
- This required several cuts into the underlying bytes logic around `bytes32`. The code should now handle `UInt8Array` as a valid value for `PossiblyBytes` and the `OApp` SDK should be able to handle Solana & Aptos addresses
- The EVM SDK tests have been adjusted to take all the different cases into account (EVM ⇌ EVM, EVM ⇌ Solana, EVM ⇌ Aptos)