### PR TITLE
🧹 Solana: Allow EndpointV2.setConfig to return multiple OmniTransactions [31/N]

### DIFF
--- a/.changeset/honest-schools-carry.md
+++ b/.changeset/honest-schools-carry.md
@@ -1,0 +1,16 @@
+---
+"@layerzerolabs/ua-devtools-evm-hardhat-test": minor
+"@layerzerolabs/protocol-devtools-solana": minor
+"@layerzerolabs/protocol-devtools-evm": minor
+"@layerzerolabs/ua-devtools-solana": minor
+"@layerzerolabs/protocol-devtools": minor
+"@layerzerolabs/devtools-solana": minor
+"@layerzerolabs/ua-devtools": minor
+"@layerzerolabs/devtools-evm": minor
+"@layerzerolabs/devtools-evm-hardhat": minor
+"@layerzerolabs/toolbox-hardhat": minor
+"@layerzerolabs/ua-devtools-evm": minor
+"@layerzerolabs/ua-devtools-evm-hardhat": minor
+---
+
+Allow EndpointV2.setConfig to return more than one transaction

--- a/packages/devtools-solana/src/transactions/serde.ts
+++ b/packages/devtools-solana/src/transactions/serde.ts
@@ -1,4 +1,4 @@
-import { Message, Transaction } from '@solana/web3.js'
+import { Message, PublicKey, Transaction, TransactionInstruction } from '@solana/web3.js'
 
 export const serializeTransactionMessage = (transaction: Transaction): string =>
     serializeTransactionBuffer(transaction.serializeMessage())
@@ -29,3 +29,86 @@ export const serializeTransactionBuffer = (buffer: Buffer): string => buffer.toS
  * @returns {Buffer}
  */
 export const deserializeTransactionBuffer = (data: string): Buffer => Buffer.from(data, 'hex')
+
+/**
+ * Roughly estimates the transaction size and returns the size in bytes.
+ *
+ * This is only an approximation and should be used with caution (and love and understanding)
+ *
+ * @param {Transaction} transaction
+ * @param {number} [numSigners]
+ * @returns {number}
+ */
+export const estimateTransactionSize = (transaction: Transaction, numSigners: number = 1): number => {
+    const originalFeePayer = transaction.feePayer
+    const originalRecentBlockHash = transaction.recentBlockhash
+
+    try {
+        transaction.feePayer = new PublicKey(0)
+        transaction.recentBlockhash = new PublicKey(0).toBase58()
+
+        const serialized = transaction.serialize({
+            verifySignatures: false,
+            requireAllSignatures: false,
+        })
+
+        return (
+            serialized.length +
+            // 1 byte for the number of signatures.
+            1 +
+            // 64 bytes per each signer. We'll default the number of signers to 1
+            numSigners * 64
+        )
+    } finally {
+        transaction.feePayer = originalFeePayer
+        transaction.recentBlockhash = originalRecentBlockHash
+    }
+}
+
+/**
+ * Estimates the size of a transaction with an additional instruction added.
+ *
+ * Returns `true` if the transaction with the additional instruction fits the size limit,
+ * `false` otherwise.
+ *
+ * Since the transaction size on Solana also depends on the number of signers,
+ * we allow this number to be overriden.
+ *
+ * @param {Transaction} transaction
+ * @param {TransactionInstruction} instruction
+ * @param {number} [numSigners]
+ *
+ * @returns {boolean}
+ */
+export const canAddInstruction = (
+    transaction: Transaction,
+    instruction: TransactionInstruction,
+    numSigners: number = 1
+): boolean => {
+    const measure = new Transaction().add(...transaction.instructions, instruction)
+    const size = estimateTransactionSize(measure, numSigners)
+
+    return size < MAX_TRANSACTION_SIZE - TRANSACTION_SIZE_BUFFER
+}
+
+const MAX_TRANSACTION_SIZE = 1232
+
+let TRANSACTION_SIZE_BUFFER = 64
+
+/**
+ * Developer helper to adjust the buffer we add when estimating transaction sizes
+ *
+ * Since the size estimation algorhytm is only an approximation,
+ * we use this buffer to offset the maximum transaction size we allow in one transaction.
+ *
+ * If set to a positive value, this will make less instructions fit into one transaction.
+ * If set to a negative value, it will make more instructions fit into one transaction.
+ *
+ * The default value for this buffer is 64
+ *
+ * @see {canAddInstruction}
+ * @param {number} value
+ */
+export const setTransactionSizeBuffer = (value: number) => {
+    TRANSACTION_SIZE_BUFFER = value
+}

--- a/packages/protocol-devtools-evm/src/endpointv2/sdk.ts
+++ b/packages/protocol-devtools-evm/src/endpointv2/sdk.ts
@@ -258,22 +258,24 @@ export class EndpointV2 extends OmniSDK implements IEndpointV2 {
         }
     }
 
