### PR TITLE
🗞️ Solana: Add account initialization checkers for OFT [37/N]

### DIFF
--- a/.changeset/clean-bugs-clap.md
+++ b/.changeset/clean-bugs-clap.md
@@ -1,0 +1,6 @@
+---
+"@layerzerolabs/ua-devtools": patch
+"@layerzerolabs/toolbox-hardhat": patch
+---
+
+Update log levels in OApp configuration

--- a/.changeset/heavy-onions-march.md
+++ b/.changeset/heavy-onions-march.md
@@ -1,0 +1,7 @@
+---
+"@layerzerolabs/protocol-devtools-solana": patch
+"@layerzerolabs/ua-devtools-solana": patch
+"@layerzerolabs/devtools-solana": patch
+---
+
+Add initialization getter methods to OFT & EndpointV2 SDKs

--- a/.changeset/poor-days-double.md
+++ b/.changeset/poor-days-double.md
@@ -1,0 +1,6 @@
+---
+"@layerzerolabs/ua-devtools-solana": patch
+"@layerzerolabs/devtools-solana": patch
+---
+
+Add account info helpers

--- a/packages/devtools-solana/src/common/accounts.ts
+++ b/packages/devtools-solana/src/common/accounts.ts
@@ -1,0 +1,18 @@
+import { Factory, mapError, OmniAddress } from '@layerzerolabs/devtools'
+import { createModuleLogger, Logger, printJson } from '@layerzerolabs/io-devtools'
+import { AccountInfo, Connection, PublicKey } from '@solana/web3.js'
+
+export type GetAccountInfo = Factory<[OmniAddress], AccountInfo<Buffer> | undefined>
+
+export const createGetAccountInfo =
+    (connection: Connection, logger: Logger = createModuleLogger('Solana account info')): GetAccountInfo =>
+    async (account: OmniAddress): Promise<AccountInfo<Buffer> | undefined> => {
+        logger.debug(`Getting account info for ${account}`)
+
+        const accountInfo = await mapError(
+            async () => connection.getAccountInfo(new PublicKey(account)),
+            (error) => new Error(`Failed to get account info for ${account}: ${error}`)
+        )
+
+        return logger.debug(`Got account info for ${account}:\n\n${printJson(accountInfo)}`), accountInfo ?? undefined
+    }

--- a/packages/devtools-solana/src/common/index.ts
+++ b/packages/devtools-solana/src/common/index.ts
@@ -1,2 +1,3 @@
+export * from './accounts'
 export * from './schema'
 export * from './types'

--- a/packages/devtools-solana/src/omnigraph/coordinates.ts
+++ b/packages/devtools-solana/src/omnigraph/coordinates.ts
@@ -1,0 +1,4 @@
+import { OmniPoint } from '@layerzerolabs/devtools'
+import { ChainType, endpointIdToChainType } from '@layerzerolabs/lz-definitions'
+
+export const isOmniPointOnSolana = ({ eid }: OmniPoint): boolean => endpointIdToChainType(eid) === ChainType.SOLANA

--- a/packages/devtools-solana/src/omnigraph/index.ts
+++ b/packages/devtools-solana/src/omnigraph/index.ts
@@ -1,2 +1,3 @@
+export * from './coordinates'
 export * from './sdk'
 export * from './types'

