### PR TITLE
🗞️ Support encoded constructor arguments in non-target verification

### DIFF
--- a/.changeset/breezy-tigers-destroy.md
+++ b/.changeset/breezy-tigers-destroy.md
@@ -1,0 +1,5 @@
+---
+"@layerzerolabs/verify-contract": patch
+---
+
+Support encoded constructor arguments

--- a/packages/verify-contract/src/cli.ts
+++ b/packages/verify-contract/src/cli.ts
@@ -16,7 +16,7 @@ interface CommonArgs {
 
 interface NonTargetArgs extends CommonArgs {
     address: string
-    arguments?: string[]
+    arguments?: string[] | string
     deployment: string
     name: string
 }
@@ -55,6 +55,11 @@ const verifyNonTargetCommand = new Command('non-target')
         '--arguments <constructor arguments>',
         'JSON encoded array of constructor arguments, e.g. [1234, "0x0"]',
         (value: string) => {
+            if (value.startsWith('0x')) {
+                // If encoded parameters were passed in, we remove the leading 0x
+                return value.slice(2)
+            }
+
             try {
                 const decoded = JSON.parse(value)
                 if (!Array.isArray(decoded)) {

--- a/packages/verify-contract/src/hardhat-deploy/types.ts
+++ b/packages/verify-contract/src/hardhat-deploy/types.ts
@@ -24,7 +24,7 @@ export interface VerifyHardhatContractConfig {
     address: string
     deployment: string
     contractName: string
-    constructorArguments?: unknown[]
+    constructorArguments?: unknown[] | string
 }
 
 export interface VerifyHardhatNonTargetConfig extends VerifyHardhatBaseConfig {

--- a/packages/verify-contract/src/hardhat-deploy/verify.ts
+++ b/packages/verify-contract/src/hardhat-deploy/verify.ts
@@ -89,8 +89,16 @@ export const verifyNonTarget = async (
         }
 
         const licenseType = findLicenseType(source.content)
-        const abi = getContructorABIFromSource(source.content)
-        const constructorArguments = encodeContructorArguments(abi, contract.constructorArguments)
+        // Constructor arguments can be passed encoded or decoded
+        const constructorArguments =
+            // If there are no constructor arguments, we don't pass anything
+            contract.constructorArguments == null
+                ? undefined
+                : // If the constructor arguments are passed encoded we pass them directly
+                  typeof contract.constructorArguments === 'string'
+                  ? contract.constructorArguments
+                  : // For decoded constructor arguments we'll need to try and encoded them using the contract source
+                    encodeContructorArguments(getContructorABIFromSource(source.content), contract.constructorArguments)
 
         // Deployment metadata contains solcInput, just a bit rearranged
         const solcInput = extractSolcInputFromMetadata(deployment.metadata)


### PR DESCRIPTION
### In this PR

- Constructor arguments (`--arguments`) can now be passed as a HEX-encoded string (with leading `0x`) to the `non-target` verification CLI