### PR TITLE
🗞️ Solana: Setting configs [17/N]

### DIFF
--- a/.changeset/fuzzy-ducks-divide.md
+++ b/.changeset/fuzzy-ducks-divide.md
@@ -1,0 +1,5 @@
+---
+"@layerzerolabs/ua-devtools": patch
+---
+
+Add type parameter to Uln302SetUlnConfig type

--- a/packages/protocol-devtools/src/endpointv2/types.ts
+++ b/packages/protocol-devtools/src/endpointv2/types.ts
@@ -182,6 +182,7 @@ export interface Uln302SetExecutorConfig {
 }
 
 export interface Uln302SetUlnConfig {
+    type: 'send' | 'receive'
     eid: EndpointId
     ulnConfig: Uln302UlnUserConfig
 }
@@ -189,7 +190,7 @@ export interface Uln302SetUlnConfig {
 export interface SetConfigParam {
     eid: EndpointId
     configType: number
-    config: string
+    config: unknown
 }
 
 export interface MessageParams {

--- a/packages/ua-devtools/src/oapp/config.ts
+++ b/packages/ua-devtools/src/oapp/config.ts
@@ -335,7 +335,7 @@ export const configureSendConfig: OAppConfigurator = withOAppLogger(
 
                 if (!hasUlnConfig) {
                     const newSetConfigs: SetConfigParam[] = await endpointSdk.getUlnConfigParams(currentSendLibrary, [
-                        { eid: to.eid, ulnConfig: config.sendConfig.ulnConfig },
+                        { eid: to.eid, ulnConfig: config.sendConfig.ulnConfig, type: 'send' },
                     ])
 
                     // Updates map with new configs for that OApp and Send Library
@@ -416,7 +416,7 @@ export const configureReceiveConfig: OAppConfigurator = withOAppLogger(
 
             if (!hasUlnConfig) {
                 const newSetConfigs: SetConfigParam[] = await endpointSdk.getUlnConfigParams(currentReceiveLibrary, [
-                    { eid: to.eid, ulnConfig: config.receiveConfig.ulnConfig },
+                    { eid: to.eid, ulnConfig: config.receiveConfig.ulnConfig, type: 'receive' },
                 ])
 
                 // Updates map with new configs for that OApp and Receive Library


### PR DESCRIPTION
### In this PR

- Adding an extra parameter required for successful config setting on Solana (Solana has 3, not 2 types of config as opposed to EVM. The ULN config has two types for send and receive)