### PR TITLE
🧹 Solana: Add a stub of account initialization functionality for OFT [33/N]

### DIFF
--- a/.changeset/flat-elephants-kneel.md
+++ b/.changeset/flat-elephants-kneel.md
@@ -1,0 +1,6 @@
+---
+"@layerzerolabs/protocol-devtools-solana": patch
+"@layerzerolabs/ua-devtools-solana": patch
+---
+
+Add nonce initialization functionality for OFT SDK on Solana

--- a/packages/ua-devtools-solana/src/oft/config.ts
+++ b/packages/ua-devtools-solana/src/oft/config.ts
@@ -1,0 +1,56 @@
+import {
+    type OmniVector,
+    type CreateTransactionsFromOmniEdges,
+    formatOmniVector,
+    createConfigureEdges,
+    createConfigureMultiple,
+} from '@layerzerolabs/devtools'
+import { createModuleLogger } from '@layerzerolabs/io-devtools'
+import { endpointIdToChainType, ChainType } from '@layerzerolabs/lz-definitions'
+import type { IOApp, OAppConfigurator, OAppOmniGraph } from '@layerzerolabs/ua-devtools'
+import { OFT } from './sdk'
+
+const createOFTLogger = () => createModuleLogger('OFT')
+
+/**
+ * Helper function that checks whether a vector originates from a Solana network
+ *
+ * @param {OmniVector} vector
+ * @returns {boolean}
+ */
+const isVectorFromSolana = (vector: OmniVector): boolean => endpointIdToChainType(vector.from.eid) === ChainType.SOLANA
+
+/**
+ * Helper function that wraps a edge configuration function,
+ * only executing it for edges that originate in Solana
+ *
+ * @param {CreateTransactionsFromOmniEdges<OAppOmniGraph, IOApp>} createTransactions
+ * @returns {CreateTransactionsFromOmniEdges<OAppOmniGraph, IOApp>}
+ */
+const onlyEdgesFromSolana = (
+    createTransactions: CreateTransactionsFromOmniEdges<OAppOmniGraph, IOApp>
+): CreateTransactionsFromOmniEdges<OAppOmniGraph, IOApp> => {
+    const logger = createOFTLogger()
+
+    return (edge, sdk, graph, createSdk) => {
+        if (!isVectorFromSolana(edge.vector)) {
+            return logger.verbose(`Ignoring connection ${formatOmniVector(edge.vector)}`), undefined
+        }
+
+        return createTransactions(edge, sdk, graph, createSdk)
+    }
+}
+
+export const initNonce: OAppConfigurator = createConfigureEdges(
+    onlyEdgesFromSolana(({ vector }, sdk) => {
+        const logger = createOFTLogger()
+
+        if (typeof (sdk as OFT).initializeNonce !== 'function') {
+            return logger.warn(`Could not find initializeNonce() method on OFT SDK, skipping`), undefined
+        }
+
+        return (sdk as OFT).initializeNonce(vector.to.eid, vector.to.address)
+    })
+)
+
+export const initOFTAccounts = createConfigureMultiple(initNonce)

--- a/packages/ua-devtools-solana/src/oft/index.ts
+++ b/packages/ua-devtools-solana/src/oft/index.ts
@@ -1,2 +1,3 @@
+export * from './config'
 export * from './factory'
 export * from './sdk'

--- a/packages/ua-devtools-solana/src/oft/sdk.ts
+++ b/packages/ua-devtools-solana/src/oft/sdk.ts
@@ -14,9 +14,8 @@ import {
     toHex,
 } from '@layerzerolabs/devtools'
 import type { EndpointId } from '@layerzerolabs/lz-definitions'
-import type { IEndpointV2 } from '@layerzerolabs/protocol-devtools'
 import { EndpointV2 } from '@layerzerolabs/protocol-devtools-solana'
-import { Logger, printBoolean, printJson } from '@layerzerolabs/io-devtools'
+import { type Logger, printBoolean, printJson } from '@layerzerolabs/io-devtools'
 import { mapError, AsyncRetriable } from '@layerzerolabs/devtools'
 import { OmniSDK } from '@layerzerolabs/devtools-solana'
 import { Connection, PublicKey, Transaction } from '@solana/web3.js'
@@ -80,7 +79,7 @@ export class OFT extends OmniSDK implements IOApp {
     }
 
     @AsyncRetriable()
-    async getEndpointSDK(): Promise<IEndpointV2> {
+    async getEndpointSDK(): Promise<EndpointV2> {
         this.logger.debug(`Getting EndpointV2 SDK`)
 
         return new EndpointV2(
@@ -232,6 +231,13 @@ export class OFT extends OmniSDK implements IOApp {
             ...(await this.createTransaction(transaction)),
             description: `Setting enforced options to ${printJson(enforcedOptions)}`,
         }
+    }
+
+    async initializeNonce(eid: EndpointId, peer: OmniAddress): Promise<[OmniTransaction] | []> {
+        this.logger.verbose(`Initializing OApp nonce`)
+
+        const endpointSdk = await this.getEndpointSDK()
+        return endpointSdk.initializeOAppNonce(this.point.address, eid, peer)
     }
 
     /**


### PR DESCRIPTION
### In this PR

- As demanded at a gunpoint by @St0rmBr3w , the Solana devtools for OFT should provide a convenient way of initializing the OFT-related accounts. This PR adds the first step, a configuration function that can be imported & plugged into a wire task
- At this point only nonce initialization is available