### PR TITLE
🧹 Add parallel utility to the dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -64,6 +64,8 @@ RUN apt-get install --yes \
     # 
     # See a tutorial here https://www.baeldung.com/linux/bash-interactive-prompts
     expect \
+    # Parallel is a utilit we use to parallelize the BATS (user) tests
+    parallel \
     # Utilities required to build solana
     pkg-config libudev-dev llvm libclang-dev protobuf-compiler
 


### PR DESCRIPTION
### In this PR

- The user tests have grown and it's time to parallelize them. The first step is to install `parallel` GNU utility into the base image. See more [here](https://bats-core.readthedocs.io/en/stable/usage.html#parallel-execution)