### PR TITLE
🪲 Fix solidity-bytes-utils in toolbox-foundry

### DIFF
--- a/.changeset/tidy-cups-accept.md
+++ b/.changeset/tidy-cups-accept.md
@@ -1,0 +1,5 @@
+---
+"@layerzerolabs/toolbox-foundry": patch
+---
+
+Update Makefile that was incorrectly copying soldity-bytes-utils

--- a/packages/oft-evm/foundry.toml
+++ b/packages/oft-evm/foundry.toml
@@ -8,21 +8,26 @@ cache_path = "cache"
 optimizer = true
 optimizer_runs = 20_000
 
+libs = [
+    # We provide a set of useful contract utilities
+    # in the lib directory of @layerzerolabs/toolbox-foundry:
+    #
+    # - forge-std
+    # - ds-test
+    # - solidity-bytes-utils
+    'node_modules/@layerzerolabs/toolbox-foundry/lib',
+    'node_modules',
+]
+
 remappings = [
-    # note: map to package level only, required for pnp-berry to work with foundry
-    # ok - solidity-stringutils/=node_modules/solidity-stringutils/
-    # not ok - solidity-stringutils/=node_modules/solidity-stringutils/src/
+    # Due to a misconfiguration of solidity-bytes-utils, an outdated version
+    # of forge-std is being dragged in
+    #
+    # To remedy this, we'll remap the ds-test and forge-std imports to ou own versions
     'ds-test/=node_modules/@layerzerolabs/toolbox-foundry/src/ds-test/src/',
     'forge-std/=node_modules/@layerzerolabs/toolbox-foundry/src/forge-std/src/',
-    '@openzeppelin/contracts/=node_modules/@openzeppelin/contracts/',
-    '@openzeppelin/contracts-upgradeable/=node_modules/@openzeppelin/contracts-upgradeable/',
-    'solidity-bytes-utils/=node_modules/solidity-bytes-utils/',
-    'hardhat-deploy/=node_modules/hardhat-deploy/',
-    '@layerzerolabs/lz-evm-oapp-v2/=node_modules/@layerzerolabs/lz-evm-oapp-v2/',
-    '@layerzerolabs/lz-evm-protocol-v2/=node_modules/@layerzerolabs/lz-evm-protocol-v2/',
-    '@layerzerolabs/lz-evm-messagelib-v2/=node_modules/@layerzerolabs/lz-evm-messagelib-v2/',
-    '@layerzerolabs/lz-evm-v1-0.7/=node_modules/@layerzerolabs/lz-evm-v1-0.7/',
-    '@layerzerolabs/test-devtools-evm-foundry/=node_modules/@layerzerolabs/test-devtools-evm-foundry/',
+    '@layerzerolabs/=node_modules/@layerzerolabs/',
+    '@openzeppelin/=node_modules/@openzeppelin/',
 ]
 
 [fuzz]

--- a/packages/toolbox-foundry/Makefile
+++ b/packages/toolbox-foundry/Makefile
@@ -18,10 +18,10 @@ node_modules:
 	mkdir -p lib/solidity-bytes-utils
 
 	# We copy the contracts
-	cp -R node_modules/solidity-bytes-utils/contracts/ lib/solidity-bytes-utils/
+	cp -R node_modules/solidity-bytes-utils/contracts/. lib/solidity-bytes-utils/.
 
 	# And we include the licenses & package.json
-	cp node_modules/solidity-bytes-utils/package.json node_modules/solidity-bytes-utils/LICENSE* lib/solidity-bytes-utils
+	cp node_modules/solidity-bytes-utils/package.json node_modules/solidity-bytes-utils/LICENSE* lib/solidity-bytes-utils/
 
 # This target will get all the git submodules installed in src/ directory
 # and copy them to lib/ directory


### PR DESCRIPTION
### In this PR

- Fix a `cp` command in `toolbox-foundry` (`cp` behaves differently on BSD and GNU systems)