### PR TITLE
🪲 Remove BASE_IMAGE when building EVM node

### DIFF
--- a/.github/workflows/reusable-publish-docker.yaml
+++ b/.github/workflows/reusable-publish-docker.yaml
@@ -108,8 +108,6 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: true
           target: node-evm-hardhat
-          build-args: |
-            BASE_IMAGE=${{ env.REGISTRY }}/${{ env.IMAGE_NAMESPACE }}/devtools-dev-base:${{ github.sha }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           annotations: ${{ steps.meta.outputs.annotations }}


### PR DESCRIPTION
### In this PR

- The `BASE_IMAGE` build argument has been removed from the docker build for the EVM node. This is because of a silly issue - the base image in a `Dockerfile` must be lowercase (see the error [here](https://github.com/LayerZero-Labs/devtools/actions/runs/10307121961/job/28538440169)).
- Since we are using docker layer caching anyway, this does not hurt the performance a lot, see a completed job [here](https://github.com/LayerZero-Labs/devtools/actions/runs/10309412989)