### PR TITLE
🧹 Decouple DVN, Executor & PriceFeed SDKs from hardhat-deploy

### DIFF
--- a/.changeset/neat-bobcats-stare.md
+++ b/.changeset/neat-bobcats-stare.md
@@ -1,0 +1,5 @@
+---
+"@layerzerolabs/protocol-devtools-evm": patch
+---
+
+Decouple DVN, Executor & PriceFeed SDKs from hardhat-deploy

--- a/.changeset/neat-bobcats-stare.md
+++ b/.changeset/neat-bobcats-stare.md
@@ -1,5 +1,5 @@
 ---
-"@layerzerolabs/protocol-devtools-evm": patch
+"@layerzerolabs/protocol-devtools-evm": minor
 ---
 
 Decouple DVN, Executor & PriceFeed SDKs from hardhat-deploy

--- a/packages/protocol-devtools-evm/src/dvn/factory.ts
+++ b/packages/protocol-devtools-evm/src/dvn/factory.ts
@@ -1,15 +1,15 @@
 import pMemoize from 'p-memoize'
-import type { OmniContractFactory } from '@layerzerolabs/devtools-evm'
+import type { ProviderFactory } from '@layerzerolabs/devtools-evm'
 import type { DVNFactory } from '@layerzerolabs/protocol-devtools'
 import { DVN } from './sdk'
+import { OmniPoint } from '@layerzerolabs/devtools'
 
 /**
  * Syntactic sugar that creates an instance of EVM `DVN` SDK
- * based on an `OmniPoint` with help of an `OmniContractFactory`
+ * based on an `OmniPoint` with help of a `ProviderFactory`
  *
- * @param {OmniContractFactory} contractFactory
+ * @param {ProviderFactory} providerFactory
  * @returns {DVNFactory<DVN>}
  */
-export const createDVNFactory = <TOmniPoint = never>(
-    contractFactory: OmniContractFactory<TOmniPoint>
-): DVNFactory<DVN, TOmniPoint> => pMemoize(async (point) => new DVN(await contractFactory(point)))
+export const createDVNFactory = (providerFactory: ProviderFactory): DVNFactory<DVN, OmniPoint> =>
+    pMemoize(async (point) => new DVN(await providerFactory(point.eid), point))

--- a/packages/protocol-devtools-evm/src/dvn/sdk.ts
+++ b/packages/protocol-devtools-evm/src/dvn/sdk.ts
@@ -1,11 +1,16 @@
 import type { EndpointId } from '@layerzerolabs/lz-definitions'
 import type { IDVN, DVNDstConfig } from '@layerzerolabs/protocol-devtools'
-import { formatEid, type OmniTransaction } from '@layerzerolabs/devtools'
-import { OmniSDK } from '@layerzerolabs/devtools-evm'
+import { formatEid, type OmniPoint, type OmniTransaction } from '@layerzerolabs/devtools'
+import { OmniSDK, type Provider } from '@layerzerolabs/devtools-evm'
 import { printJson } from '@layerzerolabs/io-devtools'
 import { DVNDstConfigSchema } from './schema'
