### PR TITLE
🗞️ Solana: Add Uln302 SDK [16/N]

### DIFF
--- a/.changeset/polite-panthers-guess.md
+++ b/.changeset/polite-panthers-guess.md
@@ -1,0 +1,5 @@
+---
+"@layerzerolabs/protocol-devtools-solana": patch
+---
+
+Add Uln302 SDK

--- a/packages/protocol-devtools-solana/src/endpointv2/sdk.ts
+++ b/packages/protocol-devtools-solana/src/endpointv2/sdk.ts
@@ -6,6 +6,7 @@ import type {
     Uln302ExecutorConfig,
     Uln302SetUlnConfig,
     Uln302UlnConfig,
+    Uln302UlnUserConfig,
 } from '@layerzerolabs/protocol-devtools'
 import {
     formatEid,
@@ -23,6 +24,7 @@ import { Logger, printJson } from '@layerzerolabs/io-devtools'
 import { EndpointProgram } from '@layerzerolabs/lz-solana-sdk-v2'
 import { Connection, PublicKey, Transaction } from '@solana/web3.js'
 import assert from 'assert'
+import { Uln302 } from '@/uln302'
 
 /**
  * Solana-specific SDK for EndpointV2 contracts
@@ -54,7 +56,7 @@ export class EndpointV2 extends OmniSDK implements IEndpointV2 {
     async getUln302SDK(address: OmniAddress): Promise<IUln302> {
         this.logger.debug(`Getting Uln302 SDK for address ${address}`)
 
-        throw new TypeError(`getUln302SDK() not implemented on Solana Endpoint SDK`)
+        return new Uln302(this.connection, { eid: this.point.eid, address }, this.userAccount)
     }
 
     @AsyncRetriable()
@@ -317,14 +319,22 @@ export class EndpointV2 extends OmniSDK implements IEndpointV2 {
     async getAppUlnConfig(oapp: OmniAddress, uln: OmniAddress, eid: EndpointId): Promise<Uln302UlnConfig> {
         this.logger.debug(`Getting App ULN config for eid ${eid} (${formatEid(eid)}) and OApp ${oapp} and ULN ${uln}`)
 
-        throw new TypeError(`getAppUlnConfig() not implemented on Solana Endpoint SDK`)
+        const ulnSdk = await this.getUln302SDK(uln)
+        return await ulnSdk.getAppUlnConfig(eid, oapp)
     }
 
     /**
      * @see {@link IEndpointV2.hasAppUlnConfig}
      */
-    async hasAppUlnConfig(): Promise<boolean> {
-        throw new TypeError(`hasAppUlnConfig() not implemented on Solana Endpoint SDK`)
+    async hasAppUlnConfig(
+        oapp: OmniAddress,
+        uln: OmniAddress,
+        eid: EndpointId,
+        config: Uln302UlnUserConfig
+    ): Promise<boolean> {
+        const ulnSdk = await this.getUln302SDK(uln)
+
+        return ulnSdk.hasAppUlnConfig(eid, oapp, config)
     }
 
     @AsyncRetriable()

--- a/packages/protocol-devtools-solana/src/index.ts
+++ b/packages/protocol-devtools-solana/src/index.ts
@@ -1,1 +1,2 @@
 export * from './endpointv2'
+export * from './uln302'

--- a/packages/protocol-devtools-solana/src/uln302/index.ts
+++ b/packages/protocol-devtools-solana/src/uln302/index.ts
@@ -1,0 +1,1 @@
+export * from './sdk'

--- a/packages/protocol-devtools-solana/src/uln302/sdk.ts
+++ b/packages/protocol-devtools-solana/src/uln302/sdk.ts
@@ -1,0 +1,252 @@
+import type { EndpointId } from '@layerzerolabs/lz-definitions'
+import type {
+    IUln302,
+    Uln302ExecutorConfig,
+    Uln302UlnConfig,
+    Uln302UlnUserConfig,
+} from '@layerzerolabs/protocol-devtools'
+import {
+    OmniAddress,
+    formatEid,
+    type OmniTransaction,
+    compareBytes32Ascending,
+    isDeepEqual,
+    OmniPoint,
+    mapError,
+} from '@layerzerolabs/devtools'
+import { Logger, printJson } from '@layerzerolabs/io-devtools'
+import { AsyncRetriable } from '@layerzerolabs/devtools'
+import { OmniSDK } from '@layerzerolabs/devtools-solana'
+import { UlnProgram } from '@layerzerolabs/lz-solana-sdk-v2'
+import { Connection, PublicKey } from '@solana/web3.js'
+import assert from 'assert'
+
+export class Uln302 extends OmniSDK implements IUln302 {
+    public readonly program: UlnProgram.Uln
+
+    constructor(connection: Connection, point: OmniPoint, userAccount: PublicKey, logger?: Logger) {
+        super(connection, point, userAccount, logger)
+
+        this.program = new UlnProgram.Uln(UlnProgram.PROGRAM_ID)
+    }
+
+    /**
+     * @see {@link IUln302.getUlnConfig}
+     */
+    @AsyncRetriable()
+    async getUlnConfig(eid: EndpointId, address?: OmniAddress | null | undefined): Promise<Uln302UlnConfig> {
+        this.logger.debug(`Getting ULN config for eid ${eid} (${formatEid(eid)}) and address ${address}`)
+
+        throw new TypeError(`getUlnConfig() not implemented on Solana Endpoint SDK`)
+    }
+
+    /**
+     * @see {@link IUln302.getAppUlnConfig}
+     */
+    @AsyncRetriable()
+    async getAppUlnConfig(eid: EndpointId, address: OmniAddress): Promise<Uln302UlnConfig> {
+        const eidLabel = formatEid(eid)
+
+        this.logger.debug(`Getting ULN config for eid ${eid} (${eidLabel}) and address ${address}`)
+
+        const config = await mapError(
+            async () => {
+                const publicKey = new PublicKey(address)
+
+                return (
+                    (await this.program.getReceiveConfigState(this.connection, publicKey, eid)) ??
+                    (this.logger.warn(
+                        `Got an empty ULN config for OApp ${address} and ${eidLabel}, getting the default one`
+                    ),
+                    await this.program.getDefaultReceiveConfigState(this.connection, eid))
+                )
+            },
+            (error) =>
+                new Error(`Failed to get ULN config for ${this.label} for OApp ${address} and ${eidLabel}: ${error}`)
+        )
+
+        assert(
+            config != null,
+            `Could not get OApp ULN config for ${this.label} and OApp ${address} and ${eidLabel}: Neither app nor default configs have been specified`
+        )
+
+        return {
+            confirmations: BigInt(
+                typeof config.uln.confirmations === 'number'
+                    ? config.uln.confirmations
+                    : config.uln.confirmations.toString(10)
+            ),
+            optionalDVNThreshold: config.uln.optionalDvnThreshold,
+            requiredDVNs: config.uln.requiredDvns.map((key) => key.toBase58()),
+            optionalDVNs: config.uln.optionalDvns.map((key) => key.toBase58()),
+        }
+    }
+
+    /**
+     * @see {@link IUln302.hasAppUlnConfig}
+     */
+    async hasAppUlnConfig(eid: EndpointId, oapp: string, config: Uln302UlnUserConfig): Promise<boolean> {
+        const currentConfig = await this.getAppUlnConfig(eid, oapp)
+        const currentSerializedConfig = this.serializeUlnConfig(currentConfig)
+        const serializedConfig = this.serializeUlnConfig(config)
+
+        this.logger.debug(`Checking whether ULN configs for eid ${eid} (${formatEid(eid)}) and OApp ${oapp} match`)
+        this.logger.debug(`Current config: ${printJson(currentSerializedConfig)}`)
+        this.logger.debug(`Incoming config: ${printJson(serializedConfig)}`)
+
+        return isDeepEqual(serializedConfig, currentSerializedConfig)
+    }
+
+    /**
+     * @see {@link IUln302.getExecutorConfig}
+     */
+    @AsyncRetriable()
+    async getExecutorConfig(
+        _eid: EndpointId,
+        _address?: OmniAddress | null | undefined
+    ): Promise<Uln302ExecutorConfig> {
+        throw new TypeError(`getExecutorConfig() not implemented on Solana Endpoint SDK`)
+    }
+
+    /**
+     * @see {@link IUln302.getAppExecutorConfig}
+     */
+    @AsyncRetriable()
+    async getAppExecutorConfig(eid: EndpointId, address: OmniAddress): Promise<Uln302ExecutorConfig> {
+        const eidLabel = formatEid(eid)
+
+        this.logger.debug(`Getting executor config for eid ${eid} (${eidLabel}) and address ${address}`)
+
+        const config = await mapError(
+            async () => {
+                const publicKey = new PublicKey(address)
+
+                return (
+                    (await this.program.getSendConfigState(this.connection, publicKey, eid)) ??
+                    (this.logger.warn(
+                        `Got an empty executor config for OApp ${address} and ${eidLabel}, getting the default one`
+                    ),
+                    await this.program.getDefaultSendConfigState(this.connection, eid))
+                )
+            },
+            (error) =>
+                new Error(
+                    `Failed to get executor config for ${this.label} for OApp ${address} and ${eidLabel}: ${error}`
+                )
+        )
+
+        assert(
+            config != null,
+            `Could not get OApp executor config for ${this.label} and OApp ${address} and ${eidLabel}: Neither app nor default configs have been specified`
+        )
+
+        return {
+            maxMessageSize: config.executor.maxMessageSize,
+            executor: config.executor.executor.toBase58(),
+        }
+    }
+
+    /**
+     * @see {@link IUln302.hasAppExecutorConfig}
+     */
+    async hasAppExecutorConfig(eid: EndpointId, oapp: OmniAddress, config: Uln302ExecutorConfig): Promise<boolean> {
+        const currentConfig = await this.getAppExecutorConfig(eid, oapp)
+        const currentSerializedConfig = this.serializeExecutorConfig(currentConfig)
+        const serializedConfig = this.serializeExecutorConfig(config)
+
+        this.logger.debug(`Checking whether Executor configs for eid ${eid} (${formatEid(eid)}) and OApp ${oapp} match`)
+        this.logger.debug(`Current config: ${printJson(currentSerializedConfig)}`)
+        this.logger.debug(`Incoming config: ${printJson(serializedConfig)}`)
+
+        return isDeepEqual(serializedConfig, currentSerializedConfig)
+    }
+
+    /**
+     * @see {@link IUln302.setDefaultExecutorConfig}
+     */
+    async setDefaultExecutorConfig(_eid: EndpointId, _config: Uln302ExecutorConfig): Promise<OmniTransaction> {
+        throw new TypeError(`getExecutorConfig() not implemented on Solana Endpoint SDK`)
+    }
+
+    decodeExecutorConfig(_executorConfigBytes: string): Uln302ExecutorConfig {
+        throw new TypeError(`getExecutorConfig() not implemented on Solana Endpoint SDK`)
+    }
+
+    encodeExecutorConfig(_config: Uln302ExecutorConfig): string {
+        throw new TypeError(`getExecutorConfig() not implemented on Solana Endpoint SDK`)
+    }
+
+    decodeUlnConfig(_ulnConfigBytes: string): Uln302UlnConfig {
+        throw new TypeError(`getExecutorConfig() not implemented on Solana Endpoint SDK`)
+    }
+
+    encodeUlnConfig(_config: Uln302UlnUserConfig): string {
+        throw new TypeError(`getExecutorConfig() not implemented on Solana Endpoint SDK`)
+    }
+
+    async setDefaultUlnConfig(_eid: EndpointId, _config: Uln302UlnUserConfig): Promise<OmniTransaction> {
+        throw new TypeError(`getExecutorConfig() not implemented on Solana Endpoint SDK`)
+    }
+
+    /**
+     * Prepares the ULN config to be sent to the contract
+     *
+     * This involves adding two properties that are required by the EVM
+     * contracts (for optimization purposes) but don't need to be present
+     * in our configuration and ensuring correct checksum on the DVN addresses.
+     *
+     * @param {Uln302UlnUserConfig} config
+     * @returns {SerializedUln302UlnConfig}
+     */
+    protected serializeUlnConfig({
+        confirmations = BigInt(0),
+        requiredDVNs,
+        optionalDVNs = [],
+        optionalDVNThreshold = 0,
+    }: Uln302UlnUserConfig): SerializedUln302UlnConfig {
+        return {
+            confirmations,
+            optionalDVNThreshold,
+            requiredDVNs: serializeDVNs(requiredDVNs),
+            optionalDVNs: serializeDVNs(optionalDVNs),
+            requiredDVNCount: requiredDVNs.length,
+            optionalDVNCount: optionalDVNs.length,
+        }
+    }
+
+    /**
+     * Prepares the Executor config to be sent to the contract
+     *
+     * @param {Uln302ExecutorConfig} config
+     * @returns {SerializedUln302ExecutorConfig}
+     */
+    protected serializeExecutorConfig({
+        maxMessageSize,
+        executor,
+    }: Uln302ExecutorConfig): SerializedUln302ExecutorConfig {
+        return {
+            maxMessageSize,
+            executor,
+        }
+    }
+}
+
+/**
+ * Helper type that matches the expected UlnConfig type for the solicity implementation
+ */
+interface SerializedUln302UlnConfig extends Uln302UlnConfig {
+    requiredDVNCount: number
+    optionalDVNCount: number
+}
+
+/**
+ * For reasons of symmetry we'll add a type for serialized `Uln302ExecutorConfig`,
+ * even though it totally matches the `Uln302ExecutorConfig` type
+ */
+type SerializedUln302ExecutorConfig = Uln302ExecutorConfig
+
+const serializeDVNs = (dvns: OmniAddress[]) =>
+    dvns
+        .map((address) => new PublicKey(address).toBytes())
+        .sort(compareBytes32Ascending)
+        .map((bytes) => new PublicKey(bytes).toBase58())

--- a/packages/protocol-devtools-solana/test/endpointv2/sdk.test.ts
+++ b/packages/protocol-devtools-solana/test/endpointv2/sdk.test.ts
@@ -230,4 +230,75 @@ describe('endpointv2/sdk', () => {
             )
         })
     })
