### PR TITLE
🪲 Solana: Fix @solana-developers/helpers version to 2.4.0

### DIFF
--- a/.changeset/rotten-plants-hear.md
+++ b/.changeset/rotten-plants-hear.md
@@ -1,0 +1,5 @@
+---
+"@layerzerolabs/oft-solana-example": patch
+---
+
+Fix @solana-developers/helpers version to 2.4.0

--- a/examples/oft-solana/package.json
+++ b/examples/oft-solana/package.json
@@ -61,7 +61,7 @@
     "@openzeppelin/contracts": "^5.0.2",
     "@openzeppelin/contracts-upgradeable": "^5.0.2",
     "@rushstack/eslint-patch": "^1.7.0",
-    "@solana-developers/helpers": "^2.3.0",
+    "@solana-developers/helpers": "~2.4.0",
     "@solana/spl-token": "^0.4.8",
     "@solana/web3.js": "~1.95.0",
     "@swc/core": "^1.4.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -528,7 +528,7 @@ importers:
         specifier: ^1.7.0
         version: 1.10.4
       '@solana-developers/helpers':
-        specifier: ^2.3.0
+        specifier: ~2.4.0
         version: 2.4.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.4)
       '@solana/spl-token':
         specifier: ^0.4.8


### PR DESCRIPTION
### In this PR

- `@solana-developers/helpers` has just been updated to `2.5.0` and this update includes a broken ESM setup. The version has been fixed to `2.4.0` to prevent the examples from breaking