### PR TITLE
chore:  fuji-testnet should be called avalanche-testnet to match url.ts

### DIFF
--- a/.changeset/young-ants-drive.md
+++ b/.changeset/young-ants-drive.md
@@ -1,0 +1,8 @@
+---
+"@layerzerolabs/oft-adapter-example": patch
+"@layerzerolabs/onft721-example": patch
+"@layerzerolabs/oapp-example": patch
+"@layerzerolabs/oft-example": patch
+---
+
+Fix avalanche-testnet url

--- a/examples/oapp/hardhat.config.ts
+++ b/examples/oapp/hardhat.config.ts
@@ -57,7 +57,7 @@ const config: HardhatUserConfig = {
             url: process.env.RPC_URL_SEPOLIA || 'https://rpc.sepolia.org/',
             accounts,
         },
-        'fuji-testnet': {
+        'avalanche-testnet': {
             eid: EndpointId.AVALANCHE_V2_TESTNET,
             url: process.env.RPC_URL_FUJI || 'https://rpc.ankr.com/avalanche_fuji',
             accounts,

--- a/examples/oft-adapter/hardhat.config.ts
+++ b/examples/oft-adapter/hardhat.config.ts
@@ -62,7 +62,7 @@ const config: HardhatUserConfig = {
                 tokenAddress: '0x0', // Set the token address for the OFT adapter
             },
         },
-        'fuji-testnet': {
+        'avalanche-testnet': {
             eid: EndpointId.AVALANCHE_V2_TESTNET,
             url: process.env.RPC_URL_FUJI || 'https://rpc.ankr.com/avalanche_fuji',
             accounts,

--- a/examples/oft/hardhat.config.ts
+++ b/examples/oft/hardhat.config.ts
@@ -57,7 +57,7 @@ const config: HardhatUserConfig = {
             url: process.env.RPC_URL_SEPOLIA || 'https://rpc.sepolia.org/',
             accounts,
         },
-        'fuji-testnet': {
+        'avalanche-testnet': {
             eid: EndpointId.AVALANCHE_V2_TESTNET,
             url: process.env.RPC_URL_FUJI || 'https://rpc.ankr.com/avalanche_fuji',
             accounts,

--- a/examples/onft721/hardhat.config.ts
+++ b/examples/onft721/hardhat.config.ts
@@ -57,7 +57,7 @@ const config: HardhatUserConfig = {
             url: process.env.RPC_URL_SEPOLIA || 'https://rpc.sepolia.org/',
             accounts,
         },
-        'fuji-testnet': {
+        'avalanche-testnet': {
             eid: EndpointId.AVALANCHE_V2_TESTNET,
             url: process.env.RPC_URL_FUJI || 'https://rpc.ankr.com/avalanche_fuji',
             accounts,


### PR DESCRIPTION
Match the name to what is used for verification tool.