### PR TITLE
🗞️ Solana: Stub of EndpointV2 SDK: Send & receive library getters [10/N]

### DIFF
--- a/packages/protocol-devtools-solana/.eslintignore
+++ b/packages/protocol-devtools-solana/.eslintignore
@@ -1,0 +1,2 @@
+dist
+node_modules

--- a/packages/protocol-devtools-solana/.eslintrc.json
+++ b/packages/protocol-devtools-solana/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../.eslintrc.json"
+}

--- a/packages/protocol-devtools-solana/.prettierignore
+++ b/packages/protocol-devtools-solana/.prettierignore
@@ -1,0 +1,2 @@
+dist/
+node_modules/

--- a/packages/protocol-devtools-solana/.swcrc
+++ b/packages/protocol-devtools-solana/.swcrc
@@ -1,0 +1,11 @@
+{
+    "jsc": {
+        "parser": {
+            "syntax": "typescript",
+            "decorators": true
+        },
+        "transform": {
+            "legacyDecorator": true
+        }
+    }
+}

--- a/packages/protocol-devtools-solana/README.md
+++ b/packages/protocol-devtools-solana/README.md
@@ -1,0 +1,19 @@
+<p align="center">
+  <a href="https://layerzero.network">
+    <img alt="LayerZero" style="max-width: 500px" src="https://d3a2dpnnrypp5h.cloudfront.net/bridge-app/lz.png"/>
+  </a>
+</p>
+
+<h1 align="center">@layerzerolabs/protocol-devtools-solana</h1>
+
+<!-- The badges section -->
+<p align="center">
+  <!-- Shields.io NPM published package version -->
+  <a href="https://www.npmjs.com/package/@layerzerolabs/protocol-devtools-solana"><img alt="NPM Version" src="https://img.shields.io/npm/v/@layerzerolabs/protocol-devtools-solana"/></a>
+  <!-- Shields.io NPM downloads -->
+  <a href="https://www.npmjs.com/package/@layerzerolabs/protocol-devtools-solana"><img alt="Downloads" src="https://img.shields.io/npm/dm/@layerzerolabs/protocol-devtools-solana"/></a>
+  <!-- Shields.io license badge -->
+  <a href="https://www.npmjs.com/package/@layerzerolabs/protocol-devtools-solana"><img alt="NPM License" src="https://img.shields.io/npm/l/@layerzerolabs/protocol-devtools-solana"/></a>
+</p>
+
+Utilities for working with LayerZero Solana protocol programs.

--- a/packages/protocol-devtools-solana/jest.config.js
+++ b/packages/protocol-devtools-solana/jest.config.js
@@ -1,0 +1,13 @@
+/** @type {import('ts-jest').JestConfigWithTsJest} */
+module.exports = {
+    cache: false,
+    reporters: [['github-actions', { silent: false }], 'default'],
+    testEnvironment: 'node',
+    setupFilesAfterEnv: ['<rootDir>/jest.setup.js'],
+    moduleNameMapper: {
+        '^@/(.*)$': '<rootDir>/src/$1',
+    },
+    transform: {
+        '^.+\\.(t|j)sx?$': '@swc/jest',
+    },
+};

