### PR TITLE
🪲 Remove edr resolution

### DIFF
--- a/examples/oapp/package.json
+++ b/examples/oapp/package.json
@@ -17,7 +17,6 @@
     "test:hardhat": "hardhat test"
   },
   "resolutions": {
-    "@nomicfoundation/edr": "0.3.5",
     "ethers": "^5.7.2",
     "hardhat-deploy": "^0.12.1"
   },
@@ -62,13 +61,11 @@
   },
   "pnpm": {
     "overrides": {
-      "@nomicfoundation/edr": "0.3.5",
       "ethers": "^5.7.2",
       "hardhat-deploy": "^0.12.1"
     }
   },
   "overrides": {
-    "@nomicfoundation/edr": "0.3.5",
     "ethers": "^5.7.2",
     "hardhat-deploy": "^0.12.1"
   }

--- a/examples/oft-adapter/package.json
+++ b/examples/oft-adapter/package.json
@@ -17,7 +17,6 @@
     "test:hardhat": "hardhat test"
   },
   "resolutions": {
-    "@nomicfoundation/edr": "0.3.5",
     "ethers": "^5.7.2",
     "hardhat-deploy": "^0.12.1"
   },
@@ -63,13 +62,11 @@
   },
   "pnpm": {
     "overrides": {
-      "@nomicfoundation/edr": "0.3.5",
       "ethers": "^5.7.2",
       "hardhat-deploy": "^0.12.1"
     }
   },
   "overrides": {
-    "@nomicfoundation/edr": "0.3.5",
     "ethers": "^5.7.2",
     "hardhat-deploy": "^0.12.1"
   }

--- a/examples/oft/package.json
+++ b/examples/oft/package.json
@@ -17,7 +17,6 @@
     "test:hardhat": "hardhat test"
   },
   "resolutions": {
-    "@nomicfoundation/edr": "0.3.5",
     "ethers": "^5.7.2",
     "hardhat-deploy": "^0.12.1"
   },
@@ -64,13 +63,11 @@
   },
   "pnpm": {
     "overrides": {
-      "@nomicfoundation/edr": "0.3.5",
       "ethers": "^5.7.2",
       "hardhat-deploy": "^0.12.1"
     }
   },
   "overrides": {
-    "@nomicfoundation/edr": "0.3.5",
     "ethers": "^5.7.2",
     "hardhat-deploy": "^0.12.1"
   }

--- a/examples/onft721/package.json
+++ b/examples/onft721/package.json
@@ -16,7 +16,6 @@
     "test:hardhat": "hardhat test"
   },
   "resolutions": {
-    "@nomicfoundation/edr": "0.3.5",
     "ethers": "^5.7.2",
     "hardhat-deploy": "^0.12.1"
   },
@@ -62,13 +61,11 @@
   },
   "pnpm": {
     "overrides": {
-      "@nomicfoundation/edr": "0.3.5",
       "ethers": "^5.7.2",
       "hardhat-deploy": "^0.12.1"
     }
   },
   "overrides": {
-    "@nomicfoundation/edr": "0.3.5",
     "ethers": "^5.7.2",
     "hardhat-deploy": "^0.12.1"
   }

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     ]
   },
   "resolutions": {
-    "@nomicfoundation/edr": "0.3.5",
     "es5-ext": "https://github.com/LayerZero-Labs/es5-ext",
     "ethers": "^5.7.2",
     "hardhat-deploy": "^0.12.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,7 +5,6 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  '@nomicfoundation/edr': 0.3.5
   es5-ext: https://github.com/LayerZero-Labs/es5-ext
   ethers: ^5.7.2
   hardhat-deploy: ^0.12.1


### PR DESCRIPTION
### In this PR

- Remove edr module resolution after `hardhat` update. This module was fixed since its older versions wouldn't compile on all architectures