### PR TITLE
🪲 Solana: Allow CLI arguments to be passed to Solana tests [30/N]

### DIFF
--- a/packages/protocol-devtools-solana/bin/test
+++ b/packages/protocol-devtools-solana/bin/test
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+if [ -z "${LZ_DEVTOOLS_ENABLE_SOLANA_TESTS}" ]; then
+    echo 'Solana tests can be enabled by setting LZ_DEVTOOLS_ENABLE_SOLANA_TESTS environment variable to a non-empty value'
+else
+    jest --ci $@
+fi

--- a/packages/protocol-devtools-solana/package.json
+++ b/packages/protocol-devtools-solana/package.json
@@ -33,7 +33,7 @@
     "dev": "$npm_execpath tsup --watch",
     "lint": "$npm_execpath eslint '**/*.{js,ts,json}'",
     "lint:fix": "eslint --fix '**/*.{js,ts,json}'",
-    "test": "if [ $(echo $LZ_DEVTOOLS_ENABLE_SOLANA_TESTS) ]; then jest --ci; else echo 'Solana tests can be enabled by setting LZ_DEVTOOLS_ENABLE_SOLANA_TESTS environment variable to a non-empty value'; fi"
+    "test": "./bin/test"
   },
   "dependencies": {
     "@safe-global/api-kit": "^1.3.0",

--- a/packages/ua-devtools-solana/bin/test
+++ b/packages/ua-devtools-solana/bin/test
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+if [ -z "${LZ_DEVTOOLS_ENABLE_SOLANA_TESTS}" ]; then
+    echo 'Solana tests can be enabled by setting LZ_DEVTOOLS_ENABLE_SOLANA_TESTS environment variable to a non-empty value'
+else
+    jest --ci $@
+fi

--- a/packages/ua-devtools-solana/package.json
+++ b/packages/ua-devtools-solana/package.json
@@ -33,7 +33,7 @@
     "dev": "$npm_execpath tsup --watch",
     "lint": "$npm_execpath eslint '**/*.{js,ts,json}'",
     "lint:fix": "eslint --fix '**/*.{js,ts,json}'",
-    "test": "if [ $(echo $LZ_DEVTOOLS_ENABLE_SOLANA_TESTS) ]; then jest --ci; else echo 'Solana tests can be enabled by setting LZ_DEVTOOLS_ENABLE_SOLANA_TESTS environment variable to a non-empty value'; fi"
+    "test": "./bin/test"
   },
   "dependencies": {
     "@safe-global/api-kit": "^1.3.0",


### PR DESCRIPTION
### In this PR

- Replace inline bash conditional expression with a bash file and pass script arguments to the underlying `jest` command. This is important for being able to e.g. update snapshots or run focused tests