### PR TITLE
🧹 Solana: Abstract config account [13/N]

### DIFF
--- a/.changeset/giant-toys-compare.md
+++ b/.changeset/giant-toys-compare.md
@@ -1,0 +1,7 @@
+---
+"@layerzerolabs/ua-devtools-solana": patch
+"@layerzerolabs/ua-devtools-evm": patch
+"@layerzerolabs/ua-devtools": patch
+---
+
+Add getEndpointConfigAddress to IOApp interface

--- a/packages/ua-devtools-evm/src/oapp/sdk.ts
+++ b/packages/ua-devtools-evm/src/oapp/sdk.ts
@@ -25,6 +25,15 @@ export class OApp extends Ownable implements IOApp {
         super(contract)
     }
 
+    /**
+     * For EVM OApps, the config is stored under the OApp's address
+     *
+     * @returns {OmniAddress}
+     */
+    getEndpointConfigAddress(): OmniAddress {
+        return this.contract.contract.address
+    }
+
     @AsyncRetriable()
     async getEndpointSDK(): Promise<IEndpointV2> {
         this.logger.debug(`Getting EndpointV2 SDK`)

--- a/packages/ua-devtools-solana/src/oft/sdk.ts
+++ b/packages/ua-devtools-solana/src/oft/sdk.ts
@@ -33,6 +33,15 @@ export class OFT extends OmniSDK implements IOApp {
         super(connection, point, userAccount, logger)
     }
 
+    /**
+     * For Solana OFTs, the endpoint config is stored under the config account
+     *
+     * @returns {OmniAddress}
+     */
+    getEndpointConfigAddress(): OmniAddress {
+        return this.configAccount.toBase58()
+    }
+
     getOwner(): Promise<OmniAddress | undefined> {
         throw new Error('Method not implemented.')
     }

--- a/packages/ua-devtools/src/oapp/types.ts
+++ b/packages/ua-devtools/src/oapp/types.ts
@@ -16,6 +16,14 @@ import { ExecutorOptionType } from '@layerzerolabs/lz-v2-utilities'
 import type { IOwnable, OwnableNodeConfig } from '@/ownable/types'
 
 export interface IOApp extends IOmniSDK, IOwnable {
+    /**
+     * For non-EVM networks the address of the contract might not correspond to the address
+     * under which the config is stored on the Endpoint
+     *
+     * An example of this is Solana for which the config is stored under a different account
+     * derviced from the program ID and the mint account
+     */
+    getEndpointConfigAddress(): OmniAddress | Promise<OmniAddress>
     getEndpointSDK(): Promise<IEndpointV2>
     getPeer(eid: EndpointId): Promise<OmniAddress | undefined>
     hasPeer(eid: EndpointId, address: OmniAddress | null | undefined): Promise<boolean>


### PR DESCRIPTION
### In this PR

- For non-EVM networks (as proven by Solana), the account that holds the OApp config can differ from the OApp itself. To account for this, `getEndpointConfigAddress` method has been added to the `IOApp` interface
- To avoid issues with mismatching dependencies, this method is used with caution in the `OApp` configurator - if it does not exist, it is substituted with the OApp address (the legacy code)