### PR TITLE
🧹 Solana: Add the ability to specify lookupTable in OmniSignerSolana [28/N]

### DIFF
--- a/.changeset/grumpy-cobras-run.md
+++ b/.changeset/grumpy-cobras-run.md
@@ -1,0 +1,5 @@
+---
+"@layerzerolabs/devtools-solana": patch
+---
+
+Add the ability to specify lookup tables in OmniSignerSolana


### PR DESCRIPTION
### In this PR

- Add the ability to specify `lookupAddress` for `OmniSignerSolana` which will trigger a versioned transaction flow