### PR TITLE
🧹 Speed up base image build

### DIFF
--- a/.github/workflows/reusable-publish-docker.yaml
+++ b/.github/workflows/reusable-publish-docker.yaml
@@ -18,21 +18,13 @@ env:
   IMAGE_NAMESPACE: ${{ github.repository_owner }}
 
 jobs:
-  build:
-    name: Build docker image
+  build-base:
+    name: Build base image
     runs-on: ubuntu-latest-4xlarge
 
     permissions:
       contents: read
       packages: write
-
-    strategy:
-      matrix:
-        include:
-          - image: devtools-dev-base
-            target: base
-          - image: devtools-dev-node-evm-hardhat
-            target: node-evm-hardhat
 
     steps:
       - name: Checkout repository
@@ -50,7 +42,7 @@ jobs:
         uses: docker/metadata-action@8e5442c4ef9f78752691e2d8f8d19755c6f78e81
         with:
           images: |
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAMESPACE }}/${{ matrix.image }}
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAMESPACE }}/devtools-dev-base
           tags: |
             type=ref,event=branch
             type=raw,value=latest,enable={{is_default_branch}}
@@ -59,14 +51,65 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Build and push Docker image
+      - name: Build and push base image
         uses: docker/build-push-action@4a13e500e55cf31b7a5d59a38ab2040ab0f42f56
         with:
           provenance: false
           context: .
           platforms: linux/amd64,linux/arm64
           push: true
-          target: ${{ matrix.target }}
+          target: base
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          annotations: ${{ steps.meta.outputs.annotations }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  build-node-evm:
+    name: Build EVM node image
+    runs-on: ubuntu-latest-4xlarge
+    needs:
+      - build-base
+
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@8e5442c4ef9f78752691e2d8f8d19755c6f78e81
+        with:
+          images: |
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAMESPACE }}/devtools-dev-node-evm-hardhat
+          tags: |
+            type=ref,event=branch
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=raw,value=${{ github.sha }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push EVM node image
+        uses: docker/build-push-action@4a13e500e55cf31b7a5d59a38ab2040ab0f42f56
+        with:
+          provenance: false
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          target: node-evm-hardhat
+          build-args: |
+            BASE_IMAGE=${{ env.REGISTRY }}/${{ env.IMAGE_NAMESPACE }}/devtools-dev-base:${{ github.sha }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           annotations: ${{ steps.meta.outputs.annotations }}


### PR DESCRIPTION
### In this PR

- The build workflow for the base docker images was still being too slow to be practical. This PR adds several optimizations:
  - The EVM node build now reuses the base build by separating the build into two jobs and specifying `BASE_IMAGE` build argument
  - The Solana binaries are only built from source if the OS/CPU combination is not supported. This is the case for arm64 (M2 macs) on Linux
  - Anchor install is no longer forced

Example run is [here](https://github.com/LayerZero-Labs/devtools/actions/runs/10305794296/job/28527452013)