### PR TITLE
🪲 Solana: Fix typo in createOFTFactory [22/N]

### DIFF
--- a/.changeset/clean-boxes-teach.md
+++ b/.changeset/clean-boxes-teach.md
@@ -1,0 +1,5 @@
+---
+"@layerzerolabs/ua-devtools-solana": patch
+---
+
+Add @layerzerolabs/protocol-devtools-solana into peer dependencies

--- a/.changeset/spicy-mails-exercise.md
+++ b/.changeset/spicy-mails-exercise.md
@@ -1,0 +1,5 @@
+---
+"@layerzerolabs/ua-devtools-solana": patch
+---
+
+Fix a typo in createOFTFactory

--- a/packages/ua-devtools-solana/package.json
+++ b/packages/ua-devtools-solana/package.json
@@ -75,6 +75,7 @@
     "@layerzerolabs/lz-solana-sdk-v2": "^2.3.31",
     "@layerzerolabs/lz-v2-utilities": "^2.3.3",
     "@layerzerolabs/protocol-devtools": "^0.3.9",
+    "@layerzerolabs/protocol-devtools-solana": "~0.0.3",
     "@layerzerolabs/ua-devtools": "^0.3.23",
     "@solana/web3.js": "~1.95.0",
     "fp-ts": "^2.16.2",

--- a/packages/ua-devtools-solana/src/oft/factory.ts
+++ b/packages/ua-devtools-solana/src/oft/factory.ts
@@ -20,7 +20,7 @@ import {
  */
 export const createOFTFactory = (
     userAccountFactory: PublicKeyFactory,
-    mintAccountFactory: PublicKeyFactory,
+    programIdFactory: PublicKeyFactory,
     connectionFactory: ConnectionFactory = createConnectionFactory(defaultRpcUrlFactory)
 ): OAppFactory<OFT> =>
     pMemoize(
@@ -29,6 +29,6 @@ export const createOFTFactory = (
                 await connectionFactory(point.eid),
                 point,
                 await userAccountFactory(point),
-                await mintAccountFactory(point)
+                await programIdFactory(point)
             )
     )


### PR DESCRIPTION
### In this PR

- After #783, the `OFT` no longer receives a mint account - it receives a program ID instead. While the types of these are the same, the name for `createOFTFactory` has not been updated and would cause confusion