### PR TITLE
🪲 Solana: Specify ULN config type when getting configuration in the SDK [32/N]

### DIFF
--- a/.changeset/famous-ties-collect.md
+++ b/.changeset/famous-ties-collect.md
@@ -1,0 +1,9 @@
+---
+"@layerzerolabs/protocol-devtools-solana": patch
+"@layerzerolabs/protocol-devtools-evm": patch
+"@layerzerolabs/protocol-devtools": patch
+"@layerzerolabs/ua-devtools": patch
+"@layerzerolabs/toolbox-hardhat": patch
+---
+
+Add ULN302 config type to EndpointV2 & ULN302 interfaces

--- a/.changeset/purple-dogs-agree.md
+++ b/.changeset/purple-dogs-agree.md
@@ -1,0 +1,5 @@
+---
+"@layerzerolabs/devtools-solana": patch
+---
+
+Add schemas for working with BN & PublicKey objects

--- a/packages/devtools-solana/package.json
+++ b/packages/devtools-solana/package.json
@@ -50,7 +50,9 @@
     "@solana/web3.js": "~1.95.0",
     "@swc/core": "^1.4.0",
     "@swc/jest": "^0.2.36",
+    "@types/bn.js": "~5.1.5",
     "@types/jest": "^29.5.12",
+    "bn.js": "^5.2.0",
     "fast-check": "^3.15.1",
     "fp-ts": "^2.16.2",
     "jest": "^29.7.0",
@@ -66,6 +68,7 @@
     "@layerzerolabs/io-devtools": "~0.1.11",
     "@layerzerolabs/lz-definitions": "^2.3.3",
     "@solana/web3.js": "~1.95.0",
+    "bn.js": "^5.2.0",
     "fp-ts": "^2.16.2",
     "zod": "^3.22.4"
   },

--- a/packages/devtools-solana/src/common/index.ts
+++ b/packages/devtools-solana/src/common/index.ts
@@ -1,1 +1,2 @@
+export * from './schema'
 export * from './types'

--- a/packages/devtools-solana/src/common/schema.ts
+++ b/packages/devtools-solana/src/common/schema.ts
@@ -1,0 +1,9 @@
+import { z } from 'zod'
+import BN from 'bn.js'
+import { PublicKey } from '@solana/web3.js'
+
+export const BNBigIntSchema = z.instanceof(BN).transform((bn) => BigInt(bn.toString()))
+
+export const PublicKeySchema = z.instanceof(PublicKey)
+
+export const PublicKeyBase58Schema = PublicKeySchema.transform((key) => key.toBase58())

--- a/packages/devtools-solana/test/common/schema.test.ts
+++ b/packages/devtools-solana/test/common/schema.test.ts
@@ -1,0 +1,47 @@
+import { BNBigIntSchema, PublicKeySchema } from '@/common/schema'
+import { keypairArbitrary } from '@layerzerolabs/test-devtools-solana'
+import BN from 'bn.js'
+import fc from 'fast-check'
+
+describe('common/schema', () => {
+    describe('BNBigIntSchema', () => {
+        const bnArbitrary: fc.Arbitrary<BN> = fc.bigInt().map((value) => new BN(value.toString()))
+
+        it('should parse a BN instance', () => {
+            fc.assert(
+                fc.property(bnArbitrary, (bn) => {
+                    expect(BNBigIntSchema.parse(bn)).toBe(BigInt(bn.toString()))
+                })
+            )
+        })
+
+        it('should not parse anything else', () => {
+            fc.assert(
+                fc.property(fc.anything(), (value) => {
+                    expect(() => BNBigIntSchema.parse(value)).toThrow(/Input not instance of BN/)
+                })
+            )
+        })
+    })
+
+    describe('PublicKeySchema', () => {
+        it('should parse a PublicKey instance', () => {
+            fc.assert(
+                fc.property(
+                    keypairArbitrary.map((keypair) => keypair.publicKey),
+                    (publicKey) => {
+                        expect(PublicKeySchema.parse(publicKey)).toBe(publicKey)
+                    }
+                )
+            )
+        })
+
+        it('should not parse anything else', () => {
+            fc.assert(
+                fc.property(fc.anything(), (value) => {
+                    expect(() => PublicKeySchema.parse(value)).toThrow(/Input not instance of PublicKey/)
+                })
+            )
+        })
+    })
+})

