### PR TITLE
🧹 Solana: AsyncRetriable runtime configuration [20/N]

### DIFF
--- a/.changeset/light-birds-rest.md
+++ b/.changeset/light-birds-rest.md
@@ -1,0 +1,6 @@
+---
+"@layerzerolabs/devtools": patch
+"@layerzerolabs/toolbox-hardhat": patch
+---
+
+Allow AsyncRetriable to be configured at runtime

--- a/.changeset/loud-impalas-shop.md
+++ b/.changeset/loud-impalas-shop.md
@@ -1,0 +1,5 @@
+---
+"@layerzerolabs/devtools-solana": patch
+---
+
+Use Asyncretriable when creating Solana transactions

--- a/packages/devtools-solana/.swcrc
+++ b/packages/devtools-solana/.swcrc
@@ -1,0 +1,11 @@
+{
+    "jsc": {
+        "parser": {
+            "syntax": "typescript",
+            "decorators": true
+        },
+        "transform": {
+            "legacyDecorator": true
+        }
+    }
+}

--- a/packages/devtools-solana/src/omnigraph/sdk.ts
+++ b/packages/devtools-solana/src/omnigraph/sdk.ts
@@ -1,5 +1,5 @@
 import { Connection, PublicKey, Transaction } from '@solana/web3.js'
-import { formatOmniPoint, type OmniPoint, type OmniTransaction } from '@layerzerolabs/devtools'
+import { AsyncRetriable, formatOmniPoint, type OmniPoint, type OmniTransaction } from '@layerzerolabs/devtools'
 import type { IOmniSDK } from './types'
 import { Logger, createModuleLogger } from '@layerzerolabs/io-devtools'
 import { serializeTransactionMessage } from '@/transactions/serde'
@@ -29,6 +29,7 @@ export abstract class OmniSDK implements IOmniSDK {
         return new PublicKey(this.point.address)
     }
 
+    @AsyncRetriable()
     protected async createTransaction(transaction: Transaction): Promise<OmniTransaction> {
         const { blockhash } = await this.connection.getLatestBlockhash('finalized')
 

--- a/packages/devtools-solana/src/omnigraph/sdk.ts
+++ b/packages/devtools-solana/src/omnigraph/sdk.ts
@@ -8,7 +8,7 @@ import { serializeTransactionMessage } from '@/transactions/serde'
  * Base class for all Solana SDKs, providing some common functionality
  * to reduce the boilerplate
  */
-export abstract class OmniSDK implements IOmniSDK {
+export class OmniSDK implements IOmniSDK {
     constructor(
         public readonly connection: Connection,
         public readonly point: OmniPoint,

--- a/packages/devtools-solana/tsconfig.json
+++ b/packages/devtools-solana/tsconfig.json
@@ -4,6 +4,7 @@
   "include": ["src", "test", "*.config.ts"],
   "compilerOptions": {
     "types": ["node", "jest"],
+    "experimentalDecorators": true,
     "paths": {
       "@/*": ["./src/*"]
     }


### PR DESCRIPTION
### In this PR

- Allow `AsyncRetriable` to be configurable at runtime. This is important especially for Solana where the public RPC is super keen on returning `HTTP 429`
- Use `AsyncRetriable` when creating Solana transactions in the SDK since they need to call the RPC to get a recent block hash
- ~~Bump `esbuild` to include [this change](https://github.com/evanw/esbuild/commit/ae5cc175165551016f8e19475c4ac9872e60f247) that allows abstract classes to have decorators~~ Removed the `abstract` modifier from OmniSDK in Solana to make it compile in `jest` (because of decorator/abstract class incompatibility)