### PR TITLE
🧹 Add hardhat CLI argument parser for eid

### DIFF
--- a/.changeset/smooth-hairs-begin.md
+++ b/.changeset/smooth-hairs-begin.md
@@ -1,0 +1,5 @@
+---
+"@layerzerolabs/devtools-evm-hardhat": patch
+---
+
+Add eid hardhat CLI parser

--- a/packages/devtools-evm-hardhat/src/cli.ts
+++ b/packages/devtools-evm-hardhat/src/cli.ts
@@ -5,7 +5,7 @@ import type { CLIArgumentType } from 'hardhat/types'
 import { splitCommaSeparated } from '@layerzerolabs/devtools'
 import { isEVMAddress, SignerDefinition } from '@layerzerolabs/devtools-evm'
 import { isLogLevel, LogLevel } from '@layerzerolabs/io-devtools'
-import { Environment, Stage } from '@layerzerolabs/lz-definitions'
+import { EndpointId, Environment, Stage } from '@layerzerolabs/lz-definitions'
 
 /**
  * Hardhat CLI type for a comma separated list of arbitrary strings
@@ -60,6 +60,43 @@ const stage: CLIArgumentType<Stage> = {
         }
 
         return value
+    },
+    validate() {},
+}
+
+/**
+ * Hardhat CLI type for a LayzerZero chain stage
+ *
+ * @see {@link Stage}
+ */
+const eid: CLIArgumentType<EndpointId> = {
+    name: 'eid',
+    parse(name: string, value: string) {
+        const valueAsInt = parseInt(value)
+        if (isNaN(valueAsInt)) {
+            const eid = EndpointId[value]
+
+            if (typeof eid !== 'number') {
+                throw new HardhatError(ERRORS.ARGUMENTS.INVALID_VALUE_FOR_TYPE, {
+                    value,
+                    name: name,
+                    type: 'stage',
+                })
+            }
+
+            return eid
+        }
+
+        const eidLabel = EndpointId[valueAsInt]
+        if (typeof eidLabel !== 'string') {
+            throw new HardhatError(ERRORS.ARGUMENTS.INVALID_VALUE_FOR_TYPE, {
+                value,
+                name: name,
+                type: 'stage',
+            })
+        }
+
+        return valueAsInt as EndpointId
     },
     validate() {},
 }
@@ -139,4 +176,4 @@ export const signer: CLIArgumentType<SignerDefinition> = {
     validate() {},
 }
 
-export const types = { csv, logLevel, fn, signer, environment, stage, ...builtInTypes }
+export const types = { csv, eid, logLevel, fn, signer, environment, stage, ...builtInTypes }

--- a/packages/devtools-evm-hardhat/test/cli.test.ts
+++ b/packages/devtools-evm-hardhat/test/cli.test.ts
@@ -1,5 +1,6 @@
-import { signer } from '@/cli'
-import { evmAddressArbitrary } from '@layerzerolabs/test-devtools'
+import { signer, types } from '@/cli'
+import { EndpointId } from '@layerzerolabs/lz-definitions'
+import { endpointArbitrary, evmAddressArbitrary } from '@layerzerolabs/test-devtools'
 import fc from 'fast-check'
 
 describe('cli', () => {
@@ -28,6 +29,44 @@ describe('cli', () => {
             fc.assert(
                 fc.property(fc.integer({ min: 0 }), (index) => {
                     expect(signer.parse('signer', String(index))).toEqual({ type: 'index', index })
+                })
+            )
+        })
+    })
+
+    describe('eid', () => {
+        it('should parse all valid endpoint IDs', () => {
+            fc.assert(
+                fc.property(endpointArbitrary, (eid) => {
+                    expect(types.eid.parse('eid', String(eid))).toEqual(eid)
+                })
+            )
+        })
+
+        it('should parse all valid endpoint labels', () => {
+            fc.assert(
+                fc.property(endpointArbitrary, (eid) => {
+                    expect(types.eid.parse('eid', EndpointId[eid]!)).toEqual(eid)
+                })
+            )
+        })
+
+        it('should not parse invalid strings', () => {
+            fc.assert(
+                fc.property(fc.string(), (eid) => {
+                    fc.pre(EndpointId[eid] == null)
+
+                    expect(() => types.eid.parse('eid', eid)).toThrow()
+                })
+            )
+        })
+
+        it('should not parse invalid numbers', () => {
+            fc.assert(
+                fc.property(fc.integer(), (eid) => {
+                    fc.pre(EndpointId[eid] == null)
+
+                    expect(() => types.eid.parse('eid', String(eid))).toThrow()
                 })
             )
         })


### PR DESCRIPTION
### In this PR

- Add `eid` hardhat CLI argument parser that accepts both labels `SOLANA_V2_MAINNET` and eids (`30101`)