### PR TITLE
🧹 Solana: Add getPoint method to OmniSigner [23/N]

### DIFF
--- a/.changeset/clever-spoons-sniff.md
+++ b/.changeset/clever-spoons-sniff.md
@@ -1,0 +1,7 @@
+---
+"@layerzerolabs/devtools-solana": patch
+"@layerzerolabs/devtools-evm": patch
+"@layerzerolabs/devtools": patch
+---
+
+Add getPoint method to OmniSigner

--- a/packages/devtools-evm/src/signer/sdk.ts
+++ b/packages/devtools-evm/src/signer/sdk.ts
@@ -9,6 +9,7 @@ import {
     type OmniTransactionResponse,
     type OmniSigner,
     type OmniTransaction,
+    type OmniPoint,
 } from '@layerzerolabs/devtools'
 import assert from 'assert'
 
@@ -20,6 +21,10 @@ export abstract class OmniSignerEVMBase extends OmniSignerBase implements OmniSi
         public readonly signer: Signer
     ) {
         super(eid)
+    }
+
+    async getPoint(): Promise<OmniPoint> {
+        return { eid: this.eid, address: await this.signer.getAddress() }
     }
 }
 

--- a/packages/devtools-solana/src/transactions/signer.ts
+++ b/packages/devtools-solana/src/transactions/signer.ts
@@ -3,6 +3,7 @@ import {
     type OmniTransaction,
     type OmniTransactionReceipt,
     type OmniTransactionResponse,
+    OmniPoint,
     OmniSignerBase,
 } from '@layerzerolabs/devtools'
 import { ConfirmOptions, Connection, sendAndConfirmTransaction, Signer } from '@solana/web3.js'
@@ -17,6 +18,10 @@ export class OmniSignerSolana extends OmniSignerBase implements OmniSigner {
         public readonly confirmOptions: ConfirmOptions = { commitment: 'finalized' }
     ) {
         super(eid)
+    }
+
+    getPoint(): OmniPoint {
+        return { eid: this.eid, address: this.signer.publicKey.toBase58() }
     }
 
     async sign(transaction: OmniTransaction): Promise<string> {

--- a/packages/devtools/src/transactions/signer.ts
+++ b/packages/devtools/src/transactions/signer.ts
@@ -12,12 +12,22 @@ import { formatEid, formatOmniPoint } from '@/omnigraph/format'
 import { groupTransactionsByEid } from './utils'
 import { EndpointId } from '@layerzerolabs/lz-definitions'
 import assert from 'assert'
+import type { OmniPoint } from '@/omnigraph'
 
 /**
  * Base class for all signers containing common functionality
  */
 export abstract class OmniSignerBase implements OmniSigner {
-    protected constructor(public readonly eid: EndpointId) {}
+    /**
+     * @deprecated Use `OmniSigner.getPoint()` instead
+     */
+    public readonly eid: EndpointId
+
+    protected constructor(eid: EndpointId) {
+        this.eid = eid
+    }
+
+    abstract getPoint(): OmniPoint | Promise<OmniPoint>
 
     abstract sign(transaction: OmniTransaction): Promise<string>
 

--- a/packages/devtools/src/transactions/types.ts
+++ b/packages/devtools/src/transactions/types.ts
@@ -35,7 +35,12 @@ export interface OmniTransactionReceipt {
 }
 
 export interface OmniSigner<TResponse extends OmniTransactionResponse = OmniTransactionResponse> {
+    /**
+     * @deprecated Use `OmniSigner.getPoint().eid` instead
+     */
     eid: EndpointId
+
+    getPoint(): OmniPoint | Promise<OmniPoint>
 
     sign: (transaction: OmniTransaction) => Promise<string>
     signAndSend: (transaction: OmniTransaction) => Promise<TResponse>


### PR DESCRIPTION
### In this PR

- On Solana, we need a user account (or its public key to be precise) when collecting the transactions that need to be executed. This user account needs to match the signer account so the prettiest way to get one is to just ask the signer for its public key