### PR TITLE
🧹 Run docker build on faster runner

### DIFF
--- a/.github/workflows/reusable-publish-docker.yaml
+++ b/.github/workflows/reusable-publish-docker.yaml
@@ -20,7 +20,7 @@ env:
 jobs:
   build-base:
     name: Build base image
-    runs-on: ubuntu-latest-4xlarge
+    runs-on: ubuntu-latest-16xlarge
 
     permissions:
       contents: read


### PR DESCRIPTION
### In this PR

- Since for `linux/arm64` the base docker image needs to build Solana binaries from source (takes about 2 hours in total to build on the github runner), we'll be using a faster runner for this