### PR TITLE
🧹 Parallelize build

### DIFF
--- a/.github/workflows/reusable-publish.yaml
+++ b/.github/workflows/reusable-publish.yaml
@@ -55,7 +55,7 @@ jobs:
       # We'll run the build in series to avoid race conditions
       # when compiling hardhat projects in monorepo setups
       - name: Build
-        run: pnpm build --concurrency=1
+        run: pnpm build
         env:
           NODE_ENV: production
 

--- a/.github/workflows/reusable-test.yaml
+++ b/.github/workflows/reusable-test.yaml
@@ -51,7 +51,7 @@ jobs:
       # We'll run the build in series to avoid race conditions
       # when compiling hardhat projects in monorepo setups
       - name: Build
-        run: pnpm build --concurrency=1
+        run: pnpm build
 
   test:
     name: Test


### PR DESCRIPTION
### In this PR

- Since we have `solc` preinstalled on the machine, we should be able to run the build in parallel. I will rerun this PR several times and only mark it as ready for review if there is no flakiness