### PR TITLE
🧹 Solana: Adjust default send/receive library logic in Solana OFT SDK [25/N]

### DIFF
--- a/.changeset/pink-donkeys-itch.md
+++ b/.changeset/pink-donkeys-itch.md
@@ -1,0 +1,5 @@
+---
+"@layerzerolabs/protocol-devtools-solana": patch
+---
+
+Adjust default send/receive library logic in Solana OFT SDK

--- a/packages/protocol-devtools-solana/test/endpointv2/sdk.test.ts
+++ b/packages/protocol-devtools-solana/test/endpointv2/sdk.test.ts
@@ -73,7 +73,7 @@ describe('endpointv2/sdk', () => {
             expect(lib).toEqual<string>(expect.any(String))
             expect(normalizePeer(lib, eid)).toEqual(expect.any(Uint8Array))
 
-            expect(await sdk.isDefaultSendLibrary(lib!, eid)).toBeTruthy()
+            expect(await sdk.isDefaultSendLibrary(lib!, eid)).toBeFalsy()
             expect(await sdk.isDefaultSendLibrary(EndpointProgram.PROGRAM_ID.toBase58(), eid)).toBeFalsy()
         })
     })
@@ -83,7 +83,7 @@ describe('endpointv2/sdk', () => {
             const connection = await connectionFactory(EndpointId.SOLANA_V2_MAINNET)
             const sdk = new EndpointV2(connection, point, account)
 
-            expect(await sdk.isDefaultSendLibrary(oftConfig.toBase58(), EndpointId.FLARE_V2_MAINNET)).toBeTruthy()
+            expect(await sdk.isDefaultSendLibrary(oftConfig.toBase58(), EndpointId.FLARE_V2_MAINNET)).toBeFalsy()
         })
 
         it('should return false if the default send library is not being used', async () => {
@@ -101,7 +101,7 @@ describe('endpointv2/sdk', () => {
 
             expect(await sdk.getReceiveLibrary(account.toBase58(), EndpointId.ETHEREUM_V2_TESTNET)).toEqual([
                 undefined,
-                true,
+                false,
             ])
         })
 


### PR DESCRIPTION
### In this PR

- Adjust the default send/receive library in Solana OFT SDK to return falsy values if defaults are not set
- Adjust the logic to return program IDs instead of config accounts for send/receive libraries