### PR TITLE
🧹 Solana: Add a feature flagged functionality for reassigning recent block hashes in solana signer [34/N]

### DIFF
--- a/.changeset/late-bottles-perform.md
+++ b/.changeset/late-bottles-perform.md
@@ -1,0 +1,5 @@
+---
+"@layerzerolabs/devtools-solana": patch
+---
+
+Add a feature flagged functionality for reassigning recent block hashes in solana signer

--- a/packages/devtools-solana/src/transactions/signer.ts
+++ b/packages/devtools-solana/src/transactions/signer.ts
@@ -18,6 +18,7 @@ import {
 } from '@solana/web3.js'
 import { EndpointId } from '@layerzerolabs/lz-definitions'
 import { deserializeTransactionMessage, serializeTransactionBuffer } from './serde'
+import { createModuleLogger, type Logger } from '@layerzerolabs/io-devtools'
 
 export class OmniSignerSolana extends OmniSignerBase implements OmniSigner {
     constructor(
@@ -25,7 +26,8 @@ export class OmniSignerSolana extends OmniSignerBase implements OmniSigner {
         public readonly connection: Connection,
         public readonly signer: Signer,
         public readonly lookupAddress?: PublicKey,
-        public readonly confirmOptions: ConfirmOptions = { commitment: 'finalized' }
+        public readonly confirmOptions: ConfirmOptions = { commitment: 'finalized' },
+        protected readonly logger: Logger = createModuleLogger('OmniSignerSolana')
     ) {
         super(eid)
     }
@@ -90,7 +92,7 @@ export class OmniSignerSolana extends OmniSignerBase implements OmniSigner {
     ): Promise<OmniTransactionResponse<OmniTransactionReceipt>> {
         const signature = await sendAndConfirmTransaction(
             this.connection,
-            transaction,
+            await this.updateRecentBlockHash(transaction),
             [this.signer],
             this.confirmOptions
         )
@@ -101,5 +103,38 @@ export class OmniSignerSolana extends OmniSignerBase implements OmniSigner {
                 transactionHash: signature,
             }),
         }
+    }
+
+    /**
+     * To prevent transactions from expiring, we will update their recentBlockHash values
+     * just before signing (if the feature flag is enabled)
+     *
+     * @param {Transaction} transaction
+     * @returns {Promise<Transaction>}
+     */
+    protected async updateRecentBlockHash(transaction: Transaction): Promise<Transaction> {
+        if (!process.env.LZ_ENABLE_EXPERIMENTAL_SOLANA_RECENT_BLOCK_HASH_UPDATE) {
+            return transaction
+        }
+
+        // If this feature flag is enabled, we'll update the transactions with a new recentBlockHash
+        // just in time before signing & sending the transaction
+        this.logger.warn(
+            `You are using experimental feature to update a recentBlockHash for transactions. Set log level to verbose for more information`
+        )
+
+        try {
+            const { blockhash } = await this.connection.getLatestBlockhash('finalized')
+
+            this.logger.verbose(
+                `Updating transaction recentBlockHash from ${transaction.recentBlockhash} to ${blockhash}`
+            )
+
+            transaction.recentBlockhash = blockhash
+        } catch (error) {
+            this.logger.verbose(`Failed to get recentBlockHash from the network: ${error}`)
+        }
+
+        return transaction
     }
 }


### PR DESCRIPTION
### In this PR

- Make `OmniSolanaSigner` assign a recent block hash just before signing & sending a transaction to avoid problems with expiring block hashes
- If this feature flagged functionality works, we might want to scrape it from the SDKs completely (the recent block hash is assigned when creating a transaction so that it can be serialized and we might be able to replace a real block hash with `PublicKey(0).toBase58()`)