### PR TITLE
🪲 Wrap errors coming from signer factories

### DIFF
--- a/.changeset/cold-clouds-kick.md
+++ b/.changeset/cold-clouds-kick.md
@@ -1,0 +1,5 @@
+---
+"@layerzerolabs/devtools": patch
+---
+
+Handle erros coming from signer factories

--- a/packages/devtools/src/transactions/signer.ts
+++ b/packages/devtools/src/transactions/signer.ts
@@ -3,6 +3,7 @@ import type {
     OmniSigner,
     OmniSignerFactory,
     OmniTransaction,
+    OmniTransactionReceipt,
     OmniTransactionResponse,
     OmniTransactionWithError,
     OmniTransactionWithReceipt,
@@ -127,7 +128,18 @@ export const createSignAndSend =
                 )
 
                 logger.debug(`Creating signer for ${eidName}`)
-                const signer = await createSigner(eid)
+                let signer: OmniSigner<OmniTransactionResponse<OmniTransactionReceipt>>
+
+                try {
+                    signer = await createSigner(eid)
+                } catch (error) {
+                    logger.error(`Failed to create a signer for ${eidName}: ${error}`)
+
+                    return handleError({
+                        error: new Error(`Failed to create a signer for ${eidName}: ${error}`),
+                        transaction: eidTransactions[0]!,
+                    })
+                }
 
                 await signerLogic(eid, logger, signer, eidTransactions, handleSuccess, handleError)
 


### PR DESCRIPTION
### In this PR

- Fixed an issue with the signing logic that was resulting in a confusing signing state (occurring for Safe signer typically). If the signer factory threw an error, the logic would terminate but would not mark any transactions as failed or successful, resulting in a confusing message saying `Your OApp is now configured, 0 transactions successful`