### PR TITLE
🧹 Change the default URL for Solana testnet

### DIFF
--- a/.changeset/fifty-pumas-play.md
+++ b/.changeset/fifty-pumas-play.md
@@ -1,0 +1,5 @@
+---
+"@layerzerolabs/devtools-solana": patch
+---
+
+Change the default RPC URL for solana testnets

--- a/packages/devtools-solana/src/connection/factory.ts
+++ b/packages/devtools-solana/src/connection/factory.ts
@@ -12,7 +12,7 @@ export const defaultRpcUrlFactory: RpcUrlFactory = (eid) => {
 
         case EndpointId.SOLANA_V2_TESTNET:
         case EndpointId.SOLANA_TESTNET:
-            return 'https://api.testnet.solana.com'
+            return 'https://api.devnet.solana.com'
     }
 
     throw new Error(`Could not find a default Solana RPC URL for eid ${eid} (${formatEid(eid)})`)

--- a/packages/devtools-solana/test/connection/factory.test.ts
+++ b/packages/devtools-solana/test/connection/factory.test.ts
@@ -71,11 +71,11 @@ describe('provider/factory', () => {
         })
 
         it('should return https://api.testnet.solana.com for SOLANA_V2_TESTNET', () => {
-            expect(defaultRpcUrlFactory(EndpointId.SOLANA_V2_TESTNET)).toBe(`https://api.testnet.solana.com`)
+            expect(defaultRpcUrlFactory(EndpointId.SOLANA_V2_TESTNET)).toBe(`https://api.devnet.solana.com`)
         })
 
         it('should return https://api.testnet.solana.com for SOLANA_TESTNET', () => {
-            expect(defaultRpcUrlFactory(EndpointId.SOLANA_TESTNET)).toBe(`https://api.testnet.solana.com`)
+            expect(defaultRpcUrlFactory(EndpointId.SOLANA_TESTNET)).toBe(`https://api.devnet.solana.com`)
         })
 
         it('should throw an error for other endpoints', () => {


### PR DESCRIPTION
### In this PR

- The default RPC URL for `SOLANA_V2_TESTNET` and `SOLANA_TESTNET` is the devnet URL