### PR TITLE
🗞️ Solana: Send & Receive library getters [11/N]

### DIFF
--- a/.changeset/lucky-mice-design.md
+++ b/.changeset/lucky-mice-design.md
@@ -1,0 +1,5 @@
+---
+"@layerzerolabs/protocol-devtools-solana": patch
+---
+
+Add send/receive library getters

--- a/packages/protocol-devtools-solana/jest.config.js
+++ b/packages/protocol-devtools-solana/jest.config.js
@@ -3,7 +3,7 @@ module.exports = {
     cache: false,
     reporters: [['github-actions', { silent: false }], 'default'],
     testEnvironment: 'node',
-    testTimeout: 15_000,
+    testTimeout: 60_000,
     setupFilesAfterEnv: ['<rootDir>/jest.setup.js'],
     moduleNameMapper: {
         '^@/(.*)$': '<rootDir>/src/$1',

--- a/packages/protocol-devtools-solana/src/endpointv2/sdk.ts
+++ b/packages/protocol-devtools-solana/src/endpointv2/sdk.ts
@@ -73,9 +73,19 @@ export class EndpointV2 extends OmniSDK implements IEndpointV2 {
 
     @AsyncRetriable()
     async getSendLibrary(sender: OmniAddress, dstEid: EndpointId): Promise<OmniAddress | undefined> {
-        this.logger.debug(`Getting send library for eid ${dstEid} (${formatEid(dstEid)}) and address ${sender}`)
+        const eidLabel = formatEid(dstEid)
 
-        throw new TypeError(`getSendLibrary() not implemented on Solana Endpoint SDK`)
+        this.logger.debug(`Getting send library for eid ${dstEid} (${eidLabel}) and address ${sender}`)
+
+        const config = await mapError(
+            () => this.program.getSendLibrary(this.connection, new PublicKey(sender), dstEid),
+            (error) =>
+                new Error(
+                    `Failed to get the send library for ${this.label} for OApp ${sender} for ${eidLabel}: ${error}`
+                )
+        )
+
+        return config?.msgLib.toBase58() ?? undefined
     }
 
     @AsyncRetriable()
@@ -83,9 +93,19 @@ export class EndpointV2 extends OmniSDK implements IEndpointV2 {
         receiver: OmniAddress,
         srcEid: EndpointId
     ): Promise<[address: OmniAddress | undefined, isDefault: boolean]> {
+        const eidLabel = formatEid(srcEid)
+
         this.logger.debug(`Getting receive library for eid ${srcEid} (${formatEid(srcEid)}) and address ${receiver}`)
 
-        throw new TypeError(`getReceiveLibrary() not implemented on Solana Endpoint SDK`)
+        const config = await mapError(
+            () => this.program.getReceiveLibrary(this.connection, new PublicKey(receiver), srcEid),
+            (error) =>
+                new Error(
+                    `Failed to get the receive library for ${this.label} for OApp ${receiver} for ${eidLabel}: ${error}`
+                )
+        )
+
+        return [config?.msgLib.toBase58() ?? undefined, config?.isDefault ?? true]
     }
 
     async setDefaultReceiveLibrary(

--- a/packages/protocol-devtools-solana/test/endpointv2/sdk.test.ts
+++ b/packages/protocol-devtools-solana/test/endpointv2/sdk.test.ts
@@ -12,6 +12,7 @@ describe('endpointv2/sdk', () => {
     // so that we can isolate these tests
     const point = { eid: EndpointId.SOLANA_V2_MAINNET, address: EndpointProgram.PROGRAM_ID.toBase58() }
     const account = new PublicKey('6tzUZqC33igPgP7YyDnUxQg6eupMmZGRGKdVAksgRzvk')
+    const oftConfig = new PublicKey('8aFeCEhGLwbWHWiiezLAKanfD5Cn3BW3nP6PZ54K9LYC')
 
     let connectionFactory: ConnectionFactory
 
@@ -27,7 +28,7 @@ describe('endpointv2/sdk', () => {
             expect(await sdk.getDefaultReceiveLibrary(EndpointId.ETHEREUM_V2_TESTNET)).toBeUndefined()
         })
 
-        it('should return a Solana address if we are asking for a peer that has been set', async () => {
+        it('should return a Solana address if we are asking for a library that has been set', async () => {
             const connectionFactory = createConnectionFactory(defaultRpcUrlFactory)
 
             const connection = await connectionFactory(EndpointId.SOLANA_V2_MAINNET)
@@ -47,7 +48,7 @@ describe('endpointv2/sdk', () => {
             expect(await sdk.getDefaultSendLibrary(EndpointId.ETHEREUM_V2_TESTNET)).toBeUndefined()
         })
 
-        it('should return a Solana address if we are asking for a peer that has been set', async () => {
+        it('should return a Solana address if we are asking for a library that has been set', async () => {
             const connectionFactory = createConnectionFactory(defaultRpcUrlFactory)
 
             const connection = await connectionFactory(EndpointId.SOLANA_V2_MAINNET)
@@ -60,6 +61,51 @@ describe('endpointv2/sdk', () => {
 
             expect(await sdk.isDefaultSendLibrary(lib!, eid)).toBeTruthy()
             expect(await sdk.isDefaultSendLibrary(EndpointProgram.PROGRAM_ID.toBase58(), eid)).toBeFalsy()
+        })
+    })
+
+    describe('getReceiveLibrary', () => {
+        it('should return undefined if we are asking for a default library that has not been set', async () => {
+            const connection = await connectionFactory(EndpointId.SOLANA_V2_MAINNET)
+            const sdk = new EndpointV2(connection, point, account)
+
+            expect(await sdk.getReceiveLibrary(account.toBase58(), EndpointId.ETHEREUM_V2_TESTNET)).toEqual([
+                undefined,
+                true,
+            ])
+        })
+
+        it('should return a Solana address if we are asking for a library that has been set', async () => {
+            const connectionFactory = createConnectionFactory(defaultRpcUrlFactory)
+
+            const connection = await connectionFactory(EndpointId.SOLANA_V2_MAINNET)
+            const sdk = new EndpointV2(connection, point, account)
+
+            const eid = EndpointId.ETHEREUM_V2_MAINNET
+            const [lib] = await sdk.getReceiveLibrary(oftConfig.toBase58(), eid)
+            expect(lib).toEqual<string>(expect.any(String))
+            expect(normalizePeer(lib, eid)).toEqual(expect.any(Uint8Array))
+        })
+    })
+
+    describe('getSendLibrary', () => {
+        it('should return undefined if we are asking for a default library that has not been set', async () => {
+            const connection = await connectionFactory(EndpointId.SOLANA_V2_MAINNET)
+            const sdk = new EndpointV2(connection, point, account)
+
+            expect(await sdk.getSendLibrary(account.toBase58(), EndpointId.ETHEREUM_V2_TESTNET)).toBeUndefined()
+        })
+
+        it('should return a Solana address if we are asking for a library that has been set', async () => {
+            const connectionFactory = createConnectionFactory(defaultRpcUrlFactory)
+
+            const connection = await connectionFactory(EndpointId.SOLANA_V2_MAINNET)
+            const sdk = new EndpointV2(connection, point, account)
+
+            const eid = EndpointId.ETHEREUM_V2_MAINNET
+            const lib = await sdk.getSendLibrary(oftConfig.toBase58(), eid)
+            expect(lib).toEqual<string>(expect.any(String))
+            expect(normalizePeer(lib, eid)).toEqual(expect.any(Uint8Array))
         })
     })
 })

--- a/packages/ua-devtools-solana/jest.config.js
+++ b/packages/ua-devtools-solana/jest.config.js
@@ -3,7 +3,7 @@ module.exports = {
     cache: false,
     reporters: [['github-actions', { silent: false }], 'default'],
     testEnvironment: 'node',
-    testTimeout: 15_000,
+    testTimeout: 60_000,
     setupFilesAfterEnv: ['<rootDir>/jest.setup.js'],
     moduleNameMapper: {
         '^@/(.*)$': '<rootDir>/src/$1',


### PR DESCRIPTION
### In this PR

- Add getters for send & receive library on the endpoint SDK for Solana. There is a slight catch here - if we're asking for a send/receive library for a particular OFT, we need to use the OFT config account address, not the OFT address. I am currently thinking about the prettiest way to encapsulate this into the SDK:
  - Subclass the `EndpointV2` SDK if we're getting it through the OFT SDK. The subclass will replace the address of the OFT with its config account address
  - Add a function to the `OApp` interface that returns an address that should be used for these calls. For EVM it will return the contract address itself whereas for Solana it will return the config account