### PR TITLE
🧹 Solana: Implement getEndpointSDK for OFT SDK [14/N]

### DIFF
--- a/.changeset/polite-eyes-wash.md
+++ b/.changeset/polite-eyes-wash.md
@@ -1,0 +1,5 @@
+---
+"@layerzerolabs/ua-devtools-solana": patch
+---
+
+Return EndpointV2 from OFT SDK for Solana

--- a/packages/ua-devtools-solana/package.json
+++ b/packages/ua-devtools-solana/package.json
@@ -49,6 +49,7 @@
     "@layerzerolabs/lz-solana-sdk-v2": "^2.3.31",
     "@layerzerolabs/lz-v2-utilities": "^2.3.25",
     "@layerzerolabs/protocol-devtools": "~0.3.9",
+    "@layerzerolabs/protocol-devtools-solana": "~0.0.1",
     "@layerzerolabs/test-devtools": "~0.2.6",
     "@layerzerolabs/test-devtools-solana": "~0.0.1",
     "@layerzerolabs/ua-devtools": "~0.3.21",

--- a/packages/ua-devtools-solana/src/oft/sdk.ts
+++ b/packages/ua-devtools-solana/src/oft/sdk.ts
@@ -1,5 +1,5 @@
 import type { IOApp, OAppEnforcedOptionParam } from '@layerzerolabs/ua-devtools'
-import { OftTools, OFT_SEED } from '@layerzerolabs/lz-solana-sdk-v2'
+import { OftTools, OFT_SEED, EndpointProgram } from '@layerzerolabs/lz-solana-sdk-v2'
 import {
     type OmniAddress,
     type OmniTransaction,
@@ -15,6 +15,7 @@ import {
 } from '@layerzerolabs/devtools'
 import type { EndpointId } from '@layerzerolabs/lz-definitions'
 import type { IEndpointV2 } from '@layerzerolabs/protocol-devtools'
+import { EndpointV2 } from '@layerzerolabs/protocol-devtools-solana'
 import { Logger, printJson } from '@layerzerolabs/io-devtools'
 import { mapError, AsyncRetriable } from '@layerzerolabs/devtools'
 import { OmniSDK } from '@layerzerolabs/devtools-solana'
@@ -62,7 +63,11 @@ export class OFT extends OmniSDK implements IOApp {
     async getEndpointSDK(): Promise<IEndpointV2> {
         this.logger.debug(`Getting EndpointV2 SDK`)
 
-        throw new TypeError(`getEndpointSDK() not implemented on Solana OFT SDK`)
+        return new EndpointV2(
+            this.connection,
+            { eid: this.point.eid, address: EndpointProgram.PROGRAM_ID.toBase58() },
+            this.userAccount
+        )
     }
 
     @AsyncRetriable()

--- a/packages/ua-devtools-solana/test/oft/sdk.test.ts
+++ b/packages/ua-devtools-solana/test/oft/sdk.test.ts
@@ -5,7 +5,7 @@ import { OFT } from '@/oft'
 import { makeBytes32, normalizePeer } from '@layerzerolabs/devtools'
 import { Options } from '@layerzerolabs/lz-v2-utilities'
 import { printJson } from '@layerzerolabs/io-devtools'
-import { OftTools } from '@layerzerolabs/lz-solana-sdk-v2'
+import { EndpointProgram, OftTools } from '@layerzerolabs/lz-solana-sdk-v2'
 
 const createSetEnforcedOptionsIxMock = OftTools.createSetEnforcedOptionsIx as jest.Mock
 
@@ -255,6 +255,22 @@ describe('oft/sdk', () => {
                 Options.newOptions().addExecutorLzReceiveOption(3, 1).toBytes(),
                 sdk.publicKey
             )
+        })
+    })
+
+    describe('getEndpointSDK', () => {
+        it('should return an SDK with the correct eid and address', async () => {
+            const connectionFactory = createConnectionFactory(defaultRpcUrlFactory)
+            const connection = await connectionFactory(EndpointId.SOLANA_V2_MAINNET)
+            const sdk = new OFT(connection, point, account, mintAccount)
+            const endpointSdk = await sdk.getEndpointSDK()
+
+            expect(endpointSdk.point).toEqual({ eid: sdk.point.eid, address: EndpointProgram.PROGRAM_ID.toBase58() })
+
+            // Run a random function on the SDK to check whether it works
+            expect(
+                await endpointSdk.isDefaultSendLibrary(sdk.configAccount.toBase58(), EndpointId.ETHEREUM_V2_MAINNET)
+            ).toBeFalsy()
         })
     })
 })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2111,6 +2111,9 @@ importers:
       '@layerzerolabs/protocol-devtools':
         specifier: ~0.3.9
         version: link:../protocol-devtools
+      '@layerzerolabs/protocol-devtools-solana':
+        specifier: ~0.0.1
+        version: link:../protocol-devtools-solana
       '@layerzerolabs/test-devtools':
         specifier: ~0.2.6
         version: link:../test-devtools


### PR DESCRIPTION
### In this PR

- Return the `EndpointV2` SDK from `OFT` SDK for Solana