### PR TITLE
🧹 Disable flaky test

### DIFF
--- a/packages/protocol-devtools-solana/test/endpointv2/sdk.test.ts
+++ b/packages/protocol-devtools-solana/test/endpointv2/sdk.test.ts
@@ -358,7 +358,8 @@ describe('endpointv2/sdk', () => {
             expect(transactions).toHaveLength(1)
         })
 
-        it('should create multiple OmniTransactions when called with a lot of uln configs', async () => {
+        // eslint-disable-next-line jest/no-disabled-tests
+        it.skip('should create multiple OmniTransactions when called with a lot of uln configs', async () => {
             getLatestBlockhashMock.mockRestore()
 
             const connection = await connectionFactory(EndpointId.SOLANA_V2_MAINNET)


### PR DESCRIPTION
### In this PR

- Unfortunately one of the Solana tests (that we run against mainnet) is flaky due to timeout issues. until we have a local Solana node with endpoints, we'll disable this test. Sad times