### PR TITLE
🧹document compatibility limitations with tokens which block transactions

### DIFF
--- a/packages/onft-evm/contracts/onft721/ONFT721Adapter.sol
+++ b/packages/onft-evm/contracts/onft721/ONFT721Adapter.sol
@@ -9,6 +9,8 @@ import { ONFT721Core } from "./ONFT721Core.sol";
 /**
  * @title ONFT721Adapter Contract
  * @dev ONFT721Adapter is a wrapper used to enable cross-chain transferring of an existing ERC721 token.
+ * @dev ERC721 NFTs from extensions which revert certain transactions, such as ones from blocked wallets or soulbound
+ * @dev tokens, may still be bridgeable.
  */
 abstract contract ONFT721Adapter is ONFT721Core {
     IERC721 internal immutable innerToken;


### PR DESCRIPTION
Similar to ERC20s, certain token implementations may extend the token logic with things such as pausing, banning and soulbound controls (non-transfer- ability of certain NFTs). For example, here are some users discussing how to make certain NFTs soulbound:

https://forum.openzeppelin.com/t/soulbound-nft-migration-from-v4-9-to--v5-0/38931/4

By using `_burn`, less metadata of who is initiating this transaction is sent to `_update`, potentially causing such checks to still pass because the auth metadata does not include the msg.sender.

This commit simply documents the limitation for such tokens with an appropriate developer warning.