--- a/packages/devtools-solana/test/common/accounts.test.ts
+++ b/packages/devtools-solana/test/common/accounts.test.ts
@@ -1,0 +1,61 @@
+import { createGetAccountInfo } from '@/common/accounts'
+import { ConnectionFactory, createConnectionFactory, createRpcUrlFactory } from '@/connection'
+import { EndpointId } from '@layerzerolabs/lz-definitions'
+import { solanaEndpointArbitrary } from '@layerzerolabs/test-devtools'
+import { keypairArbitrary } from '@layerzerolabs/test-devtools-solana'
+import { Connection } from '@solana/web3.js'
+import fc from 'fast-check'
+
+describe('common/accounts', () => {
+    // FIXME These tests are using a mainnet OFT deployment and are potentially very fragile
+    //
+    // We need to run our own Solana node with the OFT account cloned
+    // so that we can isolate these tests
+    const oftConfig = { eid: EndpointId.SOLANA_V2_MAINNET, address: '8aFeCEhGLwbWHWiiezLAKanfD5Cn3BW3nP6PZ54K9LYC' }
+
+    let connectionFactory: ConnectionFactory
+    let getAccountInfoMock: jest.SpyInstance
+
+    beforeAll(() => {
+        connectionFactory = createConnectionFactory(
+            createRpcUrlFactory({
+                [EndpointId.SOLANA_V2_MAINNET]: process.env.RPC_URL_SOLANA_MAINNET,
+                [EndpointId.SOLANA_V2_TESTNET]: process.env.RPC_URL_SOLANA_TESTNET,
+            })
+        )
+    })
+
+    beforeEach(() => {
+        getAccountInfoMock = jest.spyOn(Connection.prototype, 'getAccountInfo')
+    })
+
+    afterEach(() => {
+        getAccountInfoMock.mockRestore()
+    })
+
+    describe('createGetAccountInfo', () => {
+        it('should return account info if the account has been initialized', async () => {
+            const connection = await connectionFactory(oftConfig.eid)
+            const getAccountInfo = createGetAccountInfo(connection)
+
+            expect(await getAccountInfo(oftConfig.address)).not.toBeUndefined()
+        })
+
+        it('should return undefined if the account has not been initialized', async () => {
+            getAccountInfoMock.mockResolvedValue(null)
+
+            await fc.assert(
+                fc.asyncProperty(solanaEndpointArbitrary, keypairArbitrary, async (eid, keypair) => {
+                    fc.pre(eid !== EndpointId.SOLANA_V2_SANDBOX)
+
+                    const address = keypair.publicKey.toBase58()
+
+                    const connection = await connectionFactory(oftConfig.eid)
+                    const getAccountInfo = createGetAccountInfo(connection)
+
+                    expect(await getAccountInfo(address)).toBeUndefined()
+                })
+            )
+        })
+    })
+})

--- a/packages/protocol-devtools-solana/src/endpointv2/sdk.ts
+++ b/packages/protocol-devtools-solana/src/endpointv2/sdk.ts
@@ -510,6 +510,21 @@ export class EndpointV2 extends OmniSDK implements IEndpointV2 {
         }))
     }
 
+    async isOAppNonceInitialized(oapp: OmniAddress, eid: EndpointId, peer: OmniAddress): Promise<boolean> {
+        const eidLabel = formatEid(eid)
+        this.logger.verbose(`Checking OApp nonce for OApp ${oapp} and peer ${peer} on ${eidLabel}`)
+
+        return mapError(
+            async () => {
+                const [nonce] = this.deriver.nonce(new PublicKey(oapp), eid, normalizePeer(peer, eid))
+
+                return this.isAccountInitialized(nonce.toBase58())
+            },
+            (error) =>
+                new Error(`Failed to check OApp nonce for OApp ${oapp} and peer ${peer} on ${eidLabel}: ${error}`)
+        )
+    }
+
     async initializeOAppNonce(oapp: OmniAddress, eid: EndpointId, peer: OmniAddress): Promise<[OmniTransaction] | []> {
         const eidLabel = formatEid(eid)
         this.logger.verbose(`Initializing OApp nonce for OApp ${oapp} and peer ${peer} on ${eidLabel}`)
@@ -546,6 +561,23 @@ export class EndpointV2 extends OmniSDK implements IEndpointV2 {
         ]
     }
 
+    async isSendLibraryInitialized(oapp: OmniAddress, eid: EndpointId) {
+        const eidLabel = formatEid(eid)
+        this.logger.verbose(`Checking OApp send library initialization status for OApp ${oapp} on ${eidLabel}`)
+
+        return mapError(
+            async () => {
+                const [sendLibraryConfig] = this.deriver.sendLibraryConfig(new PublicKey(oapp), eid)
+
+                return this.isAccountInitialized(sendLibraryConfig.toBase58())
+            },
+            (error) =>
+                new Error(
+                    `Failed to check OApp send library initialization status for OApp ${oapp} on ${eidLabel}: ${error}`
+                )
+        )
+    }
+
     async initializeSendLibrary(oapp: OmniAddress, eid: EndpointId): Promise<[OmniTransaction] | []> {
         const eidLabel = formatEid(eid)
         this.logger.verbose(`Initializing OApp send library for OApp ${oapp} on ${eidLabel}`)
@@ -566,6 +598,23 @@ export class EndpointV2 extends OmniSDK implements IEndpointV2 {
                 description: `Initializing send library for OApp ${oapp} on ${eidLabel}`,
             },
         ]
