### PR TITLE
🗞️ Solana: Setting ULN & Executor configs [18/N]

### DIFF
--- a/.changeset/grumpy-seas-double.md
+++ b/.changeset/grumpy-seas-double.md
@@ -1,0 +1,5 @@
+---
+"@layerzerolabs/protocol-devtools-solana": patch
+---
+
+Add setConfig related functionality

--- a/packages/protocol-devtools-solana/src/endpointv2/schema.ts
+++ b/packages/protocol-devtools-solana/src/endpointv2/schema.ts
@@ -1,0 +1,27 @@
+import { SetConfigType } from '@layerzerolabs/lz-solana-sdk-v2'
+import { Uln302ExecutorConfigSchema, Uln302UlnConfigSchema } from '@layerzerolabs/protocol-devtools'
+import { PublicKey } from '@solana/web3.js'
+import { z } from 'zod'
+
+export const SetConfigSchema = z.union([
+    z.object({
+        configType: z.literal(SetConfigType.EXECUTOR),
+        config: Uln302ExecutorConfigSchema.transform(({ executor, maxMessageSize }) => ({
+            executor: new PublicKey(executor),
+            maxMessageSize,
+        })),
+    }),
+    z.object({
+        configType: z.union([z.literal(SetConfigType.RECEIVE_ULN), z.literal(SetConfigType.SEND_ULN)]),
+        config: Uln302UlnConfigSchema.transform(
+            ({ confirmations, requiredDVNs, optionalDVNs, optionalDVNThreshold }) => ({
+                confirmations: Number(confirmations),
+                optionalDvnCount: optionalDVNs.length,
+                requiredDvnCount: requiredDVNs.length,
+                requiredDvns: requiredDVNs.map((dvn) => new PublicKey(dvn)),
+                optionalDvns: optionalDVNs.map((dvn) => new PublicKey(dvn)),
+                optionalDvnThreshold: optionalDVNThreshold,
+            })
+        ),
+    }),
+])

--- a/packages/protocol-devtools-solana/src/uln302/sdk.ts
+++ b/packages/protocol-devtools-solana/src/uln302/sdk.ts
@@ -168,20 +168,12 @@ export class Uln302 extends OmniSDK implements IUln302 {
         throw new TypeError(`getExecutorConfig() not implemented on Solana Endpoint SDK`)
     }
 
-    decodeExecutorConfig(_executorConfigBytes: string): Uln302ExecutorConfig {
-        throw new TypeError(`getExecutorConfig() not implemented on Solana Endpoint SDK`)
+    encodeExecutorConfig(config: Uln302ExecutorConfig): SerializedUln302ExecutorConfig {
+        return this.serializeExecutorConfig(config)
     }
 
-    encodeExecutorConfig(_config: Uln302ExecutorConfig): string {
-        throw new TypeError(`getExecutorConfig() not implemented on Solana Endpoint SDK`)
-    }
-
-    decodeUlnConfig(_ulnConfigBytes: string): Uln302UlnConfig {
-        throw new TypeError(`getExecutorConfig() not implemented on Solana Endpoint SDK`)
-    }
-
-    encodeUlnConfig(_config: Uln302UlnUserConfig): string {
-        throw new TypeError(`getExecutorConfig() not implemented on Solana Endpoint SDK`)
+    encodeUlnConfig(config: Uln302UlnUserConfig): SerializedUln302UlnConfig {
+        return this.serializeUlnConfig(config)
     }
 
     async setDefaultUlnConfig(_eid: EndpointId, _config: Uln302UlnUserConfig): Promise<OmniTransaction> {

--- a/packages/protocol-devtools-solana/test/endpointv2/sdk.test.ts
+++ b/packages/protocol-devtools-solana/test/endpointv2/sdk.test.ts
@@ -3,7 +3,7 @@ import { ConnectionFactory, createConnectionFactory, defaultRpcUrlFactory } from
 import { EndpointId } from '@layerzerolabs/lz-definitions'
 import { EndpointV2 } from '@/endpointv2'
 import { formatEid, normalizePeer } from '@layerzerolabs/devtools'
-import { EndpointProgram, UlnProgram } from '@layerzerolabs/lz-solana-sdk-v2'
+import { EndpointProgram } from '@layerzerolabs/lz-solana-sdk-v2'
 
 describe('endpointv2/sdk', () => {
     // FIXME These tests are using a mainnet OFT deployment and are potentially very fragile
@@ -320,8 +320,6 @@ describe('endpointv2/sdk', () => {
 
             const sendUln = await sdk.getSendLibrary(oftConfig.toBase58(), eid)
             expect(sendUln).not.toBeUndefined()
-
-            console.warn({ orig: UlnProgram.PROGRAM_ID.toBase58(), sendUln })
 
             const params = await sdk.getUlnConfigParams(sendUln!, [
                 {


### PR DESCRIPTION
### In this PR

- Update `EndpointV2` SDK to return program IDs for send/receive libraries instead of the config accounts. The `getDefaultSendLibrary` and `getDefaultReceiveLibrary` do not return program ID and need to be fix in upstream before they start working correctly
- Add Send, Receive & Executor config setting functionality to `EndpointV2`
  - Seeing the implementation for Solana, we might later encapsulate this logic completely within the `OApp` SDK to avoid passing data around