### PR TITLE
🧹 Add exports to EVM contract packages

### DIFF
--- a/.changeset/empty-buses-occur.md
+++ b/.changeset/empty-buses-occur.md
@@ -1,0 +1,7 @@
+---
+"@layerzerolabs/oapp-evm": patch
+"@layerzerolabs/onft-evm": patch
+"@layerzerolabs/oft-evm": patch
+---
+
+Add artifacts exports to EVM contract packages

--- a/packages/oapp-evm/package.json
+++ b/packages/oapp-evm/package.json
@@ -16,7 +16,11 @@
   },
   "license": "MIT",
   "exports": {
-    "./package.json": "./package.json"
+    "./package.json": "./package.json",
+    "./artifacts/*.json": {
+      "require": "./artifacts/*.json",
+      "imports": "./artifacts/*.json"
+    }
   },
   "files": [
     "artifacts/**/*",

--- a/packages/oft-evm/package.json
+++ b/packages/oft-evm/package.json
@@ -18,7 +18,11 @@
   },
   "license": "MIT",
   "exports": {
-    "./package.json": "./package.json"
+    "./package.json": "./package.json",
+    "./artifacts/*.json": {
+      "require": "./artifacts/*.json",
+      "imports": "./artifacts/*.json"
+    }
   },
   "files": [
     "artifacts/Fee.sol/Fee.json",

--- a/packages/onft-evm/package.json
+++ b/packages/onft-evm/package.json
@@ -17,7 +17,11 @@
   },
   "license": "MIT",
   "exports": {
-    "./package.json": "./package.json"
+    "./package.json": "./package.json",
+    "./artifacts/*.json": {
+      "require": "./artifacts/*.json",
+      "imports": "./artifacts/*.json"
+    }
   },
   "files": [
     "artifacts/IONFT721.sol/IONFT721.json",


### PR DESCRIPTION
### In this PR

- Add `artifacts` to the `exports` in EVM contract packages
- Requires #866 to be merged since the user tests are failing