+import { abi } from '@layerzerolabs/lz-evm-sdk-v2/artifacts/contracts/uln/dvn/DVN.sol/DVN.json'
 
 export class DVN extends OmniSDK implements IDVN {
+    constructor(provider: Provider, point: OmniPoint) {
+        super(provider, point, abi)
+    }
+
     async getDstConfig(eid: EndpointId): Promise<DVNDstConfig> {
         const config = await this.contract.contract.dstConfig(eid)
 

--- a/packages/protocol-devtools-evm/src/dvn/sdk.ts
+++ b/packages/protocol-devtools-evm/src/dvn/sdk.ts
@@ -5,10 +5,11 @@ import { OmniSDK, type Provider } from '@layerzerolabs/devtools-evm'
 import { printJson } from '@layerzerolabs/io-devtools'
 import { DVNDstConfigSchema } from './schema'
 import { abi } from '@layerzerolabs/lz-evm-sdk-v2/artifacts/contracts/uln/dvn/DVN.sol/DVN.json'
+import { Contract } from '@ethersproject/contracts'
 
 export class DVN extends OmniSDK implements IDVN {
     constructor(provider: Provider, point: OmniPoint) {
-        super(provider, point, abi)
+        super({ eid: point.eid, contract: new Contract(point.address, abi).connect(provider) })
     }
 
     async getDstConfig(eid: EndpointId): Promise<DVNDstConfig> {

--- a/packages/protocol-devtools-evm/src/endpointv2/sdk.ts
+++ b/packages/protocol-devtools-evm/src/endpointv2/sdk.ts
@@ -28,6 +28,7 @@ import { Uln302SetExecutorConfig } from '@layerzerolabs/protocol-devtools'
 import { printJson } from '@layerzerolabs/io-devtools'
 import { ReceiveLibrarySchema } from './schema'
 import { abi } from '@layerzerolabs/lz-evm-sdk-v2/artifacts/contracts/EndpointV2.sol/EndpointV2.json'
+import { Contract } from '@ethersproject/contracts'
 
 const CONFIG_TYPE_EXECUTOR = 1
 const CONFIG_TYPE_ULN = 2
@@ -39,7 +40,7 @@ const CONFIG_TYPE_ULN = 2
  */
 export class EndpointV2 extends OmniSDK implements IEndpointV2 {
     constructor(provider: Provider, point: OmniPoint) {
-        super(provider, point, abi)
+        super({ eid: point.eid, contract: new Contract(point.address, abi).connect(provider) })
     }
 
     @AsyncRetriable()
@@ -65,7 +66,7 @@ export class EndpointV2 extends OmniSDK implements IEndpointV2 {
             )}`
         )
 
-        return new Uln302(this.provider, { eid: this.point.eid, address })
+        return new Uln302(this.contract.contract.provider as Provider, { eid: this.point.eid, address })
     }
 
     @AsyncRetriable()

--- a/packages/protocol-devtools-evm/src/endpointv2/sdk.ts
+++ b/packages/protocol-devtools-evm/src/endpointv2/sdk.ts
@@ -27,7 +27,6 @@ import { Uln302 } from '@/uln302'
 import { Uln302SetExecutorConfig } from '@layerzerolabs/protocol-devtools'
 import { printJson } from '@layerzerolabs/io-devtools'
 import { ReceiveLibrarySchema } from './schema'
-import { Contract } from '@ethersproject/contracts'
 import { abi } from '@layerzerolabs/lz-evm-sdk-v2/artifacts/contracts/EndpointV2.sol/EndpointV2.json'
 
 const CONFIG_TYPE_EXECUTOR = 1
@@ -39,11 +38,8 @@ const CONFIG_TYPE_ULN = 2
  * @implements {IEndpointV2}
  */
 export class EndpointV2 extends OmniSDK implements IEndpointV2 {
-    constructor(
-        private readonly provider: Provider,
-        point: OmniPoint
-    ) {
-        super({ eid: point.eid, contract: new Contract(point.address, abi).connect(provider) })
+    constructor(provider: Provider, point: OmniPoint) {
+        super(provider, point, abi)
     }
 
     @AsyncRetriable()

--- a/packages/protocol-devtools-evm/src/executor/factory.ts
+++ b/packages/protocol-devtools-evm/src/executor/factory.ts
@@ -1,15 +1,15 @@
 import pMemoize from 'p-memoize'
-import type { OmniContractFactory } from '@layerzerolabs/devtools-evm'
+import type { ProviderFactory } from '@layerzerolabs/devtools-evm'
 import type { ExecutorFactory } from '@layerzerolabs/protocol-devtools'
 import { Executor } from './sdk'
+import type { OmniPoint } from '@layerzerolabs/devtools'
 
 /**
  * Syntactic sugar that creates an instance of EVM `Executor` SDK
- * based on an `OmniPoint` with help of an `OmniContractFactory`
+ * based on an `OmniPoint` with help of a `ProviderFactory`
  *
- * @param {OmniContractFactory} contractFactory
+ * @param {ProviderFactory} providerFactory
  * @returns {ExecutorFactory<Executor>}
  */
-export const createExecutorFactory = <TOmniPoint = never>(
-    contractFactory: OmniContractFactory<TOmniPoint>
-): ExecutorFactory<Executor, TOmniPoint> => pMemoize(async (point) => new Executor(await contractFactory(point)))
+export const createExecutorFactory = (providerFactory: ProviderFactory): ExecutorFactory<Executor, OmniPoint> =>
+    pMemoize(async (point) => new Executor(await providerFactory(point.eid), point))

--- a/packages/protocol-devtools-evm/src/executor/sdk.ts
+++ b/packages/protocol-devtools-evm/src/executor/sdk.ts
@@ -5,10 +5,11 @@ import { OmniSDK, type Provider } from '@layerzerolabs/devtools-evm'
 import { printJson } from '@layerzerolabs/io-devtools'
 import { ExecutorDstConfigSchema } from './schema'
 import { abi } from '@layerzerolabs/lz-evm-sdk-v2/artifacts/contracts/Executor.sol/Executor.json'
+import { Contract } from '@ethersproject/contracts'
 
 export class Executor extends OmniSDK implements IExecutor {
     constructor(provider: Provider, point: OmniPoint) {
-        super(provider, point, abi)
+        super({ eid: point.eid, contract: new Contract(point.address, abi).connect(provider) })
     }
 
     async getDstConfig(eid: EndpointId): Promise<ExecutorDstConfig> {

--- a/packages/protocol-devtools-evm/src/executor/sdk.ts
+++ b/packages/protocol-devtools-evm/src/executor/sdk.ts
@@ -1,11 +1,16 @@
 import type { EndpointId } from '@layerzerolabs/lz-definitions'
 import { type IExecutor, type ExecutorDstConfig } from '@layerzerolabs/protocol-devtools'
-import { formatEid, type OmniTransaction } from '@layerzerolabs/devtools'
-import { OmniSDK } from '@layerzerolabs/devtools-evm'
+import { formatEid, type OmniPoint, type OmniTransaction } from '@layerzerolabs/devtools'
+import { OmniSDK, type Provider } from '@layerzerolabs/devtools-evm'
 import { printJson } from '@layerzerolabs/io-devtools'
 import { ExecutorDstConfigSchema } from './schema'
+import { abi } from '@layerzerolabs/lz-evm-sdk-v2/artifacts/contracts/Executor.sol/Executor.json'
 
 export class Executor extends OmniSDK implements IExecutor {
+    constructor(provider: Provider, point: OmniPoint) {
+        super(provider, point, abi)
+    }
+
     async getDstConfig(eid: EndpointId): Promise<ExecutorDstConfig> {
         const config = await this.contract.contract.dstConfig(eid)
 

--- a/packages/protocol-devtools-evm/src/priceFeed/factory.ts
+++ b/packages/protocol-devtools-evm/src/priceFeed/factory.ts
@@ -1,15 +1,15 @@
 import pMemoize from 'p-memoize'
-import type { OmniContractFactory } from '@layerzerolabs/devtools-evm'
+import type { ProviderFactory } from '@layerzerolabs/devtools-evm'
 import type { PriceFeedFactory } from '@layerzerolabs/protocol-devtools'
 import { PriceFeed } from './sdk'
+import type { OmniPoint } from '@layerzerolabs/devtools'
 
 /**
  * Syntactic sugar that creates an instance of EVM `PriceFeed` SDK
  * based on an `OmniPoint` with help of an `OmniContractFactory`
  *
- * @param {OmniContractFactory} contractFactory
+ * @param {ProviderFactory} providerFactory
  * @returns {PriceFeedFactory<PriceFeed>}
  */
-export const createPriceFeedFactory = <TOmniPoint = never>(
-    contractFactory: OmniContractFactory<TOmniPoint>
-): PriceFeedFactory<PriceFeed, TOmniPoint> => pMemoize(async (point) => new PriceFeed(await contractFactory(point)))
+export const createPriceFeedFactory = (providerFactory: ProviderFactory): PriceFeedFactory<PriceFeed, OmniPoint> =>
+    pMemoize(async (point) => new PriceFeed(await providerFactory(point.eid), point))

--- a/packages/protocol-devtools-evm/src/priceFeed/sdk.ts
+++ b/packages/protocol-devtools-evm/src/priceFeed/sdk.ts
@@ -5,10 +5,11 @@ import { OmniSDK, type Provider } from '@layerzerolabs/devtools-evm'
 import { printJson } from '@layerzerolabs/io-devtools'
 import { PriceDataSchema } from './schema'
 import { abi } from '@layerzerolabs/lz-evm-sdk-v2/artifacts/contracts/PriceFeed.sol/PriceFeed.json'
+import { Contract } from '@ethersproject/contracts'
 
 export class PriceFeed extends OmniSDK implements IPriceFeed {
     constructor(provider: Provider, point: OmniPoint) {
-        super(provider, point, abi)
+        super({ eid: point.eid, contract: new Contract(point.address, abi).connect(provider) })
     }
 
     async getPrice(eid: EndpointId): Promise<PriceData> {

--- a/packages/protocol-devtools-evm/src/priceFeed/sdk.ts
+++ b/packages/protocol-devtools-evm/src/priceFeed/sdk.ts
@@ -1,11 +1,16 @@
 import type { EndpointId } from '@layerzerolabs/lz-definitions'
 import type { IPriceFeed, PriceData } from '@layerzerolabs/protocol-devtools'
-import { formatEid, type OmniTransaction } from '@layerzerolabs/devtools'
-import { OmniSDK } from '@layerzerolabs/devtools-evm'
+import { formatEid, type OmniPoint, type OmniTransaction } from '@layerzerolabs/devtools'
+import { OmniSDK, type Provider } from '@layerzerolabs/devtools-evm'
 import { printJson } from '@layerzerolabs/io-devtools'
 import { PriceDataSchema } from './schema'
+import { abi } from '@layerzerolabs/lz-evm-sdk-v2/artifacts/contracts/PriceFeed.sol/PriceFeed.json'
 
 export class PriceFeed extends OmniSDK implements IPriceFeed {
+    constructor(provider: Provider, point: OmniPoint) {
+        super(provider, point, abi)
+    }
+
     async getPrice(eid: EndpointId): Promise<PriceData> {
         const config = await this.contract.contract['getPrice(uint32)'](eid)
 

--- a/packages/ua-devtools-evm-hardhat/src/utils/taskHelpers.ts
+++ b/packages/ua-devtools-evm-hardhat/src/utils/taskHelpers.ts
@@ -6,7 +6,7 @@ import type {
     Uln302UlnConfig,
 } from '@layerzerolabs/protocol-devtools'
 import {
-    createConnectedContractFactory,
+    createContractFactory,
     createOmniPointHardhatTransformer,
     createProviderFactory,
     getEidForNetworkName,
@@ -175,8 +175,10 @@ export async function getExecutorDstConfig(
 ): Promise<ExecutorDstConfig | undefined> {
     const localEid = getEidForNetworkName(localNetworkName)
     const remoteEid = getEidForNetworkName(remoteNetworkName)
-    const contractFactory = createConnectedContractFactory()
-    const executorFactory = createExecutorFactory(contractFactory)
-    const localExecutorSDK = await executorFactory({ eid: localEid, contractName: 'Executor' })
+    const omnipointTransformer = createOmniPointHardhatTransformer(createContractFactory())
+    const executorFactory = createExecutorFactory(createProviderFactory())
+    const localExecutorSDK = await executorFactory(
+        await omnipointTransformer({ eid: localEid, contractName: 'Executor' })
+    )
     return await localExecutorSDK.getDstConfig(remoteEid)
 }

--- a/tests/test-setup-devtools-evm-hardhat/src/endpointV2/setup.ts
+++ b/tests/test-setup-devtools-evm-hardhat/src/endpointV2/setup.ts
@@ -1,15 +1,14 @@
 /// <reference types="hardhat-deploy/dist/src/type-extensions" />
 
 import {
-    createConnectedContractFactory,
     createErrorParser,
+    createOmniPointHardhatTransformer,
     createProviderFactory,
     createSignerFactory,
     OmniGraphBuilderHardhat,
     type OmniGraphHardhat,
 } from '@layerzerolabs/devtools-evm-hardhat'
 import { EndpointId } from '@layerzerolabs/lz-definitions'
-import { omniContractToPoint } from '@layerzerolabs/devtools-evm'
 import {
     configureEndpointV2,
     DVNDstConfig,
@@ -123,30 +122,30 @@ export const getDefaultUlnConfig = (dvnAddress: string): Uln302UlnConfig => {
 export const setupDefaultEndpointV2 = async (): Promise<void> => {
     // This is the tooling we are going to need
     const providerFactory = createProviderFactory()
-    const contractFactory = createConnectedContractFactory()
     const signAndSend = createSignAndSend(createSignerFactory())
     const ulnSdkFactory = createUln302Factory(providerFactory)
     const endpointV2SdkFactory = createEndpointV2Factory(providerFactory)
-    const priceFeedSdkFactory = createPriceFeedFactory(contractFactory)
-    const executorSdkFactory = createExecutorFactory(contractFactory)
-    const dvnSdkFactory = createDVNFactory(contractFactory)
+    const priceFeedSdkFactory = createPriceFeedFactory(providerFactory)
+    const executorSdkFactory = createExecutorFactory(providerFactory)
+    const dvnSdkFactory = createDVNFactory(providerFactory)
+    const omnipointTransformer = createOmniPointHardhatTransformer()
 
     // For the graphs, we'll also need the pointers to the contracts
-    const ethSendUlnPoint = omniContractToPoint(await contractFactory(ethSendUln))
-    const avaxSendUlnPoint = omniContractToPoint(await contractFactory(avaxSendUln))
-    const bscSendUlnPoint = omniContractToPoint(await contractFactory(bscSendUln))
+    const ethSendUlnPoint = await omnipointTransformer(ethSendUln)
+    const avaxSendUlnPoint = await omnipointTransformer(avaxSendUln)
+    const bscSendUlnPoint = await omnipointTransformer(bscSendUln)
 
-    const ethReceiveUlnPoint = omniContractToPoint(await contractFactory(ethReceiveUln))
-    const avaxReceiveUlnPoint = omniContractToPoint(await contractFactory(avaxReceiveUln))
-    const bscReceiveUlnPoint = omniContractToPoint(await contractFactory(bscReceiveUln))
+    const ethReceiveUlnPoint = await omnipointTransformer(ethReceiveUln)
+    const avaxReceiveUlnPoint = await omnipointTransformer(avaxReceiveUln)
+    const bscReceiveUlnPoint = await omnipointTransformer(bscReceiveUln)
 
-    const ethExecutorPoint = omniContractToPoint(await contractFactory(ethExecutor))
-    const avaxExecutorPoint = omniContractToPoint(await contractFactory(avaxExecutor))
-    const bscExecutorPoint = omniContractToPoint(await contractFactory(bscExecutor))
+    const ethExecutorPoint = await omnipointTransformer(ethExecutor)
+    const avaxExecutorPoint = await omnipointTransformer(avaxExecutor)
+    const bscExecutorPoint = await omnipointTransformer(bscExecutor)
 
-    const ethDvnPoint = omniContractToPoint(await contractFactory(ethDvn))
-    const avaxDvnPoint = omniContractToPoint(await contractFactory(avaxDvn))
-    const bscDvnPoint = omniContractToPoint(await contractFactory(bscDvn))
+    const ethDvnPoint = await omnipointTransformer(ethDvn)
+    const avaxDvnPoint = await omnipointTransformer(avaxDvn)
+    const bscDvnPoint = await omnipointTransformer(bscDvn)
 
     const ethUlnConfig: Uln302UlnConfig = getDefaultUlnConfig(ethDvnPoint.address)
     const avaxUlnConfig: Uln302UlnConfig = getDefaultUlnConfig(avaxDvnPoint.address)


### PR DESCRIPTION
### In this PR

- Continue decoupling SDKs from hardhat-deploy - embedding ABIs for `DVN`, `Executor` and `PriceFeed` SDKs
- The OApp constructor has not changed yet