--- a/packages/protocol-devtools-solana/jest.config.js
+++ b/packages/protocol-devtools-solana/jest.config.js
@@ -3,6 +3,7 @@ module.exports = {
     cache: false,
     reporters: [['github-actions', { silent: false }], 'default'],
     testEnvironment: 'node',
+    testTimeout: 15_000,
     setupFilesAfterEnv: ['<rootDir>/jest.setup.js'],
     moduleNameMapper: {
         '^@/(.*)$': '<rootDir>/src/$1',

--- a/packages/protocol-devtools-solana/jest.setup.js
+++ b/packages/protocol-devtools-solana/jest.setup.js
@@ -1,0 +1,4 @@
+import * as jestExtended from 'jest-extended';
+
+// add all jest-extended matchers
+expect.extend(jestExtended);

--- a/packages/protocol-devtools-solana/package.json
+++ b/packages/protocol-devtools-solana/package.json
@@ -1,0 +1,85 @@
+{
+  "name": "@layerzerolabs/protocol-devtools-solana",
+  "version": "0.0.1",
+  "description": "Utilities for LayerZero Solana protocol programs",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/LayerZero-Labs/devtools.git",
+    "directory": "packages/protocol-devtools-solana"
+  },
+  "license": "MIT",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "require": "./dist/index.js",
+      "import": "./dist/index.mjs"
+    },
+    "./*": {
+      "types": "./dist/*.d.ts",
+      "require": "./dist/*.js",
+      "import": "./dist/*.mjs"
+    }
+  },
+  "main": "./dist/index.js",
+  "module": "./dist/index.mjs",
+  "types": "./dist/index.d.ts",
+  "files": [
+    "./dist/index.*"
+  ],
+  "scripts": {
+    "prebuild": "$npm_execpath tsc --noEmit",
+    "build": "$npm_execpath tsup",
+    "clean": "rm -rf dist",
+    "dev": "$npm_execpath tsup --watch",
+    "lint": "$npm_execpath eslint '**/*.{js,ts,json}'",
+    "lint:fix": "eslint --fix '**/*.{js,ts,json}'",
+    "test": "jest --ci --passWithNoTests"
+  },
+  "dependencies": {
+    "@safe-global/api-kit": "^1.3.0",
+    "@safe-global/protocol-kit": "^1.3.0",
+    "ethers": "^5.7.2",
+    "p-memoize": "~4.0.4"
+  },
+  "devDependencies": {
+    "@layerzerolabs/devtools": "~0.3.21",
+    "@layerzerolabs/devtools-solana": "~0.0.2",
+    "@layerzerolabs/io-devtools": "~0.1.11",
+    "@layerzerolabs/lz-definitions": "^2.3.25",
+    "@layerzerolabs/lz-solana-sdk-v2": "^2.3.31",
+    "@layerzerolabs/lz-v2-utilities": "^2.3.25",
+    "@layerzerolabs/protocol-devtools": "~0.3.9",
+    "@layerzerolabs/test-devtools": "~0.2.6",
+    "@layerzerolabs/test-devtools-solana": "~0.0.1",
+    "@layerzerolabs/ua-devtools": "~0.3.21",
+    "@solana/web3.js": "~1.95.0",
+    "@swc/core": "^1.4.0",
+    "@swc/jest": "^0.2.36",
+    "@types/jest": "^29.5.12",
+    "fast-check": "^3.15.1",
+    "fp-ts": "^2.16.2",
+    "jest": "^29.7.0",
+    "jest-extended": "^4.0.2",
+    "ts-node": "^10.9.2",
+    "tslib": "~2.6.2",
+    "tsup": "~8.0.1",
+    "typescript": "^5.3.3",
+    "zod": "^3.22.4"
+  },
+  "peerDependencies": {
+    "@layerzerolabs/devtools": "~0.3.20",
+    "@layerzerolabs/devtools-solana": "~0.0.2",
+    "@layerzerolabs/io-devtools": "~0.1.11",
+    "@layerzerolabs/lz-definitions": "^2.3.3",
+    "@layerzerolabs/lz-solana-sdk-v2": "^2.3.31",
+    "@layerzerolabs/lz-v2-utilities": "^2.3.3",
+    "@layerzerolabs/protocol-devtools": "^0.3.9",
+    "@layerzerolabs/ua-devtools": "^0.3.21",
+    "@solana/web3.js": "~1.95.0",
+    "fp-ts": "^2.16.2",
+    "zod": "^3.22.4"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/protocol-devtools-solana/src/endpointv2/index.ts
+++ b/packages/protocol-devtools-solana/src/endpointv2/index.ts
@@ -1,0 +1,1 @@
+export * from './sdk'

--- a/packages/protocol-devtools-solana/src/endpointv2/sdk.ts
+++ b/packages/protocol-devtools-solana/src/endpointv2/sdk.ts
@@ -1,0 +1,257 @@
+import { MessagingFee } from '@layerzerolabs/protocol-devtools'
+import type {
+    IEndpointV2,
+    IUln302,
+    SetConfigParam,
+    Uln302ExecutorConfig,
+    Uln302SetUlnConfig,
+    Uln302UlnConfig,
+} from '@layerzerolabs/protocol-devtools'
+import { formatEid, type OmniAddress, type OmniTransaction, AsyncRetriable, OmniPoint } from '@layerzerolabs/devtools'
+import type { EndpointId } from '@layerzerolabs/lz-definitions'
+import { OmniSDK } from '@layerzerolabs/devtools-solana'
+import { Timeout } from '@layerzerolabs/protocol-devtools'
+import { Uln302SetExecutorConfig } from '@layerzerolabs/protocol-devtools'
+import { Logger, printJson } from '@layerzerolabs/io-devtools'
+import { EndpointProgram } from '@layerzerolabs/lz-solana-sdk-v2'
+import { Connection, PublicKey } from '@solana/web3.js'
+
+/**
+ * EVM-specific SDK for EndpointV2 contracts
+ *
+ * @implements {IEndpointV2}
+ */
+export class EndpointV2 extends OmniSDK implements IEndpointV2 {
+    public readonly program: EndpointProgram.Endpoint
+
+    constructor(connection: Connection, point: OmniPoint, userAccount: PublicKey, logger?: Logger) {
+        super(connection, point, userAccount, logger)
+
+        this.program = new EndpointProgram.Endpoint(this.publicKey)
+    }
+
+    @AsyncRetriable()
+    async getDelegate(oapp: OmniAddress): Promise<OmniAddress | undefined> {
+        this.logger.debug(`Getting delegate for ${oapp}`)
+
+        throw new TypeError(`getDelegate() not implemented on Solana Endpoint SDK`)
+    }
+
+    async isDelegate(oapp: OmniAddress, delegate: OmniAddress): Promise<boolean> {
+        this.logger.debug(`Checking whether ${delegate} is a delegate for OApp ${oapp}`)
+
+        throw new TypeError(`isDelegate() not implemented on Solana Endpoint SDK`)
+    }
+
+    async getUln302SDK(address: OmniAddress): Promise<IUln302> {
+        this.logger.debug(`Getting Uln302 SDK for address ${address}`)
+
+        throw new TypeError(`getUln302SDK() not implemented on Solana Endpoint SDK`)
+    }
+
+    @AsyncRetriable()
+    async getDefaultReceiveLibrary(eid: EndpointId): Promise<OmniAddress | undefined> {
+        this.logger.debug(`Getting default receive library for eid ${eid} (${formatEid(eid)})`)
+
+        throw new TypeError(`getDefaultReceiveLibrary() not implemented on Solana Endpoint SDK`)
+    }
+
+    @AsyncRetriable()
+    async getSendLibrary(sender: OmniAddress, dstEid: EndpointId): Promise<OmniAddress | undefined> {
+        this.logger.debug(`Getting send library for eid ${dstEid} (${formatEid(dstEid)}) and address ${sender}`)
+
+        throw new TypeError(`getSendLibrary() not implemented on Solana Endpoint SDK`)
+    }
+
+    @AsyncRetriable()
+    async getReceiveLibrary(
+        receiver: OmniAddress,
+        srcEid: EndpointId
+    ): Promise<[address: OmniAddress | undefined, isDefault: boolean]> {
+        this.logger.debug(`Getting receive library for eid ${srcEid} (${formatEid(srcEid)}) and address ${receiver}`)
+
+        throw new TypeError(`getReceiveLibrary() not implemented on Solana Endpoint SDK`)
+    }
+
+    async setDefaultReceiveLibrary(
+        eid: EndpointId,
+        uln: OmniAddress | null | undefined,
+        gracePeriod: bigint = BigInt(0)
+    ): Promise<OmniTransaction> {
+        this.logger.debug(
+            `Setting default receive library for eid ${eid} (${formatEid(eid)}) and ULN ${uln} with grace period of ${gracePeriod}`
+        )
+
+        throw new TypeError(`setDefaultReceiveLibrary() not implemented on Solana Endpoint SDK`)
+    }
+
+    @AsyncRetriable()
+    async getDefaultSendLibrary(eid: EndpointId): Promise<OmniAddress | undefined> {
+        this.logger.debug(`Getting default send library for eid ${eid} (${formatEid(eid)})`)
+
+        throw new TypeError(`getDefaultSendLibrary() not implemented on Solana Endpoint SDK`)
+    }
+
+    @AsyncRetriable()
+    async isDefaultSendLibrary(sender: OmniAddress, dstEid: EndpointId): Promise<boolean> {
+        this.logger.debug(
+            `Checking default send library for eid ${dstEid} (${formatEid(dstEid)}) and address ${sender}`
+        )
+
+        throw new TypeError(`isDefaultSendLibrary() not implemented on Solana Endpoint SDK`)
+    }
+
+    async setDefaultSendLibrary(eid: EndpointId, uln: OmniAddress | null | undefined): Promise<OmniTransaction> {
+        this.logger.debug(`Setting default send library for eid ${eid} (${formatEid(eid)}) and ULN ${uln}`)
+
+        throw new TypeError(`setDefaultSendLibrary() not implemented on Solana Endpoint SDK`)
+    }
+
+    async setSendLibrary(
+        oapp: OmniAddress,
+        eid: EndpointId,
+        uln: OmniAddress | null | undefined
+    ): Promise<OmniTransaction> {
+        this.logger.debug(`Setting send library for eid ${eid} (${formatEid(eid)}) and OApp ${oapp} to ULN ${uln}`)
+
+        throw new TypeError(`setSendLibrary() not implemented on Solana Endpoint SDK`)
+    }
+
+    async setReceiveLibrary(
+        oapp: OmniAddress,
+        eid: EndpointId,
+        uln: OmniAddress | null | undefined,
+        gracePeriod: bigint
+    ): Promise<OmniTransaction> {
+        this.logger.debug(
+            `Setting send library for eid ${eid} (${formatEid(eid)}) and OApp ${oapp} to ULN ${uln} with a grace period of ${gracePeriod}`
+        )
+
+        throw new TypeError(`setReceiveLibrary() not implemented on Solana Endpoint SDK`)
+    }
+
+    @AsyncRetriable()
+    async getReceiveLibraryTimeout(receiver: OmniAddress, srcEid: EndpointId): Promise<Timeout> {
+        this.logger.debug(
+            `Getting receive library timeout for eid ${srcEid} (${formatEid(srcEid)}) and address ${receiver}`
+        )
+
+        throw new TypeError(`getReceiveLibraryTimeout() not implemented on Solana Endpoint SDK`)
+    }
+
+    @AsyncRetriable()
+    async getDefaultReceiveLibraryTimeout(eid: EndpointId): Promise<Timeout> {
+        this.logger.debug(`Getting default receive library timeout for eid ${eid} (${formatEid(eid)})`)
+
+        throw new TypeError(`getDefaultReceiveLibraryTimeout() not implemented on Solana Endpoint SDK`)
+    }
+
+    async setReceiveLibraryTimeout(
+        oapp: OmniAddress,
+        eid: EndpointId,
+        uln: OmniAddress | null | undefined,
+        expiry: bigint
+    ): Promise<OmniTransaction> {
+        this.logger.debug(
+            `Setting receive library timeout for eid ${eid} (${formatEid(eid)}) and OApp ${oapp} to ULN ${uln} with expiration period ${expiry}`
+        )
+
+        throw new TypeError(`setReceiveLibraryTimeout() not implemented on Solana Endpoint SDK`)
+    }
+
+    async setConfig(oapp: OmniAddress, uln: OmniAddress, setConfigParam: SetConfigParam[]): Promise<OmniTransaction> {
+        this.logger.debug(`Setting config for OApp ${oapp} to ULN ${uln} with config ${printJson(setConfigParam)}`)
+
+        throw new TypeError(`setConfig() not implemented on Solana Endpoint SDK`)
+    }
+
+    async setUlnConfig(
+        oapp: OmniAddress,
+        uln: OmniAddress,
+        setUlnConfig: Uln302SetUlnConfig[]
+    ): Promise<OmniTransaction> {
+        this.logger.debug(`Setting ULN config for OApp ${oapp} to ULN ${uln} with config ${printJson(setUlnConfig)}`)
+
+        throw new TypeError(`setConfig() not implemented on Solana Endpoint SDK`)
+    }
+
+    async setExecutorConfig(
+        oapp: OmniAddress,
+        uln: OmniAddress,
+        setExecutorConfig: Uln302SetExecutorConfig[]
+    ): Promise<OmniTransaction> {
+        this.logger.debug(
+            `Setting executor config for OApp ${oapp} to ULN ${uln} with config ${printJson(setExecutorConfig)}`
+        )
+
+        throw new TypeError(`setExecutorConfig() not implemented on Solana Endpoint SDK`)
+    }
+
+    async getExecutorConfig(oapp: OmniAddress, uln: OmniAddress, eid: EndpointId): Promise<Uln302ExecutorConfig> {
+        this.logger.debug(`Getting executor config for eid ${eid} (${formatEid(eid)}) and OApp ${oapp} and ULN ${uln}`)
+
+        throw new TypeError(`getExecutorConfig() not implemented on Solana Endpoint SDK`)
+    }
+
+    async getAppExecutorConfig(oapp: OmniAddress, uln: OmniAddress, eid: EndpointId): Promise<Uln302ExecutorConfig> {
+        this.logger.debug(
+            `Getting executor app config for eid ${eid} (${formatEid(eid)}) and OApp ${oapp} and ULN ${uln}`
+        )
+
+        throw new TypeError(`getAppExecutorConfig() not implemented on Solana Endpoint SDK`)
+    }
+
+    /**
+     * @see {@link IEndpointV2.hasAppExecutorConfig}
+     */
+    async hasAppExecutorConfig(): Promise<boolean> {
+        throw new TypeError(`hasAppExecutorConfig() not implemented on Solana Endpoint SDK`)
+    }
+
+    /**
+     * @see {@link IUln302.getUlnConfig}
+     */
+    async getUlnConfig(oapp: OmniAddress, uln: OmniAddress, eid: EndpointId): Promise<Uln302UlnConfig> {
+        this.logger.debug(`Getting ULN config for eid ${eid} (${formatEid(eid)}) and OApp ${oapp} and ULN ${uln}`)
+
+        throw new TypeError(`getUlnConfig() not implemented on Solana Endpoint SDK`)
+    }
+
+    /**
+     * @see {@link IUln302.getAppUlnConfig}
+     */
+    async getAppUlnConfig(oapp: OmniAddress, uln: OmniAddress, eid: EndpointId): Promise<Uln302UlnConfig> {
+        this.logger.debug(`Getting App ULN config for eid ${eid} (${formatEid(eid)}) and OApp ${oapp} and ULN ${uln}`)
+
+        throw new TypeError(`getAppUlnConfig() not implemented on Solana Endpoint SDK`)
+    }
+
+    /**
+     * @see {@link IEndpointV2.hasAppUlnConfig}
+     */
+    async hasAppUlnConfig(): Promise<boolean> {
+        throw new TypeError(`hasAppUlnConfig() not implemented on Solana Endpoint SDK`)
+    }
+
+    @AsyncRetriable()
+    isRegisteredLibrary(): Promise<boolean> {
+        throw new TypeError(`isRegisteredLibrary() not implemented on Solana Endpoint SDK`)
+    }
+
+    async registerLibrary(): Promise<OmniTransaction> {
+        throw new TypeError(`registerLibrary() not implemented on Solana Endpoint SDK`)
+    }
+
+    @AsyncRetriable()
+    public async quote(): Promise<MessagingFee> {
+        throw new TypeError(`quote() not implemented on Solana Endpoint SDK`)
+    }
+
+    async getUlnConfigParams(): Promise<SetConfigParam[]> {
+        throw new TypeError(`getUlnConfigParams() not implemented on Solana Endpoint SDK`)
+    }
+
+    async getExecutorConfigParams(): Promise<SetConfigParam[]> {
+        throw new TypeError(`getExecutorConfigParams() not implemented on Solana Endpoint SDK`)
+    }
+}

--- a/packages/protocol-devtools-solana/src/endpointv2/sdk.ts
+++ b/packages/protocol-devtools-solana/src/endpointv2/sdk.ts
@@ -26,7 +26,7 @@ import { EndpointProgram } from '@layerzerolabs/lz-solana-sdk-v2'
 import { Connection, PublicKey } from '@solana/web3.js'
 
 /**
- * EVM-specific SDK for EndpointV2 contracts
+ * Solana-specific SDK for EndpointV2 contracts
  *
  * @implements {IEndpointV2}
  */

--- a/packages/protocol-devtools-solana/src/endpointv2/sdk.ts
+++ b/packages/protocol-devtools-solana/src/endpointv2/sdk.ts
@@ -62,7 +62,13 @@ export class EndpointV2 extends OmniSDK implements IEndpointV2 {
     async getDefaultReceiveLibrary(eid: EndpointId): Promise<OmniAddress | undefined> {
         this.logger.debug(`Getting default receive library for eid ${eid} (${formatEid(eid)})`)
 
-        throw new TypeError(`getDefaultReceiveLibrary() not implemented on Solana Endpoint SDK`)
+        const config = await mapError(
+            () => this.program.getDefaultReceiveLibrary(this.connection, eid),
+            (error) =>
+                new Error(`Failed to get the default receive library for ${this.label} for ${formatEid(eid)}: ${error}`)
+        )
+
+        return config?.msgLib.toBase58() ?? undefined
     }
 
     @AsyncRetriable()

--- a/packages/protocol-devtools-solana/src/index.ts
+++ b/packages/protocol-devtools-solana/src/index.ts
@@ -1,0 +1,1 @@
+export * from './endpointv2'

--- a/packages/protocol-devtools-solana/test/endpointv2/sdk.test.ts
+++ b/packages/protocol-devtools-solana/test/endpointv2/sdk.test.ts
@@ -1,0 +1,65 @@
+import { PublicKey } from '@solana/web3.js'
+import { ConnectionFactory, createConnectionFactory, defaultRpcUrlFactory } from '@layerzerolabs/devtools-solana'
+import { EndpointId } from '@layerzerolabs/lz-definitions'
+import { EndpointV2 } from '@/endpointv2'
+import { normalizePeer } from '@layerzerolabs/devtools'
+import { EndpointProgram } from '@layerzerolabs/lz-solana-sdk-v2'
+
+describe('endpointv2/sdk', () => {
+    // FIXME These tests are using a mainnet OFT deployment and are potentially very fragile
+    //
+    // We need to run our own Solana node with the OFT account cloned
+    // so that we can isolate these tests
+    const point = { eid: EndpointId.SOLANA_V2_MAINNET, address: EndpointProgram.PROGRAM_ID.toBase58() }
+    const account = new PublicKey('6tzUZqC33igPgP7YyDnUxQg6eupMmZGRGKdVAksgRzvk')
+
+    let connectionFactory: ConnectionFactory
+
+    beforeAll(() => {
+        connectionFactory = createConnectionFactory(defaultRpcUrlFactory)
+    })
+
+    describe('getDefaultReceiveLibrary', () => {
+        it('should return undefined if we are asking for a default library that has not been set', async () => {
+            const connection = await connectionFactory(EndpointId.SOLANA_V2_MAINNET)
+            const sdk = new EndpointV2(connection, point, account)
+
+            expect(await sdk.getDefaultReceiveLibrary(EndpointId.ETHEREUM_V2_TESTNET)).toBeUndefined()
+        })
+
+        it('should return a Solana address if we are asking for a peer that has been set', async () => {
+            const connectionFactory = createConnectionFactory(defaultRpcUrlFactory)
+
+            const connection = await connectionFactory(EndpointId.SOLANA_V2_MAINNET)
+            const sdk = new EndpointV2(connection, point, account)
+
+            const lib = await sdk.getDefaultReceiveLibrary(EndpointId.ETHEREUM_V2_MAINNET)
+            expect(lib).toEqual(expect.any(String))
+            expect(normalizePeer(lib, EndpointId.ETHEREUM_V2_MAINNET)).toEqual(expect.any(Uint8Array))
+        })
+    })
+
+    describe('getDefaultSendLibrary', () => {
+        it('should return undefined if we are asking for a default library that has not been set', async () => {
+            const connection = await connectionFactory(EndpointId.SOLANA_V2_MAINNET)
+            const sdk = new EndpointV2(connection, point, account)
+
+            expect(await sdk.getDefaultSendLibrary(EndpointId.ETHEREUM_V2_TESTNET)).toBeUndefined()
+        })
+
+        it('should return a Solana address if we are asking for a peer that has been set', async () => {
+            const connectionFactory = createConnectionFactory(defaultRpcUrlFactory)
+
+            const connection = await connectionFactory(EndpointId.SOLANA_V2_MAINNET)
+            const sdk = new EndpointV2(connection, point, account)
+
+            const eid = EndpointId.ETHEREUM_V2_MAINNET
+            const lib = await sdk.getDefaultSendLibrary(eid)
+            expect(lib).toEqual<string>(expect.any(String))
+            expect(normalizePeer(lib, eid)).toEqual(expect.any(Uint8Array))
+
+            expect(await sdk.isDefaultSendLibrary(lib!, eid)).toBeTruthy()
+            expect(await sdk.isDefaultSendLibrary(EndpointProgram.PROGRAM_ID.toBase58(), eid)).toBeFalsy()
+        })
+    })
+})

--- a/packages/protocol-devtools-solana/tsconfig.json
+++ b/packages/protocol-devtools-solana/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.json",
+  "exclude": ["dist", "node_modules"],
+  "include": ["src", "test", "*.config.ts"],
+  "compilerOptions": {
+    "experimentalDecorators": true,
+    "types": ["node", "jest"],
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  }
+}

--- a/packages/protocol-devtools-solana/tsup.config.ts
+++ b/packages/protocol-devtools-solana/tsup.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from 'tsup'
+
+export default defineConfig([
+    {
+        entry: ['src/index.ts'],
+        outDir: './dist',
+        clean: true,
+        dts: true,
+        sourcemap: true,
+        splitting: false,
+        treeshake: true,
+        format: ['esm', 'cjs'],
+    },
+])

--- a/packages/ua-devtools-solana/jest.config.js
+++ b/packages/ua-devtools-solana/jest.config.js
@@ -3,6 +3,7 @@ module.exports = {
     cache: false,
     reporters: [['github-actions', { silent: false }], 'default'],
     testEnvironment: 'node',
+    testTimeout: 15_000,
     setupFilesAfterEnv: ['<rootDir>/jest.setup.js'],
     moduleNameMapper: {
         '^@/(.*)$': '<rootDir>/src/$1',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1503,6 +1503,91 @@ importers:
         specifier: ^3.22.4
         version: 3.22.4
 
+  packages/protocol-devtools-solana:
+    dependencies:
+      '@safe-global/api-kit':
+        specifier: ^1.3.0
+        version: 1.3.1
+      '@safe-global/protocol-kit':
+        specifier: ^1.3.0
+        version: 1.3.0(ethers@5.7.2)
+      ethers:
+        specifier: ^5.7.2
+        version: 5.7.2
+      p-memoize:
+        specifier: ~4.0.4
+        version: 4.0.4
+    devDependencies:
+      '@layerzerolabs/devtools':
+        specifier: ~0.3.21
+        version: link:../devtools
+      '@layerzerolabs/devtools-solana':
+        specifier: ~0.0.2
+        version: link:../devtools-solana
+      '@layerzerolabs/io-devtools':
+        specifier: ~0.1.11
+        version: link:../io-devtools
+      '@layerzerolabs/lz-definitions':
+        specifier: ^2.3.25
+        version: 2.3.25
+      '@layerzerolabs/lz-solana-sdk-v2':
+        specifier: ^2.3.31
+        version: 2.3.31(fastestsmallesttextencoderdecoder@1.0.22)
+      '@layerzerolabs/lz-v2-utilities':
+        specifier: ^2.3.25
+        version: 2.3.25
+      '@layerzerolabs/protocol-devtools':
+        specifier: ~0.3.9
+        version: link:../protocol-devtools
+      '@layerzerolabs/test-devtools':
+        specifier: ~0.2.6
+        version: link:../test-devtools
+      '@layerzerolabs/test-devtools-solana':
+        specifier: ~0.0.1
+        version: link:../test-devtools-solana
+      '@layerzerolabs/ua-devtools':
+        specifier: ~0.3.21
+        version: link:../ua-devtools
+      '@solana/web3.js':
+        specifier: ~1.95.0
+        version: 1.95.0
+      '@swc/core':
+        specifier: ^1.4.0
+        version: 1.4.0
+      '@swc/jest':
+        specifier: ^0.2.36
+        version: 0.2.36(@swc/core@1.4.0)
+      '@types/jest':
+        specifier: ^29.5.12
+        version: 29.5.12
+      fast-check:
+        specifier: ^3.15.1
+        version: 3.15.1
+      fp-ts:
+        specifier: ^2.16.2
+        version: 2.16.2
+      jest:
+        specifier: ^29.7.0
+        version: 29.7.0(@types/node@18.18.14)(ts-node@10.9.2)
+      jest-extended:
+        specifier: ^4.0.2
+        version: 4.0.2(jest@29.7.0)
+      ts-node:
+        specifier: ^10.9.2
+        version: 10.9.2(@swc/core@1.4.0)(@types/node@18.18.14)(typescript@5.5.3)
+      tslib:
+        specifier: ~2.6.2
+        version: 2.6.3
+      tsup:
+        specifier: ~8.0.1
+        version: 8.0.1(@swc/core@1.4.0)(ts-node@10.9.2)(typescript@5.5.3)
+      typescript:
+        specifier: ^5.3.3
+        version: 5.5.3
+      zod:
+        specifier: ^3.22.4
+        version: 3.22.4
+
   packages/test-devtools:
     dependencies:
       '@scure/bip39':


### PR DESCRIPTION
### In this PR

- Add `protocol-devtools-solana` package with only a stub of `EndpointV2` SDK
- The only implemented getters are `getDefaultReceiveLibrary`, `getDefaultSendLibrary` and `isDefaultSendLibrary`
- The SDK is not yet connected to the OFT SDK