+
+    describe('getAppUlnConfig', () => {
+        it('should be able to get OApp ULN config', async () => {
+            const connection = await connectionFactory(EndpointId.SOLANA_V2_MAINNET)
+            const sdk = new EndpointV2(connection, point, account)
+
+            const eid = EndpointId.ETHEREUM_V2_MAINNET
+
+            const ulnAddress = await sdk.getSendLibrary(oftConfig.toBase58(), eid)
+            expect(ulnAddress).not.toBeUndefined()
+
+            const config = await sdk.getAppUlnConfig(oftConfig.toBase58(), ulnAddress!, eid)
+
+            // FIXME This test is prone to be flaky since it check sthe mainnet configuration that can change anytime
+            expect(config).toEqual({
+                confirmations: BigInt(32),
+                optionalDVNThreshold: 0,
+                requiredDVNs: [
+                    '4VDjp6XQaxoZf5RGwiPU9NR1EXSZn2TP4ATMmiSzLfhb',
+                    'GPjyWr8vCotGuFubDpTxDxy9Vj1ZeEN4F2dwRmFiaGab',
+                ],
+                optionalDVNs: [],
+            })
+        })
+    })
+
+    describe('hasAppUlnConfig', () => {
+        it('should return true if the config matches', async () => {
+            const connection = await connectionFactory(EndpointId.SOLANA_V2_MAINNET)
+            const sdk = new EndpointV2(connection, point, account)
+
+            const eid = EndpointId.ETHEREUM_V2_MAINNET
+
+            const ulnAddress = await sdk.getSendLibrary(oftConfig.toBase58(), eid)
+            expect(ulnAddress).not.toBeUndefined()
+
+            expect(
+                await sdk.hasAppUlnConfig(oftConfig.toBase58(), ulnAddress!, eid, {
+                    confirmations: BigInt(32),
+                    optionalDVNThreshold: 0,
+                    requiredDVNs: [
+                        '4VDjp6XQaxoZf5RGwiPU9NR1EXSZn2TP4ATMmiSzLfhb',
+                        'GPjyWr8vCotGuFubDpTxDxy9Vj1ZeEN4F2dwRmFiaGab',
+                    ],
+                    optionalDVNs: [],
+                })
+            ).toBeTruthy()
+
+            expect(
+                await sdk.hasAppUlnConfig(oftConfig.toBase58(), ulnAddress!, eid, {
+                    confirmations: BigInt(32),
+                    optionalDVNThreshold: 0,
+                    requiredDVNs: [
+                        // We flip the DVNs
+                        'GPjyWr8vCotGuFubDpTxDxy9Vj1ZeEN4F2dwRmFiaGab',
+                        '4VDjp6XQaxoZf5RGwiPU9NR1EXSZn2TP4ATMmiSzLfhb',
+                    ],
+                    optionalDVNs: [],
+                })
+            ).toBeTruthy()
+
+            expect(
+                await sdk.hasAppUlnConfig(oftConfig.toBase58(), ulnAddress!, eid, {
+                    confirmations: BigInt(0),
+                    optionalDVNThreshold: 0,
+                    requiredDVNs: [],
+                    optionalDVNs: [],
+                })
+            ).toBeFalsy()
+        })
+    })
 })


### PR DESCRIPTION
### In this PR

- Add a stub of `Uln302` SDK with only `getAppExecutorConfig` and `getAppUlnConfig` implemented