+    }
+
+    async isReceiveLibraryInitialized(oapp: OmniAddress, eid: EndpointId) {
+        const eidLabel = formatEid(eid)
+        this.logger.verbose(`Checking OApp receive library initialization status for OApp ${oapp} on ${eidLabel}`)
+
+        return mapError(
+            async () => {
+                const [receiveLibraryConfig] = this.deriver.receiveLibraryConfig(new PublicKey(oapp), eid)
+
+                return this.isAccountInitialized(receiveLibraryConfig.toBase58())
+            },
+            (error) =>
+                new Error(
+                    `Failed to check OApp receive library initialization status for OApp ${oapp} on ${eidLabel}: ${error}`
+                )
+        )
     }
 
     async initializeReceiveLibrary(oapp: OmniAddress, eid: EndpointId): Promise<[OmniTransaction] | []> {
@@ -590,6 +639,22 @@ export class EndpointV2 extends OmniSDK implements IEndpointV2 {
                 description: `Initializing receive library for OApp ${oapp} on ${eidLabel}`,
             },
         ]
+    }
+
+    async isOAppConfigInitialized(oapp: OmniAddress, eid: EndpointId): Promise<boolean> {
+        const eidLabel = formatEid(eid)
+        this.logger.verbose(`Checking OApp config initialization status for OApp ${oapp} on ${eidLabel}`)
+
+        return mapError(
+            async () => {
+                // TODO Verify that this is the only account that needs to be checked for the verification status
+                const [oappRegistry] = this.deriver.oappRegistry(new PublicKey(oapp))
+
+                return this.isAccountInitialized(oappRegistry.toBase58())
+            },
+            (error) =>
+                new Error(`Failed to check OApp config initialization status for OApp ${oapp} on ${eidLabel}: ${error}`)
+        )
     }
 
     async initializeOAppConfig(

--- a/packages/ua-devtools-solana/src/oft/sdk.ts
+++ b/packages/ua-devtools-solana/src/oft/sdk.ts
@@ -233,11 +233,21 @@ export class OFT extends OmniSDK implements IOApp {
         }
     }
 
+    async isNonceInitialized(eid: EndpointId, peer: OmniAddress): Promise<boolean> {
+        const endpointSdk = await this.getEndpointSDK()
+        return endpointSdk.isOAppNonceInitialized(this.point.address, eid, peer)
+    }
+
     async initializeNonce(eid: EndpointId, peer: OmniAddress): Promise<[OmniTransaction] | []> {
         this.logger.verbose(`Initializing OApp nonce for peer ${peer} on ${formatEid(eid)}`)
 
         const endpointSdk = await this.getEndpointSDK()
         return endpointSdk.initializeOAppNonce(this.point.address, eid, peer)
+    }
+
+    async isSendLibraryInitialized(eid: EndpointId): Promise<boolean> {
+        const endpointSdk = await this.getEndpointSDK()
+        return endpointSdk.isSendLibraryInitialized(this.point.address, eid)
     }
 
     async initializeSendLibrary(eid: EndpointId): Promise<[OmniTransaction] | []> {
@@ -247,11 +257,21 @@ export class OFT extends OmniSDK implements IOApp {
         return endpointSdk.initializeSendLibrary(this.point.address, eid)
     }
 
+    async isReceiveLibraryInitialized(eid: EndpointId): Promise<boolean> {
+        const endpointSdk = await this.getEndpointSDK()
+        return endpointSdk.isReceiveLibraryInitialized(this.point.address, eid)
+    }
+
     async initializeReceiveLibrary(eid: EndpointId): Promise<[OmniTransaction] | []> {
         this.logger.verbose(`Initializing receive library on ${formatEid(eid)}`)
 
         const endpointSdk = await this.getEndpointSDK()
         return endpointSdk.initializeReceiveLibrary(this.point.address, eid)
+    }
+
+    async isOAppConfigInitialized(eid: EndpointId): Promise<boolean> {
+        const endpointSdk = await this.getEndpointSDK()
+        return endpointSdk.isOAppConfigInitialized(this.point.address, eid)
     }
 
     async initializeOAppConfig(eid: EndpointId, lib: OmniAddress | null | undefined): Promise<[OmniTransaction] | []> {


### PR DESCRIPTION
### In this PR

- Add account initialization status checkers to `OFT` and `EndpointV2` SDK. These are used in the initialization configurator to check whether we need to initialize `OApp` nonce, send & receive lib or config accounts