-    async setConfig(oapp: OmniAddress, uln: OmniAddress, setConfigParam: SetConfigParam[]): Promise<OmniTransaction> {
+    async setConfig(oapp: OmniAddress, uln: OmniAddress, setConfigParam: SetConfigParam[]): Promise<OmniTransaction[]> {
         this.logger.debug(`Setting config for OApp ${oapp} to ULN ${uln} with config ${printJson(setConfigParam)}`)
 
         const data = this.contract.contract.interface.encodeFunctionData('setConfig', [oapp, uln, setConfigParam])
 
-        return {
-            ...this.createTransaction(data),
-            description: `Setting config for ULN ${uln} to ${printJson(setConfigParam)}`,
-        }
+        return [
+            {
+                ...this.createTransaction(data),
+                description: `Setting config for ULN ${uln} to ${printJson(setConfigParam)}`,
+            },
+        ]
     }
 
     async setUlnConfig(
         oapp: OmniAddress,
         uln: OmniAddress,
         setUlnConfig: Uln302SetUlnConfig[]
-    ): Promise<OmniTransaction> {
+    ): Promise<OmniTransaction[]> {
         this.logger.debug(`Setting ULN config for OApp ${oapp} to ULN ${uln} with config ${printJson(setUlnConfig)}`)
 
         const setUlnConfigParams: SetConfigParam[] = await this.getUlnConfigParams(uln, setUlnConfig)
@@ -284,7 +286,7 @@ export class EndpointV2 extends OmniSDK implements IEndpointV2 {
         oapp: OmniAddress,
         uln: OmniAddress,
         setExecutorConfig: Uln302SetExecutorConfig[]
-    ): Promise<OmniTransaction> {
+    ): Promise<OmniTransaction[]> {
         this.logger.debug(
             `Setting executor config for OApp ${oapp} to ULN ${uln} with config ${printJson(setExecutorConfig)}`
         )

--- a/packages/protocol-devtools-solana/test/endpointv2/__snapshots__/sdk.test.ts.snap
+++ b/packages/protocol-devtools-solana/test/endpointv2/__snapshots__/sdk.test.ts.snap
@@ -1,0 +1,400 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`endpointv2/sdk setConfig should create multiple OmniTransactions when called with a lot of uln configs 1`] = `
+[
+  {
+    "description": "Setting config for ULN 7a4WjyR8VZ7yZz5XJAKm39BUGn5iT9CKcv2pmG9tdXVH to [
+	{
+		"eid": 30101,
+		"configType": 2,
+		"config": {
+			"confirmations": "32",
+			"optionalDVNThreshold": 0,
+			"requiredDVNs": [
+				"4VDjp6XQaxoZf5RGwiPU9NR1EXSZn2TP4ATMmiSzLfhb",
+				"GPjyWr8vCotGuFubDpTxDxy9Vj1ZeEN4F2dwRmFiaGab"
+			],
+			"optionalDVNs": [],
+			"requiredDVNCount": 2,
+			"optionalDVNCount": 0
+		}
+	},
+	{
+		"eid": 30101,
+		"configType": 3,
+		"config": {
+			"confirmations": "32",
+			"optionalDVNThreshold": 0,
+			"requiredDVNs": [
+				"4VDjp6XQaxoZf5RGwiPU9NR1EXSZn2TP4ATMmiSzLfhb",
+				"GPjyWr8vCotGuFubDpTxDxy9Vj1ZeEN4F2dwRmFiaGab"
+			],
+			"optionalDVNs": [],
+			"requiredDVNCount": 2,
+			"optionalDVNCount": 0
+		}
+	},
+	{
+		"eid": 30101,
+		"configType": 2,
+		"config": {
+			"confirmations": "32",
+			"optionalDVNThreshold": 0,
+			"requiredDVNs": [
+				"4VDjp6XQaxoZf5RGwiPU9NR1EXSZn2TP4ATMmiSzLfhb",
+				"GPjyWr8vCotGuFubDpTxDxy9Vj1ZeEN4F2dwRmFiaGab"
+			],
+			"optionalDVNs": [],
+			"requiredDVNCount": 2,
+			"optionalDVNCount": 0
+		}
+	}
+]",
+    "point": {
+      "address": "76y77prsiCMvXMjuoZ5VRrhG5qYBrUMYTE5WgHqgjEn6",
+      "eid": 30168,
+    },
+  },
+  {
+    "description": "Setting config for ULN 7a4WjyR8VZ7yZz5XJAKm39BUGn5iT9CKcv2pmG9tdXVH to [
+	{
+		"eid": 30101,
+		"configType": 2,
+		"config": {
+			"confirmations": "32",
+			"optionalDVNThreshold": 0,
+			"requiredDVNs": [
+				"4VDjp6XQaxoZf5RGwiPU9NR1EXSZn2TP4ATMmiSzLfhb",
+				"GPjyWr8vCotGuFubDpTxDxy9Vj1ZeEN4F2dwRmFiaGab"
+			],
+			"optionalDVNs": [],
+			"requiredDVNCount": 2,
+			"optionalDVNCount": 0
+		}
+	},
+	{
+		"eid": 30101,
+		"configType": 2,
+		"config": {
+			"confirmations": "32",
+			"optionalDVNThreshold": 0,
+			"requiredDVNs": [
+				"4VDjp6XQaxoZf5RGwiPU9NR1EXSZn2TP4ATMmiSzLfhb",
+				"GPjyWr8vCotGuFubDpTxDxy9Vj1ZeEN4F2dwRmFiaGab"
+			],
+			"optionalDVNs": [],
+			"requiredDVNCount": 2,
+			"optionalDVNCount": 0
+		}
+	},
+	{
+		"eid": 30101,
+		"configType": 2,
+		"config": {
+			"confirmations": "32",
+			"optionalDVNThreshold": 0,
+			"requiredDVNs": [
+				"4VDjp6XQaxoZf5RGwiPU9NR1EXSZn2TP4ATMmiSzLfhb",
+				"GPjyWr8vCotGuFubDpTxDxy9Vj1ZeEN4F2dwRmFiaGab"
+			],
+			"optionalDVNs": [],
+			"requiredDVNCount": 2,
+			"optionalDVNCount": 0
+		}
+	}
+]",
+    "point": {
+      "address": "76y77prsiCMvXMjuoZ5VRrhG5qYBrUMYTE5WgHqgjEn6",
+      "eid": 30168,
+    },
+  },
+  {
+    "description": "Setting config for ULN 7a4WjyR8VZ7yZz5XJAKm39BUGn5iT9CKcv2pmG9tdXVH to [
+	{
+		"eid": 30101,
+		"configType": 3,
+		"config": {
+			"confirmations": "32",
+			"optionalDVNThreshold": 0,
+			"requiredDVNs": [
+				"4VDjp6XQaxoZf5RGwiPU9NR1EXSZn2TP4ATMmiSzLfhb",
+				"GPjyWr8vCotGuFubDpTxDxy9Vj1ZeEN4F2dwRmFiaGab"
+			],
+			"optionalDVNs": [],
+			"requiredDVNCount": 2,
+			"optionalDVNCount": 0
+		}
+	},
+	{
+		"eid": 30101,
+		"configType": 2,
+		"config": {
+			"confirmations": "32",
+			"optionalDVNThreshold": 0,
+			"requiredDVNs": [
+				"4VDjp6XQaxoZf5RGwiPU9NR1EXSZn2TP4ATMmiSzLfhb",
+				"GPjyWr8vCotGuFubDpTxDxy9Vj1ZeEN4F2dwRmFiaGab"
+			],
+			"optionalDVNs": [],
+			"requiredDVNCount": 2,
+			"optionalDVNCount": 0
+		}
+	},
+	{
+		"eid": 30101,
+		"configType": 3,
+		"config": {
+			"confirmations": "32",
+			"optionalDVNThreshold": 0,
+			"requiredDVNs": [
+				"4VDjp6XQaxoZf5RGwiPU9NR1EXSZn2TP4ATMmiSzLfhb",
+				"GPjyWr8vCotGuFubDpTxDxy9Vj1ZeEN4F2dwRmFiaGab"
+			],
+			"optionalDVNs": [],
+			"requiredDVNCount": 2,
+			"optionalDVNCount": 0
+		}
+	}
+]",
+    "point": {
+      "address": "76y77prsiCMvXMjuoZ5VRrhG5qYBrUMYTE5WgHqgjEn6",
+      "eid": 30168,
+    },
+  },
+  {
+    "description": "Setting config for ULN 7a4WjyR8VZ7yZz5XJAKm39BUGn5iT9CKcv2pmG9tdXVH to [
+	{
+		"eid": 30101,
+		"configType": 2,
+		"config": {
+			"confirmations": "32",
+			"optionalDVNThreshold": 0,
+			"requiredDVNs": [
+				"4VDjp6XQaxoZf5RGwiPU9NR1EXSZn2TP4ATMmiSzLfhb",
+				"GPjyWr8vCotGuFubDpTxDxy9Vj1ZeEN4F2dwRmFiaGab"
+			],
+			"optionalDVNs": [],
+			"requiredDVNCount": 2,
+			"optionalDVNCount": 0
+		}
+	},
+	{
+		"eid": 30101,
+		"configType": 3,
+		"config": {
+			"confirmations": "32",
+			"optionalDVNThreshold": 0,
+			"requiredDVNs": [
+				"4VDjp6XQaxoZf5RGwiPU9NR1EXSZn2TP4ATMmiSzLfhb",
+				"GPjyWr8vCotGuFubDpTxDxy9Vj1ZeEN4F2dwRmFiaGab"
+			],
+			"optionalDVNs": [],
+			"requiredDVNCount": 2,
+			"optionalDVNCount": 0
+		}
+	},
+	{
+		"eid": 30101,
+		"configType": 2,
+		"config": {
+			"confirmations": "32",
+			"optionalDVNThreshold": 0,
+			"requiredDVNs": [
+				"4VDjp6XQaxoZf5RGwiPU9NR1EXSZn2TP4ATMmiSzLfhb",
+				"GPjyWr8vCotGuFubDpTxDxy9Vj1ZeEN4F2dwRmFiaGab"
+			],
+			"optionalDVNs": [],
+			"requiredDVNCount": 2,
+			"optionalDVNCount": 0
+		}
+	}
+]",
+    "point": {
+      "address": "76y77prsiCMvXMjuoZ5VRrhG5qYBrUMYTE5WgHqgjEn6",
+      "eid": 30168,
+    },
+  },
+  {
+    "description": "Setting config for ULN 7a4WjyR8VZ7yZz5XJAKm39BUGn5iT9CKcv2pmG9tdXVH to [
+	{
+		"eid": 30101,
+		"configType": 3,
+		"config": {
+			"confirmations": "32",
+			"optionalDVNThreshold": 0,
+			"requiredDVNs": [
+				"4VDjp6XQaxoZf5RGwiPU9NR1EXSZn2TP4ATMmiSzLfhb",
+				"GPjyWr8vCotGuFubDpTxDxy9Vj1ZeEN4F2dwRmFiaGab"
+			],
+			"optionalDVNs": [],
+			"requiredDVNCount": 2,
+			"optionalDVNCount": 0
+		}
+	},
+	{
+		"eid": 30101,
+		"configType": 2,
+		"config": {
+			"confirmations": "32",
+			"optionalDVNThreshold": 0,
+			"requiredDVNs": [
+				"4VDjp6XQaxoZf5RGwiPU9NR1EXSZn2TP4ATMmiSzLfhb",
+				"GPjyWr8vCotGuFubDpTxDxy9Vj1ZeEN4F2dwRmFiaGab"
+			],
+			"optionalDVNs": [],
+			"requiredDVNCount": 2,
+			"optionalDVNCount": 0
+		}
+	},
+	{
+		"eid": 30101,
+		"configType": 2,
+		"config": {
+			"confirmations": "32",
+			"optionalDVNThreshold": 0,
+			"requiredDVNs": [
+				"4VDjp6XQaxoZf5RGwiPU9NR1EXSZn2TP4ATMmiSzLfhb",
+				"GPjyWr8vCotGuFubDpTxDxy9Vj1ZeEN4F2dwRmFiaGab"
+			],
+			"optionalDVNs": [],
+			"requiredDVNCount": 2,
+			"optionalDVNCount": 0
+		}
+	}
+]",
+    "point": {
+      "address": "76y77prsiCMvXMjuoZ5VRrhG5qYBrUMYTE5WgHqgjEn6",
+      "eid": 30168,
+    },
+  },
+  {
+    "description": "Setting config for ULN 7a4WjyR8VZ7yZz5XJAKm39BUGn5iT9CKcv2pmG9tdXVH to [
+	{
+		"eid": 30101,
+		"configType": 2,
+		"config": {
+			"confirmations": "32",
+			"optionalDVNThreshold": 0,
+			"requiredDVNs": [
+				"4VDjp6XQaxoZf5RGwiPU9NR1EXSZn2TP4ATMmiSzLfhb",
+				"GPjyWr8vCotGuFubDpTxDxy9Vj1ZeEN4F2dwRmFiaGab"
+			],
+			"optionalDVNs": [],
+			"requiredDVNCount": 2,
+			"optionalDVNCount": 0
+		}
+	},
+	{
+		"eid": 30101,
+		"configType": 2,
+		"config": {
+			"confirmations": "32",
+			"optionalDVNThreshold": 0,
+			"requiredDVNs": [
+				"4VDjp6XQaxoZf5RGwiPU9NR1EXSZn2TP4ATMmiSzLfhb",
+				"GPjyWr8vCotGuFubDpTxDxy9Vj1ZeEN4F2dwRmFiaGab"
+			],
+			"optionalDVNs": [],
+			"requiredDVNCount": 2,
+			"optionalDVNCount": 0
+		}
+	},
+	{
+		"eid": 30101,
+		"configType": 3,
+		"config": {
+			"confirmations": "32",
+			"optionalDVNThreshold": 0,
+			"requiredDVNs": [
+				"4VDjp6XQaxoZf5RGwiPU9NR1EXSZn2TP4ATMmiSzLfhb",
+				"GPjyWr8vCotGuFubDpTxDxy9Vj1ZeEN4F2dwRmFiaGab"
+			],
+			"optionalDVNs": [],
+			"requiredDVNCount": 2,
+			"optionalDVNCount": 0
+		}
+	}
+]",
+    "point": {
+      "address": "76y77prsiCMvXMjuoZ5VRrhG5qYBrUMYTE5WgHqgjEn6",
+      "eid": 30168,
+    },
+  },
+  {
+    "description": "Setting config for ULN 7a4WjyR8VZ7yZz5XJAKm39BUGn5iT9CKcv2pmG9tdXVH to [
+	{
+		"eid": 30101,
+		"configType": 2,
+		"config": {
+			"confirmations": "32",
+			"optionalDVNThreshold": 0,
+			"requiredDVNs": [
+				"4VDjp6XQaxoZf5RGwiPU9NR1EXSZn2TP4ATMmiSzLfhb",
+				"GPjyWr8vCotGuFubDpTxDxy9Vj1ZeEN4F2dwRmFiaGab"
+			],
+			"optionalDVNs": [],
+			"requiredDVNCount": 2,
+			"optionalDVNCount": 0
+		}
+	},
+	{
+		"eid": 30101,
+		"configType": 3,
+		"config": {
+			"confirmations": "32",
+			"optionalDVNThreshold": 0,
+			"requiredDVNs": [
+				"4VDjp6XQaxoZf5RGwiPU9NR1EXSZn2TP4ATMmiSzLfhb",
+				"GPjyWr8vCotGuFubDpTxDxy9Vj1ZeEN4F2dwRmFiaGab"
+			],
+			"optionalDVNs": [],
+			"requiredDVNCount": 2,
+			"optionalDVNCount": 0
+		}
+	},
+	{
+		"eid": 30101,
+		"configType": 2,
+		"config": {
+			"confirmations": "32",
+			"optionalDVNThreshold": 0,
+			"requiredDVNs": [
+				"4VDjp6XQaxoZf5RGwiPU9NR1EXSZn2TP4ATMmiSzLfhb",
+				"GPjyWr8vCotGuFubDpTxDxy9Vj1ZeEN4F2dwRmFiaGab"
+			],
+			"optionalDVNs": [],
+			"requiredDVNCount": 2,
+			"optionalDVNCount": 0
+		}
+	}
+]",
+    "point": {
+      "address": "76y77prsiCMvXMjuoZ5VRrhG5qYBrUMYTE5WgHqgjEn6",
+      "eid": 30168,
+    },
+  },
+  {
+    "description": "Setting config for ULN 7a4WjyR8VZ7yZz5XJAKm39BUGn5iT9CKcv2pmG9tdXVH to [
+	{
+		"eid": 30101,
+		"configType": 3,
+		"config": {
+			"confirmations": "32",
+			"optionalDVNThreshold": 0,
+			"requiredDVNs": [
+				"4VDjp6XQaxoZf5RGwiPU9NR1EXSZn2TP4ATMmiSzLfhb",
+				"GPjyWr8vCotGuFubDpTxDxy9Vj1ZeEN4F2dwRmFiaGab"
+			],
+			"optionalDVNs": [],
+			"requiredDVNCount": 2,
+			"optionalDVNCount": 0
+		}
+	}
+]",
+    "point": {
+      "address": "76y77prsiCMvXMjuoZ5VRrhG5qYBrUMYTE5WgHqgjEn6",
+      "eid": 30168,
+    },
+  },
+]
+`;

--- a/packages/protocol-devtools/src/endpointv2/types.ts
+++ b/packages/protocol-devtools/src/endpointv2/types.ts
@@ -121,7 +121,7 @@ export interface IEndpointV2 extends IOmniSDK {
         oapp: PossiblyBytes,
         uln: PossiblyBytes,
         setExecutorConfig: Uln302SetExecutorConfig[]
-    ): Promise<OmniTransaction>
+    ): Promise<OmniTransaction[]>
 
     /**
      * Gets the ULN config for a given OApp, library and a destination
@@ -167,11 +167,11 @@ export interface IEndpointV2 extends IOmniSDK {
      */
     hasAppUlnConfig(oapp: OmniAddress, uln: OmniAddress, eid: EndpointId, config: Uln302UlnUserConfig): Promise<boolean>
 
-    setUlnConfig(oapp: OmniAddress, uln: OmniAddress, setUlnConfig: Uln302SetUlnConfig[]): Promise<OmniTransaction>
+    setUlnConfig(oapp: OmniAddress, uln: OmniAddress, setUlnConfig: Uln302SetUlnConfig[]): Promise<OmniTransaction[]>
 
     getUlnConfigParams(uln: OmniAddress, setUlnConfig: Uln302SetUlnConfig[]): Promise<SetConfigParam[]>
     getExecutorConfigParams(uln: OmniAddress, setExecutorConfig: Uln302SetExecutorConfig[]): Promise<SetConfigParam[]>
-    setConfig(oapp: OmniAddress, uln: OmniAddress, setConfigParam: SetConfigParam[]): Promise<OmniTransaction>
+    setConfig(oapp: OmniAddress, uln: OmniAddress, setConfigParam: SetConfigParam[]): Promise<OmniTransaction[]>
 
     quote(params: MessageParams, sender: OmniAddress): Promise<MessagingFee>
 }

