### PR TITLE
🧹 Use larger runner for building base images

### DIFF
--- a/.github/workflows/reusable-publish-docker.yaml
+++ b/.github/workflows/reusable-publish-docker.yaml
@@ -20,7 +20,7 @@ env:
 jobs:
   build:
     name: Build docker image
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-4xlarge
 
     permissions:
       contents: read


### PR DESCRIPTION
### In this PR

- Use the 4x runn er to build docker images since the default one is timing out