--- a/packages/protocol-devtools-solana/src/endpointv2/sdk.ts
+++ b/packages/protocol-devtools-solana/src/endpointv2/sdk.ts
@@ -1,8 +1,8 @@
 import { MessagingFee } from '@layerzerolabs/protocol-devtools'
 import type {
     IEndpointV2,
-    IUln302,
     SetConfigParam,
+    Uln302ConfigType,
     Uln302ExecutorConfig,
     Uln302SetUlnConfig,
     Uln302UlnConfig,
@@ -72,7 +72,7 @@ export class EndpointV2 extends OmniSDK implements IEndpointV2 {
         )
     }
 
-    async getUln302SDK(address: OmniAddress): Promise<IUln302> {
+    async getUln302SDK(address: OmniAddress): Promise<Uln302> {
         this.logger.debug(`Getting Uln302 SDK for address ${address}`)
 
         return new Uln302(this.connection, { eid: this.point.eid, address }, this.userAccount)
@@ -419,8 +419,15 @@ export class EndpointV2 extends OmniSDK implements IEndpointV2 {
     /**
      * @see {@link IUln302.getUlnConfig}
      */
-    async getUlnConfig(oapp: OmniAddress, uln: OmniAddress, eid: EndpointId): Promise<Uln302UlnConfig> {
-        this.logger.debug(`Getting ULN config for eid ${eid} (${formatEid(eid)}) and OApp ${oapp} and ULN ${uln}`)
+    async getUlnConfig(
+        oapp: OmniAddress,
+        uln: OmniAddress,
+        eid: EndpointId,
+        type: Uln302ConfigType
+    ): Promise<Uln302UlnConfig> {
+        this.logger.debug(
+            `Getting ULN ${type} config for eid ${eid} (${formatEid(eid)}) and OApp ${oapp} and ULN ${uln}`
+        )
 
         throw new TypeError(`getUlnConfig() not implemented on Solana Endpoint SDK`)
     }
@@ -428,11 +435,18 @@ export class EndpointV2 extends OmniSDK implements IEndpointV2 {
     /**
      * @see {@link IUln302.getAppUlnConfig}
      */
-    async getAppUlnConfig(oapp: OmniAddress, uln: OmniAddress, eid: EndpointId): Promise<Uln302UlnConfig> {
-        this.logger.debug(`Getting App ULN config for eid ${eid} (${formatEid(eid)}) and OApp ${oapp} and ULN ${uln}`)
+    async getAppUlnConfig(
+        oapp: OmniAddress,
+        uln: OmniAddress,
+        eid: EndpointId,
+        type: Uln302ConfigType
+    ): Promise<Uln302UlnConfig> {
+        this.logger.debug(
+            `Getting App ULN ${type} config for eid ${eid} (${formatEid(eid)}) and OApp ${oapp} and ULN ${uln}`
+        )
 
         const ulnSdk = await this.getUln302SDK(uln)
-        return await ulnSdk.getAppUlnConfig(eid, oapp)
+        return await ulnSdk.getAppUlnConfig(eid, oapp, type)
     }
 
     /**
@@ -442,12 +456,15 @@ export class EndpointV2 extends OmniSDK implements IEndpointV2 {
         oapp: OmniAddress,
         uln: OmniAddress,
         eid: EndpointId,
-        config: Uln302UlnUserConfig
+        config: Uln302UlnUserConfig,
+        type: Uln302ConfigType
     ): Promise<boolean> {
-        this.logger.debug(`Checking ULN app config for eid ${eid} (${formatEid(eid)}) and OApp ${oapp} and ULN ${uln}`)
+        this.logger.debug(
+            `Checking App ULN ${type} config for eid ${eid} (${formatEid(eid)}) and OApp ${oapp} and ULN ${uln}`
+        )
 
         const ulnSdk = await this.getUln302SDK(uln)
-        return ulnSdk.hasAppUlnConfig(eid, oapp, config)
+        return ulnSdk.hasAppUlnConfig(eid, oapp, config, type)
     }
 
     @AsyncRetriable()
@@ -465,7 +482,7 @@ export class EndpointV2 extends OmniSDK implements IEndpointV2 {
     }
 
     async getUlnConfigParams(uln: OmniAddress, setUlnConfig: Uln302SetUlnConfig[]): Promise<SetConfigParam[]> {
-        const ulnSdk = (await this.getUln302SDK(uln)) as Uln302
+        const ulnSdk = await this.getUln302SDK(uln)
 
         return setUlnConfig.map(({ eid, ulnConfig, type }) => ({
             eid,
@@ -478,7 +495,7 @@ export class EndpointV2 extends OmniSDK implements IEndpointV2 {
         uln: OmniAddress,
         setExecutorConfig: Uln302SetExecutorConfig[]
     ): Promise<SetConfigParam[]> {
-        const ulnSdk = (await this.getUln302SDK(uln)) as Uln302
+        const ulnSdk = await this.getUln302SDK(uln)
 
         return setExecutorConfig.map(({ eid, executorConfig }) => ({
             eid,

--- a/packages/protocol-devtools-solana/src/uln302/schema.ts
+++ b/packages/protocol-devtools-solana/src/uln302/schema.ts
@@ -1,0 +1,18 @@
+import { UIntBigIntSchema, UIntNumberSchema } from '@layerzerolabs/devtools'
+import { BNBigIntSchema, PublicKeyBase58Schema } from '@layerzerolabs/devtools-solana'
+import { Uln302UlnConfig } from '@layerzerolabs/protocol-devtools'
+import { z } from 'zod'
+
+export const Uln302UlnConfigInputSchema: z.ZodSchema<Uln302UlnConfig, z.ZodTypeDef, unknown> = z
+    .object({
+        confirmations: z.union([UIntBigIntSchema, BNBigIntSchema]),
+        optionalDvnThreshold: UIntNumberSchema,
+        requiredDvns: z.array(PublicKeyBase58Schema),
+        optionalDvns: z.array(PublicKeyBase58Schema),
+    })
+    .transform(({ confirmations, optionalDvnThreshold, requiredDvns, optionalDvns }) => ({
+        confirmations,
+        optionalDVNThreshold: optionalDvnThreshold,
+        requiredDVNs: requiredDvns,
+        optionalDVNs: optionalDvns,
+    }))

--- a/packages/protocol-devtools-solana/src/uln302/sdk.ts
+++ b/packages/protocol-devtools-solana/src/uln302/sdk.ts
@@ -1,6 +1,7 @@
 import type { EndpointId } from '@layerzerolabs/lz-definitions'
 import type {
     IUln302,
+    Uln302ConfigType,
     Uln302ExecutorConfig,
     Uln302UlnConfig,
     Uln302UlnUserConfig,
@@ -14,7 +15,7 @@ import {
     OmniPoint,
     mapError,
 } from '@layerzerolabs/devtools'
-import { Logger, printJson } from '@layerzerolabs/io-devtools'
+import { Logger, printBoolean, printJson } from '@layerzerolabs/io-devtools'
 import { AsyncRetriable } from '@layerzerolabs/devtools'
 import { OmniSDK } from '@layerzerolabs/devtools-solana'
 import { UlnProgram } from '@layerzerolabs/lz-solana-sdk-v2'
@@ -34,8 +35,12 @@ export class Uln302 extends OmniSDK implements IUln302 {
      * @see {@link IUln302.getUlnConfig}
      */
     @AsyncRetriable()
-    async getUlnConfig(eid: EndpointId, address?: OmniAddress | null | undefined): Promise<Uln302UlnConfig> {
-        this.logger.debug(`Getting ULN config for eid ${eid} (${formatEid(eid)}) and address ${address}`)
+    async getUlnConfig(
+        eid: EndpointId,
+        address: OmniAddress | null | undefined,
+        type: Uln302ConfigType
+    ): Promise<Uln302UlnConfig> {
+        this.logger.debug(`Getting ULN ${type} config for eid ${eid} (${formatEid(eid)}) and address ${address}`)
 
         throw new TypeError(`getUlnConfig() not implemented on Solana Endpoint SDK`)
     }
@@ -44,10 +49,10 @@ export class Uln302 extends OmniSDK implements IUln302 {
      * @see {@link IUln302.getAppUlnConfig}
      */
     @AsyncRetriable()
-    async getAppUlnConfig(eid: EndpointId, address: OmniAddress): Promise<Uln302UlnConfig> {
+    async getAppUlnConfig(eid: EndpointId, address: OmniAddress, type: Uln302ConfigType): Promise<Uln302UlnConfig> {
         const eidLabel = formatEid(eid)
 
-        this.logger.debug(`Getting ULN config for eid ${eid} (${eidLabel}) and address ${address}`)
+        this.logger.debug(`Getting App ULN ${type} config for eid ${eid} (${eidLabel}) and address ${address}`)
 
         const config = await mapError(
             async () => {
@@ -56,18 +61,20 @@ export class Uln302 extends OmniSDK implements IUln302 {
                 return (
                     (await this.program.getReceiveConfigState(this.connection, publicKey, eid)) ??
                     (this.logger.warn(
-                        `Got an empty ULN config for OApp ${address} and ${eidLabel}, getting the default one`
+                        `Got an empty App ULN ${type} config for OApp ${address} and ${eidLabel}, getting the default one`
                     ),
                     await this.program.getDefaultReceiveConfigState(this.connection, eid))
                 )
             },
             (error) =>
-                new Error(`Failed to get ULN config for ${this.label} for OApp ${address} and ${eidLabel}: ${error}`)
+                new Error(
+                    `Failed to get App ULN ${type} config for ${this.label} for OApp ${address} and ${eidLabel}: ${error}`
+                )
         )
 
         assert(
             config != null,
-            `Could not get OApp ULN config for ${this.label} and OApp ${address} and ${eidLabel}: Neither app nor default configs have been specified`
+            `Could not get App ULN ${type} config for ${this.label} and OApp ${address} and ${eidLabel}: Neither OApp nor default configs have been specified`
         )
 
         return {
@@ -85,26 +92,33 @@ export class Uln302 extends OmniSDK implements IUln302 {
     /**
      * @see {@link IUln302.hasAppUlnConfig}
      */
-    async hasAppUlnConfig(eid: EndpointId, oapp: string, config: Uln302UlnUserConfig): Promise<boolean> {
-        const currentConfig = await this.getAppUlnConfig(eid, oapp)
+    async hasAppUlnConfig(
+        eid: EndpointId,
+        oapp: string,
+        config: Uln302UlnUserConfig,
+        type: Uln302ConfigType
+    ): Promise<boolean> {
+        this.logger.verbose(
+            `Checking whether App ULN ${type} configs for eid ${eid} (${formatEid(eid)}) and OApp ${oapp} match`
+        )
+
+        const currentConfig = await this.getAppUlnConfig(eid, oapp, type)
         const currentSerializedConfig = this.serializeUlnConfig(currentConfig)
         const serializedConfig = this.serializeUlnConfig(config)
 
-        this.logger.debug(`Checking whether ULN configs for eid ${eid} (${formatEid(eid)}) and OApp ${oapp} match`)
-        this.logger.debug(`Current config: ${printJson(currentSerializedConfig)}`)
-        this.logger.debug(`Incoming config: ${printJson(serializedConfig)}`)
+        this.logger.debug(`Current App ULN ${type} config: ${printJson(currentSerializedConfig)}`)
+        this.logger.debug(`Incoming App ULN ${type} config: ${printJson(serializedConfig)}`)
 
-        return isDeepEqual(serializedConfig, currentSerializedConfig)
+        const areEqual = isDeepEqual(serializedConfig, currentSerializedConfig)
+
+        return this.logger.verbose(`Checked App ULN ${type} configs: ${printBoolean(areEqual)}`), areEqual
     }
 
     /**
      * @see {@link IUln302.getExecutorConfig}
      */
     @AsyncRetriable()
-    async getExecutorConfig(
-        _eid: EndpointId,
-        _address?: OmniAddress | null | undefined
-    ): Promise<Uln302ExecutorConfig> {
+    async getExecutorConfig(): Promise<Uln302ExecutorConfig> {
         throw new TypeError(`getExecutorConfig() not implemented on Solana Endpoint SDK`)
     }
 

--- a/packages/protocol-devtools/src/endpointv2/types.ts
+++ b/packages/protocol-devtools/src/endpointv2/types.ts
@@ -10,7 +10,13 @@ import type {
     Configurator,
 } from '@layerzerolabs/devtools'
 import type { EndpointId } from '@layerzerolabs/lz-definitions'
-import type { IUln302, Uln302ExecutorConfig, Uln302UlnConfig, Uln302UlnUserConfig } from '@/uln302/types'
+import type {
+    IUln302,
+    Uln302ConfigType,
+    Uln302ExecutorConfig,
+    Uln302UlnConfig,
+    Uln302UlnUserConfig,
+} from '@/uln302/types'
 
 export interface IEndpointV2 extends IOmniSDK {
     getUln302SDK(address: OmniAddress): Promise<IUln302>
@@ -127,7 +133,7 @@ export interface IEndpointV2 extends IOmniSDK {
      * Gets the ULN config for a given OApp, library and a destination
      * endpoint ID.
      *
-     * If there is no executor config specified, this function will return the default
+     * If there is no ULN config specified, this function will return the default
      * config set for this library and EndpointID
      *
      * @see {@link getAppUlnConfig}
@@ -135,8 +141,9 @@ export interface IEndpointV2 extends IOmniSDK {
      * @param {PossiblyBytes} oapp OApp address
      * @param {PossiblyBytes} uln Library address
      * @param {EndpointId} eid Endpoint ID
+     * @param {Uln302ConfigType} type
      */
-    getUlnConfig(oapp: OmniAddress, uln: OmniAddress, eid: EndpointId): Promise<Uln302UlnConfig>
+    getUlnConfig(oapp: OmniAddress, uln: OmniAddress, eid: EndpointId, type: Uln302ConfigType): Promise<Uln302UlnConfig>
 
     /**
      * Gets the ULN config for a given OApp, library and a destination
@@ -150,8 +157,14 @@ export interface IEndpointV2 extends IOmniSDK {
      * @param {PossiblyBytes} oapp OApp address
      * @param {PossiblyBytes} uln Library address
      * @param {EndpointId} eid Endpoint ID
+     * @param {Uln302ConfigType} type
      */
-    getAppUlnConfig(oapp: OmniAddress, uln: OmniAddress, eid: EndpointId): Promise<Uln302UlnConfig>
+    getAppUlnConfig(
+        oapp: OmniAddress,
+        uln: OmniAddress,
+        eid: EndpointId,
+        type: Uln302ConfigType
+    ): Promise<Uln302UlnConfig>
 
     /**
      * Checks whether a given `config` is set explicitly for a given OApp
@@ -163,9 +176,16 @@ export interface IEndpointV2 extends IOmniSDK {
      * @param {OmniAddress} uln
      * @param {EndpointId} eid
      * @param {Uln302UlnUserConfig} config
+     * @param {Uln302ConfigType} type
      * @returns {Promise<boolean>} `true` if the config has been explicitly set, `false` otherwise
      */
-    hasAppUlnConfig(oapp: OmniAddress, uln: OmniAddress, eid: EndpointId, config: Uln302UlnUserConfig): Promise<boolean>
+    hasAppUlnConfig(
+        oapp: OmniAddress,
+        uln: OmniAddress,
+        eid: EndpointId,
+        config: Uln302UlnUserConfig,
+        type: Uln302ConfigType
+    ): Promise<boolean>
 
     setUlnConfig(oapp: OmniAddress, uln: OmniAddress, setUlnConfig: Uln302SetUlnConfig[]): Promise<OmniTransaction[]>
 
@@ -182,7 +202,7 @@ export interface Uln302SetExecutorConfig {
 }
 
 export interface Uln302SetUlnConfig {
-    type: 'send' | 'receive'
+    type: Uln302ConfigType
     eid: EndpointId
     ulnConfig: Uln302UlnUserConfig
 }

--- a/packages/protocol-devtools/src/uln302/types.ts
+++ b/packages/protocol-devtools/src/uln302/types.ts
@@ -9,6 +9,11 @@ import type {
 } from '@layerzerolabs/devtools'
 import type { EndpointId } from '@layerzerolabs/lz-definitions'
 
+export enum Uln302ConfigType {
+    Send = 'send',
+    Receive = 'receive',
+}
+
 export interface IUln302 extends IOmniSDK {
     /**
      * Gets the ULN config for a given endpoint ID and an address.
@@ -19,9 +24,14 @@ export interface IUln302 extends IOmniSDK {
      * @see {@link getAppUlnConfig}
      *
      * @param {EndpointId} eid Endpoint ID
-     * @param {PossiblyBytes} address
+     * @param {OmniAddress | null | undefined} address
+     * @param {Uln302ConfigType} type
      */
-    getUlnConfig(eid: EndpointId, address?: OmniAddress | null | undefined): Promise<Uln302UlnConfig>
+    getUlnConfig(
+        eid: EndpointId,
+        address: OmniAddress | null | undefined,
+        type: Uln302ConfigType
+    ): Promise<Uln302UlnConfig>
 
     /**
      * Gets the ULN config for a given endpoint ID and an address.
@@ -32,9 +42,10 @@ export interface IUln302 extends IOmniSDK {
      * @see {@link getUlnConfig}
      *
      * @param {EndpointId} eid Endpoint ID
-     * @param {PossiblyBytes} address
+     * @param {OmniAddress} address
+     * @param {Uln302ConfigType} type
      */
-    getAppUlnConfig(eid: EndpointId, address: OmniAddress): Promise<Uln302UlnConfig>
+    getAppUlnConfig(eid: EndpointId, address: OmniAddress, type: Uln302ConfigType): Promise<Uln302UlnConfig>
 
     /**
      * Checks whether a given `config` is set explicitly on a given OApp.
@@ -45,9 +56,15 @@ export interface IUln302 extends IOmniSDK {
      * @param {EndpointId} eid
      * @param {OmniAddress} oapp
      * @param {Uln302UlnUserConfig} config
+     * @param {Uln302ConfigType} type
      * @returns {Promise<boolean>} `true` if the config has been explicitly set, `false` otherwise
      */
-    hasAppUlnConfig(eid: EndpointId, oapp: OmniAddress, config: Uln302UlnUserConfig): Promise<boolean>
+    hasAppUlnConfig(
+        eid: EndpointId,
+        oapp: OmniAddress,
+        config: Uln302UlnUserConfig,
+        type: Uln302ConfigType
+    ): Promise<boolean>
 
     setDefaultUlnConfig(eid: EndpointId, config: Uln302UlnUserConfig): Promise<OmniTransaction>
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1043,9 +1043,15 @@ importers:
       '@swc/jest':
         specifier: ^0.2.36
         version: 0.2.36(@swc/core@1.4.0)
+      '@types/bn.js':
+        specifier: ~5.1.5
+        version: 5.1.5
       '@types/jest':
         specifier: ^29.5.12
         version: 29.5.12
+      bn.js:
+        specifier: ^5.2.0
+        version: 5.2.1
       fast-check:
         specifier: ^3.15.1
         version: 3.15.1


### PR DESCRIPTION
### In this PR

- Solana `Uln302` SDK had a bug where it was returning the receive config for both send & receive configuration. This was because on Solana the send and receive addresses are/can be the same and we need to specify which config we want
- A `type` parameter has been added to SDKs and configs and logging was adjusted to better reflect on what's going on. For the EVM implementation this type is only displayed in the logs and has no functional meaning - if not passed (e.g. when somebody partially updates the devtools packages), everything will still work so no polyfill necessary
- `getAppUlnConfig` no longer uses the defaults as the fallback, instead, it returns an empty config
- A schema was introduced instead of inline parsing for `getAppUlnConfig`