--- a/tests/ua-devtools-evm-hardhat-test/test/oapp/config.test.ts
+++ b/tests/ua-devtools-evm-hardhat-test/test/oapp/config.test.ts
@@ -819,50 +819,48 @@ describe('oapp/config', () => {
 
                 it('should return all configureSendConfig transactions', async () => {
                     transactions = await configureOApp(graph, oappSdkFactory)
-                    const expectedTransactions = [
-                        await ethEndpointV2Sdk.setConfig(ethPoint.address, ethSendLibrary, [
-                            ...(await ethEndpointV2Sdk.getExecutorConfigParams(ethSendLibrary, [
-                                {
-                                    eid: avaxPoint.eid,
-                                    executorConfig: {
-                                        maxMessageSize: 99,
-                                        executor: ethExecutorAddress,
-                                    },
+                    const expectedTransactions = await ethEndpointV2Sdk.setConfig(ethPoint.address, ethSendLibrary, [
+                        ...(await ethEndpointV2Sdk.getExecutorConfigParams(ethSendLibrary, [
+                            {
+                                eid: avaxPoint.eid,
+                                executorConfig: {
+                                    maxMessageSize: 99,
+                                    executor: ethExecutorAddress,
                                 },
-                            ])),
-                            ...(await ethEndpointV2Sdk.getUlnConfigParams(ethSendLibrary, [
-                                {
-                                    eid: avaxPoint.eid,
-                                    ulnConfig: {
-                                        confirmations: BigInt(42),
-                                        requiredDVNs: [ethDvnAddress],
-                                        optionalDVNs: [ethDvnAddress],
-                                        optionalDVNThreshold: 1,
-                                    },
+                            },
+                        ])),
+                        ...(await ethEndpointV2Sdk.getUlnConfigParams(ethSendLibrary, [
+                            {
+                                eid: avaxPoint.eid,
+                                ulnConfig: {
+                                    confirmations: BigInt(42),
+                                    requiredDVNs: [ethDvnAddress],
+                                    optionalDVNs: [ethDvnAddress],
+                                    optionalDVNThreshold: 1,
                                 },
-                            ])),
-                            ...(await ethEndpointV2Sdk.getExecutorConfigParams(ethSendLibrary, [
-                                {
-                                    eid: bscPoint.eid,
-                                    executorConfig: {
-                                        maxMessageSize: 99,
-                                        executor: ethExecutorAddress,
-                                    },
+                            },
+                        ])),
+                        ...(await ethEndpointV2Sdk.getExecutorConfigParams(ethSendLibrary, [
+                            {
+                                eid: bscPoint.eid,
+                                executorConfig: {
+                                    maxMessageSize: 99,
+                                    executor: ethExecutorAddress,
                                 },
-                            ])),
-                            ...(await ethEndpointV2Sdk.getUlnConfigParams(ethSendLibrary, [
-                                {
-                                    eid: bscPoint.eid,
-                                    ulnConfig: {
-                                        confirmations: BigInt(42),
-                                        requiredDVNs: [ethDvnAddress],
-                                        optionalDVNs: [ethDvnAddress],
-                                        optionalDVNThreshold: 1,
-                                    },
+                            },
+                        ])),
+                        ...(await ethEndpointV2Sdk.getUlnConfigParams(ethSendLibrary, [
+                            {
+                                eid: bscPoint.eid,
+                                ulnConfig: {
+                                    confirmations: BigInt(42),
+                                    requiredDVNs: [ethDvnAddress],
+                                    optionalDVNs: [ethDvnAddress],
+                                    optionalDVNThreshold: 1,
                                 },
-                            ])),
-                        ]),
-                    ]
+                            },
+                        ])),
+                    ])
                     expect(transactions).toEqual(expectedTransactions)
                 })
 

--- a/tests/ua-devtools-evm-hardhat-test/test/oapp/config.test.ts
+++ b/tests/ua-devtools-evm-hardhat-test/test/oapp/config.test.ts
@@ -867,7 +867,7 @@ describe('oapp/config', () => {
                 })
 
                 it('should return one configureSendConfig transaction', async () => {
-                    const [_, errors] = await signAndSend([
+                    const [_, errors] = await signAndSend(
                         await ethEndpointV2Sdk.setConfig(ethPoint.address, ethSendLibrary, [
                             ...(await ethEndpointV2Sdk.getExecutorConfigParams(ethSendLibrary, [
                                 {
@@ -889,36 +889,35 @@ describe('oapp/config', () => {
                                     },
                                 },
                             ])),
-                        ]),
-                    ])
+                        ])
+                    )
                     expect(errors).toEqual([])
 
                     // Now we configure the OApp
                     transactions = await configureOApp(graph, oappSdkFactory)
-                    const expectedTransactions = [
-                        await ethEndpointV2Sdk.setConfig(ethPoint.address, ethSendLibrary, [
-                            ...(await ethEndpointV2Sdk.getExecutorConfigParams(ethSendLibrary, [
-                                {
-                                    eid: avaxPoint.eid,
-                                    executorConfig: {
-                                        maxMessageSize: 99,
-                                        executor: ethExecutorAddress,
-                                    },
+                    const expectedTransactions = await ethEndpointV2Sdk.setConfig(ethPoint.address, ethSendLibrary, [
+                        ...(await ethEndpointV2Sdk.getExecutorConfigParams(ethSendLibrary, [
+                            {
+                                eid: avaxPoint.eid,
+                                executorConfig: {
+                                    maxMessageSize: 99,
+                                    executor: ethExecutorAddress,
                                 },
-                            ])),
-                            ...(await ethEndpointV2Sdk.getUlnConfigParams(ethSendLibrary, [
-                                {
-                                    eid: avaxPoint.eid,
-                                    ulnConfig: {
-                                        confirmations: BigInt(42),
-                                        requiredDVNs: [ethDvnAddress],
-                                        optionalDVNs: [ethDvnAddress],
-                                        optionalDVNThreshold: 1,
-                                    },
+                            },
+                        ])),
+                        ...(await ethEndpointV2Sdk.getUlnConfigParams(ethSendLibrary, [
+                            {
+                                eid: avaxPoint.eid,
+                                ulnConfig: {
+                                    confirmations: BigInt(42),
+                                    requiredDVNs: [ethDvnAddress],
+                                    optionalDVNs: [ethDvnAddress],
+                                    optionalDVNThreshold: 1,
                                 },
-                            ])),
-                        ]),
-                    ]
+                            },
+                        ])),
+                    ])
+
                     expect(transactions).toEqual(expectedTransactions)
                 })
 
@@ -1128,37 +1127,36 @@ describe('oapp/config', () => {
                 it('should return all configureReceiveConfig transactions', async () => {
                     // Now we configure the OApp
                     transactions = await configureOApp(graph, oappSdkFactory)
-                    const expectedTransactions = [
-                        await ethEndpointV2Sdk.setConfig(ethPoint.address, ethReceiveLibrary, [
-                            ...(await ethEndpointV2Sdk.getUlnConfigParams(ethReceiveLibrary, [
-                                {
-                                    eid: avaxPoint.eid,
-                                    ulnConfig: {
-                                        confirmations: BigInt(42),
-                                        requiredDVNs: ethReceiveUlnDVNs,
-                                        optionalDVNs: ethReceiveUlnDVNs,
-                                        optionalDVNThreshold: 1,
-                                    },
+                    const expectedTransactions = await ethEndpointV2Sdk.setConfig(ethPoint.address, ethReceiveLibrary, [
+                        ...(await ethEndpointV2Sdk.getUlnConfigParams(ethReceiveLibrary, [
+                            {
+                                eid: avaxPoint.eid,
+                                ulnConfig: {
+                                    confirmations: BigInt(42),
+                                    requiredDVNs: ethReceiveUlnDVNs,
+                                    optionalDVNs: ethReceiveUlnDVNs,
+                                    optionalDVNThreshold: 1,
                                 },
-                            ])),
-                            ...(await ethEndpointV2Sdk.getUlnConfigParams(ethReceiveLibrary, [
-                                {
-                                    eid: bscPoint.eid,
-                                    ulnConfig: {
-                                        confirmations: BigInt(24),
-                                        requiredDVNs: ethReceiveUlnDVNs,
-                                        optionalDVNs: ethReceiveUlnDVNs,
-                                        optionalDVNThreshold: 1,
-                                    },
+                            },
+                        ])),
+                        ...(await ethEndpointV2Sdk.getUlnConfigParams(ethReceiveLibrary, [
+                            {
+                                eid: bscPoint.eid,
+                                ulnConfig: {
+                                    confirmations: BigInt(24),
+                                    requiredDVNs: ethReceiveUlnDVNs,
+                                    optionalDVNs: ethReceiveUlnDVNs,
+                                    optionalDVNThreshold: 1,
                                 },
-                            ])),
-                        ]),
-                    ]
+                            },
+                        ])),
+                    ])
+
                     expect(transactions).toEqual(expectedTransactions)
                 })
 
                 it('should return one configureReceiveConfig transactions', async () => {
-                    const [_, errors] = await signAndSend([
+                    const [_, errors] = await signAndSend(
                         await ethEndpointV2Sdk.setConfig(ethPoint.address, ethReceiveLibrary, [
                             ...(await ethEndpointV2Sdk.getUlnConfigParams(ethReceiveLibrary, [
                                 {
@@ -1171,27 +1169,26 @@ describe('oapp/config', () => {
                                     },
                                 },
                             ])),
-                        ]),
-                    ])
+                        ])
+                    )
                     expect(errors).toEqual([])
 
                     // Now we configure the OApp
                     transactions = await configureOApp(graph, oappSdkFactory)
-                    const expectedTransactions = [
-                        await ethEndpointV2Sdk.setConfig(ethPoint.address, ethReceiveLibrary, [
-                            ...(await ethEndpointV2Sdk.getUlnConfigParams(ethReceiveLibrary, [
-                                {
-                                    eid: bscPoint.eid,
-                                    ulnConfig: {
-                                        confirmations: BigInt(24),
-                                        requiredDVNs: ethReceiveUlnDVNs,
-                                        optionalDVNs: ethReceiveUlnDVNs,
-                                        optionalDVNThreshold: 1,
-                                    },
+                    const expectedTransactions = await ethEndpointV2Sdk.setConfig(ethPoint.address, ethReceiveLibrary, [
+                        ...(await ethEndpointV2Sdk.getUlnConfigParams(ethReceiveLibrary, [
+                            {
+                                eid: bscPoint.eid,
+                                ulnConfig: {
+                                    confirmations: BigInt(24),
+                                    requiredDVNs: ethReceiveUlnDVNs,
+                                    optionalDVNs: ethReceiveUlnDVNs,
+                                    optionalDVNThreshold: 1,
                                 },
-                            ])),
-                        ]),
-                    ]
+                            },
+                        ])),
+                    ])
+
                     expect(transactions).toEqual(expectedTransactions)
                 })
 
@@ -1261,7 +1258,7 @@ describe('oapp/config', () => {
                 // Now we configure the OApp
                 transactions = await configureOApp(graph, oappSdkFactory)
                 expect(transactions).toEqual([
-                    await ethEndpointV2Sdk.setConfig(ethPoint.address, ethSendLibrary, [
+                    ...(await ethEndpointV2Sdk.setConfig(ethPoint.address, ethSendLibrary, [
                         ...(await ethEndpointV2Sdk.getExecutorConfigParams(ethSendLibrary, [
                             {
                                 eid: avaxPoint.eid,
@@ -1282,8 +1279,8 @@ describe('oapp/config', () => {
                                 },
                             },
                         ])),
-                    ]),
-                    await ethEndpointV2Sdk.setConfig(ethPoint.address, ethReceiveLibrary, [
+                    ])),
+                    ...(await ethEndpointV2Sdk.setConfig(ethPoint.address, ethReceiveLibrary, [
                         ...(await ethEndpointV2Sdk.getUlnConfigParams(ethReceiveLibrary, [
                             {
                                 eid: avaxPoint.eid,
@@ -1295,7 +1292,7 @@ describe('oapp/config', () => {
                                 },
                             },
                         ])),
-                    ]),
+                    ])),
                 ])
             })
 
@@ -1397,7 +1394,7 @@ describe('oapp/config', () => {
                         ethDefaultReceiveLibrary,
                         expiryEthBlock
                     ),
-                    await ethEndpointV2Sdk.setConfig(ethPoint.address, ethSendLibrary, [
+                    ...(await ethEndpointV2Sdk.setConfig(ethPoint.address, ethSendLibrary, [
                         ...(await ethEndpointV2Sdk.getExecutorConfigParams(ethSendLibrary, [
                             {
                                 eid: avaxPoint.eid,
@@ -1418,8 +1415,8 @@ describe('oapp/config', () => {
                                 },
                             },
                         ])),
-                    ]),
-                    await ethEndpointV2Sdk.setConfig(ethPoint.address, ethReceiveLibrary, [
+                    ])),
+                    ...(await ethEndpointV2Sdk.setConfig(ethPoint.address, ethReceiveLibrary, [
                         ...(await ethEndpointV2Sdk.getUlnConfigParams(ethReceiveLibrary, [
                             {
                                 eid: avaxPoint.eid,
@@ -1431,7 +1428,7 @@ describe('oapp/config', () => {
                                 },
                             },
                         ])),
-                    ]),
+                    ])),
                 ])
             })
 
@@ -1524,7 +1521,7 @@ describe('oapp/config', () => {
                         ethDefaultReceiveLibrary,
                         expiryEthBlock
                     ),
-                    await ethEndpointV2Sdk.setConfig(ethPoint.address, ethSendLibrary, [
+                    ...(await ethEndpointV2Sdk.setConfig(ethPoint.address, ethSendLibrary, [
                         ...(await ethEndpointV2Sdk.getExecutorConfigParams(ethSendLibrary, [
                             {
                                 eid: avaxPoint.eid,
@@ -1545,8 +1542,8 @@ describe('oapp/config', () => {
                                 },
                             },
                         ])),
-                    ]),
-                    await ethEndpointV2Sdk.setConfig(ethPoint.address, ethReceiveLibrary, [
+                    ])),
+                    ...(await ethEndpointV2Sdk.setConfig(ethPoint.address, ethReceiveLibrary, [
                         ...(await ethEndpointV2Sdk.getUlnConfigParams(ethReceiveLibrary, [
                             {
                                 eid: avaxPoint.eid,
@@ -1558,7 +1555,7 @@ describe('oapp/config', () => {
                                 },
                             },
                         ])),
-                    ]),
+                    ])),
                 ])
             })
 


### PR DESCRIPTION
### In this PR

- For Solana specifically, the `setConfig` function for larger projects produced transactions that were too large. This logic introduces a very naive transaction size estimation (not accounting for any lookup tables used and assuming 1 signer) and splits the `setConfig` transaction for Solana into multiple ones
- A backwards-compatible change has been introduced to `ua-devtools` to account for outdated packages being used. This ensures that the wire script will run even if an older SDK is used and only one transaction is returned from `setConfig`