### PR TITLE
🧹 Decoupling UA SDKs from hardhat deploy

### DIFF
--- a/.changeset/unlucky-cameras-draw.md
+++ b/.changeset/unlucky-cameras-draw.md
@@ -1,0 +1,15 @@
+---
+"@layerzerolabs/omnicounter-devtools-evm": major
+"@layerzerolabs/ua-devtools-evm-hardhat": major
+"@layerzerolabs/ua-devtools-evm": major
+"@layerzerolabs/devtools-evm": major
+"@layerzerolabs/ua-devtools-evm-hardhat-v1-test": patch
+"@layerzerolabs/ua-devtools-evm-hardhat-test": patch
+"@layerzerolabs/protocol-devtools-evm": patch
+"@layerzerolabs/devtools-cli-test": patch
+"@layerzerolabs/oft-solana-example": patch
+---
+
+Decouple UA SDKs from `hardhat-deploy`
+
+The UA (`OApp`, `Ownable`, `LzApp`, `ERC20`) SDKs now accept a `Provider` and an `ABI` instead of an ethers `Contract` instance. Any code that uses these constructors directly needs to be updated.

--- a/examples/oft-solana/tasks/common/utils.ts
+++ b/examples/oft-solana/tasks/common/utils.ts
@@ -10,7 +10,7 @@ import {
     firstFactory,
     formatEid,
 } from '@layerzerolabs/devtools'
-import { createConnectedContractFactory } from '@layerzerolabs/devtools-evm-hardhat'
+import { createProviderFactory } from '@layerzerolabs/devtools-evm-hardhat'
 import { OmniSignerSolana, createConnectionFactory, createRpcUrlFactory } from '@layerzerolabs/devtools-solana'
 import { ChainType, EndpointId, endpointIdToChainType } from '@layerzerolabs/lz-definitions'
 import { IOApp } from '@layerzerolabs/ua-devtools'
@@ -34,7 +34,7 @@ export const createSdkFactory = (
     //
     // We do this by using the firstFactory helper function that is provided by the devtools package.
     // This function will try to execute the factories one by one and return the first one that succeeds.
-    const evmSdkfactory = createOAppFactory(createConnectedContractFactory())
+    const evmSdkfactory = createOAppFactory(createProviderFactory())
     const solanaSdkFactory = createOFTFactory(
         // The first parameter to createOFTFactory is a user account factory
         //

--- a/packages/devtools-cli/src/commands/oapp/wire/index.ts
+++ b/packages/devtools-cli/src/commands/oapp/wire/index.ts
@@ -154,7 +154,7 @@ export const wire = new Command('wire')
 
             // If we are in dry run mode, we'll just print the transactions and exit
             if (dryRun) {
-                printRecords(transactions.map(formatOmniTransaction))
+                return printRecords(transactions.map(formatOmniTransaction))
             }
         }
     )

--- a/packages/devtools-evm/src/omnigraph/types.ts
+++ b/packages/devtools-evm/src/omnigraph/types.ts
@@ -1,3 +1,4 @@
+import { JsonFragment } from '@ethersproject/abi'
 import type { Contract } from '@ethersproject/contracts'
 import type { Factory, IOmniSDK as IOmniSDKAbstract, OmniPoint, WithEid } from '@layerzerolabs/devtools'
 
@@ -11,5 +12,6 @@ export type OmniContractFactory<TOmniPoint = OmniPoint> = Factory<[TOmniPoint], 
  * Base interface for all EVM SDKs, adding the EVM specific attributes
  */
 export interface IOmniSDK extends IOmniSDKAbstract {
+    abi: JsonFragment[]
     contract: OmniContract
 }

--- a/packages/devtools/src/flows/wire.ts
+++ b/packages/devtools/src/flows/wire.ts
@@ -1,0 +1,84 @@
+import type { Configurator, OmniGraph, OmniSDKFactory } from '@/omnigraph/types'
+import { formatOmniTransaction, OmniTransaction, SignAndSend } from '@/transactions'
+import { createLogger, printBoolean, printJson, type Logger } from '@layerzerolabs/io-devtools'
+import { printRecords } from '@layerzerolabs/io-devtools/swag'
+
+export interface WireFlowOptions {
+    assert?: boolean
+    dryRun?: boolean
+    logger?: Logger
+    configPath: string
+    loadConfig: (path: string) => Promise<OmniGraph>
+    configure: Configurator
+    signAndSend: SignAndSend
+    createSdk: OmniSDKFactory
+}
+
+export const wireFlow = async ({
+    assert,
+    dryRun,
+    logger = createLogger(),
+    configPath,
+    loadConfig,
+    configure,
+    createSdk,
+}: WireFlowOptions) => {
+    // And since this command is not complete yet, we'll warn the user
+    logger.warn(
+        `This command is just a placeholder. Please use @layerzerolabs/toolbox-hardhat package for the time being.`
+    )
+
+    if (assert) {
+        logger.info(`Running in assertion mode`)
+    } else if (dryRun) {
+        logger.info(`Running in dry run mode`)
+    }
+
+    let graph: OmniGraph
+
+    // Now it's time to load the config file
+    try {
+        logger.info(`Loading config file from ${configPath}`)
+
+        graph = await loadConfig(configPath)
+
+        logger.info(`${printBoolean(true)} Successfully loaded config file from ${configPath}`)
+        logger.debug(`Loaded config file from ${configPath}:\n\n${printJson(graph)}`)
+    } catch (error) {
+        logger.error(`Failed to load config from ${configPath}:\n\n${error}`)
+
+        process.exit(1)
+    }
+
+    let transactions: OmniTransaction[]
+
+    try {
+        logger.info(`Checking configuration`)
+
+        transactions = await configure(graph, createSdk)
+    } catch (error) {
+        logger.error(`Failed to check OApp configuration:\n\n${error}`)
+
+        process.exit(1)
+    }
+
+    // If there are no transactions that need to be executed, we'll just exit
+    if (transactions.length === 0) {
+        return logger.info(`The OApp is wired, no action is necessary`), undefined
+    } else if (assert) {
+        // If we are in assertion mode, we'll print out the transactions and exit with code 1
+        // if there is anything left to configure
+        logger.error(`The OApp is not fully wired, following transactions are necessary:`)
+
+        // Print the outstanding transactions
+        printRecords(transactions.map(formatOmniTransaction))
+
+        // Exit with non-zero error code
+        process.exit(1)
+    }
+
+    // If we are in dry run mode, we'll just print the transactions and exit
+    if (dryRun) {
+        printRecords(transactions.map(formatOmniTransaction))
+    }
+}

--- a/packages/omnicounter-devtools-evm/src/omnicounter/factory.ts
+++ b/packages/omnicounter-devtools-evm/src/omnicounter/factory.ts
@@ -1,14 +1,14 @@
 import pMemoize from 'p-memoize'
 import { OmniCounter } from '@/omnicounter/sdk'
 import { OAppFactory } from '@layerzerolabs/ua-devtools'
-import { OmniContractFactory } from '@layerzerolabs/devtools-evm'
+import { ProviderFactory } from '@layerzerolabs/devtools-evm'
 
 /**
- * Syntactic sugar that creates an instance of EVM `OmniCounter` SDK based on an `OmniPoint` with help of an
- * `OmniContractFactory` and an (optional) `EndpointV2Factory`
+ * Syntactic sugar that creates an instance of EVM `OmniCounter` SDK based on an `OmniPoint` with help of a
+ * `ProviderFactory`
  *
- * @param {OmniContractFactory} contractFactory
- * @returns {EndpointV2Factory<Endpoint>}
+ * @param {ProviderFactory} providerFactory
+ * @returns {OAppFactory<OmniCounter>}
  */
-export const createOmniCounterFactory = (contractFactory: OmniContractFactory): OAppFactory<OmniCounter> =>
-    pMemoize(async (point) => new OmniCounter(await contractFactory(point)))
+export const createOmniCounterFactory = (providerFactory: ProviderFactory): OAppFactory<OmniCounter> =>
+    pMemoize(async (point) => new OmniCounter(await providerFactory(point.eid), point))

--- a/packages/protocol-devtools-evm/src/dvn/sdk.ts
+++ b/packages/protocol-devtools-evm/src/dvn/sdk.ts
@@ -5,11 +5,10 @@ import { OmniSDK, type Provider } from '@layerzerolabs/devtools-evm'
 import { printJson } from '@layerzerolabs/io-devtools'
 import { DVNDstConfigSchema } from './schema'
 import { abi } from '@layerzerolabs/lz-evm-sdk-v2/artifacts/contracts/uln/dvn/DVN.sol/DVN.json'
-import { Contract } from '@ethersproject/contracts'
 
 export class DVN extends OmniSDK implements IDVN {
     constructor(provider: Provider, point: OmniPoint) {
-        super({ eid: point.eid, contract: new Contract(point.address, abi).connect(provider) })
+        super(provider, point, abi)
     }
 
     async getDstConfig(eid: EndpointId): Promise<DVNDstConfig> {

--- a/packages/protocol-devtools-evm/src/dvn/sdk.ts
+++ b/packages/protocol-devtools-evm/src/dvn/sdk.ts
@@ -5,10 +5,11 @@ import { OmniSDK, type Provider } from '@layerzerolabs/devtools-evm'
 import { printJson } from '@layerzerolabs/io-devtools'
 import { DVNDstConfigSchema } from './schema'
 import { abi } from '@layerzerolabs/lz-evm-sdk-v2/artifacts/contracts/uln/dvn/DVN.sol/DVN.json'
+import { Contract } from '@ethersproject/contracts'
 
 export class DVN extends OmniSDK implements IDVN {
     constructor(provider: Provider, point: OmniPoint) {
-        super(provider, point, abi)
+        super({ eid: point.eid, contract: new Contract(point.address, abi).connect(provider) })
     }
 
     async getDstConfig(eid: EndpointId): Promise<DVNDstConfig> {

--- a/packages/protocol-devtools-evm/src/endpointv2/sdk.ts
+++ b/packages/protocol-devtools-evm/src/endpointv2/sdk.ts
@@ -28,7 +28,6 @@ import { Uln302SetExecutorConfig } from '@layerzerolabs/protocol-devtools'
 import { printJson } from '@layerzerolabs/io-devtools'
 import { ReceiveLibrarySchema } from './schema'
 import { abi } from '@layerzerolabs/lz-evm-sdk-v2/artifacts/contracts/EndpointV2.sol/EndpointV2.json'
-import { Contract } from '@ethersproject/contracts'
 
 const CONFIG_TYPE_EXECUTOR = 1
 const CONFIG_TYPE_ULN = 2
@@ -40,7 +39,7 @@ const CONFIG_TYPE_ULN = 2
  */
 export class EndpointV2 extends OmniSDK implements IEndpointV2 {
     constructor(provider: Provider, point: OmniPoint) {
-        super({ eid: point.eid, contract: new Contract(point.address, abi).connect(provider) })
+        super(provider, point, abi)
     }
 
     @AsyncRetriable()

--- a/packages/protocol-devtools-evm/src/endpointv2/sdk.ts
+++ b/packages/protocol-devtools-evm/src/endpointv2/sdk.ts
@@ -28,6 +28,7 @@ import { Uln302SetExecutorConfig } from '@layerzerolabs/protocol-devtools'
 import { printJson } from '@layerzerolabs/io-devtools'
 import { ReceiveLibrarySchema } from './schema'
 import { abi } from '@layerzerolabs/lz-evm-sdk-v2/artifacts/contracts/EndpointV2.sol/EndpointV2.json'
+import { Contract } from '@ethersproject/contracts'
 
 const CONFIG_TYPE_EXECUTOR = 1
 const CONFIG_TYPE_ULN = 2
@@ -39,7 +40,7 @@ const CONFIG_TYPE_ULN = 2
  */
 export class EndpointV2 extends OmniSDK implements IEndpointV2 {
     constructor(provider: Provider, point: OmniPoint) {
-        super(provider, point, abi)
+        super({ eid: point.eid, contract: new Contract(point.address, abi).connect(provider) })
     }
 
     @AsyncRetriable()

--- a/packages/protocol-devtools-evm/src/executor/sdk.ts
+++ b/packages/protocol-devtools-evm/src/executor/sdk.ts
@@ -5,11 +5,10 @@ import { OmniSDK, type Provider } from '@layerzerolabs/devtools-evm'
 import { printJson } from '@layerzerolabs/io-devtools'
 import { ExecutorDstConfigSchema } from './schema'
 import { abi } from '@layerzerolabs/lz-evm-sdk-v2/artifacts/contracts/Executor.sol/Executor.json'
-import { Contract } from '@ethersproject/contracts'
 
 export class Executor extends OmniSDK implements IExecutor {
     constructor(provider: Provider, point: OmniPoint) {
-        super({ eid: point.eid, contract: new Contract(point.address, abi).connect(provider) })
+        super(provider, point, abi)
     }
 
     async getDstConfig(eid: EndpointId): Promise<ExecutorDstConfig> {

--- a/packages/protocol-devtools-evm/src/executor/sdk.ts
+++ b/packages/protocol-devtools-evm/src/executor/sdk.ts
@@ -5,10 +5,11 @@ import { OmniSDK, type Provider } from '@layerzerolabs/devtools-evm'
 import { printJson } from '@layerzerolabs/io-devtools'
 import { ExecutorDstConfigSchema } from './schema'
 import { abi } from '@layerzerolabs/lz-evm-sdk-v2/artifacts/contracts/Executor.sol/Executor.json'
+import { Contract } from '@ethersproject/contracts'
 
 export class Executor extends OmniSDK implements IExecutor {
     constructor(provider: Provider, point: OmniPoint) {
-        super(provider, point, abi)
+        super({ eid: point.eid, contract: new Contract(point.address, abi).connect(provider) })
     }
 
     async getDstConfig(eid: EndpointId): Promise<ExecutorDstConfig> {

--- a/packages/protocol-devtools-evm/src/priceFeed/sdk.ts
+++ b/packages/protocol-devtools-evm/src/priceFeed/sdk.ts
@@ -5,10 +5,11 @@ import { OmniSDK, type Provider } from '@layerzerolabs/devtools-evm'
 import { printJson } from '@layerzerolabs/io-devtools'
 import { PriceDataSchema } from './schema'
 import { abi } from '@layerzerolabs/lz-evm-sdk-v2/artifacts/contracts/PriceFeed.sol/PriceFeed.json'
+import { Contract } from '@ethersproject/contracts'
 
 export class PriceFeed extends OmniSDK implements IPriceFeed {
     constructor(provider: Provider, point: OmniPoint) {
-        super(provider, point, abi)
+        super({ eid: point.eid, contract: new Contract(point.address, abi).connect(provider) })
     }
 
     async getPrice(eid: EndpointId): Promise<PriceData> {

--- a/packages/protocol-devtools-evm/src/priceFeed/sdk.ts
+++ b/packages/protocol-devtools-evm/src/priceFeed/sdk.ts
@@ -5,11 +5,10 @@ import { OmniSDK, type Provider } from '@layerzerolabs/devtools-evm'
 import { printJson } from '@layerzerolabs/io-devtools'
 import { PriceDataSchema } from './schema'
 import { abi } from '@layerzerolabs/lz-evm-sdk-v2/artifacts/contracts/PriceFeed.sol/PriceFeed.json'
-import { Contract } from '@ethersproject/contracts'
 
 export class PriceFeed extends OmniSDK implements IPriceFeed {
     constructor(provider: Provider, point: OmniPoint) {
-        super({ eid: point.eid, contract: new Contract(point.address, abi).connect(provider) })
+        super(provider, point, abi)
     }
 
     async getPrice(eid: EndpointId): Promise<PriceData> {

--- a/packages/protocol-devtools-evm/src/uln302/sdk.ts
+++ b/packages/protocol-devtools-evm/src/uln302/sdk.ts
@@ -19,14 +19,13 @@ import assert from 'assert'
 import { printBoolean, printJson } from '@layerzerolabs/io-devtools'
 import { isZero, AsyncRetriable } from '@layerzerolabs/devtools'
 import { OmniSDK, Provider, addChecksum, makeZeroAddress } from '@layerzerolabs/devtools-evm'
-import { Contract } from '@ethersproject/contracts'
 // Although this SDK is not specific to SendUln302, it uses the SendUln302 ABI
 // because it contains all the necessary method fragments
 import { abi } from '@layerzerolabs/lz-evm-sdk-v2/artifacts/contracts/uln/uln302/SendUln302.sol/SendUln302.json'
 
 export class Uln302 extends OmniSDK implements IUln302 {
     constructor(provider: Provider, point: OmniPoint) {
-        super({ eid: point.eid, contract: new Contract(point.address, abi).connect(provider) })
+        super(provider, point, abi)
     }
 
     /**

--- a/packages/ua-devtools-evm-hardhat/src/tasks/oapp/enforced.opts.get.ts
+++ b/packages/ua-devtools-evm-hardhat/src/tasks/oapp/enforced.opts.get.ts
@@ -4,7 +4,7 @@ import { printCrossTable, printRecord, setDefaultLogLevel } from '@layerzerolabs
 import { SUBTASK_LZ_OAPP_CONFIG_LOAD, TASK_LZ_OAPP_ENFORCED_OPTS_GET } from '@/constants/tasks'
 import { printLogo } from '@layerzerolabs/io-devtools/swag'
 import { EncodedOption, OAppOmniGraph } from '@layerzerolabs/ua-devtools'
-import { createConnectedContractFactory, types } from '@layerzerolabs/devtools-evm-hardhat'
+import { createProviderFactory, types } from '@layerzerolabs/devtools-evm-hardhat'
 import { createOAppFactory } from '@layerzerolabs/ua-devtools-evm'
 import { checkOAppEnforcedOptions } from '@layerzerolabs/ua-devtools'
 import { getNetworkNameForEid } from '@layerzerolabs/devtools-evm-hardhat'
@@ -39,8 +39,7 @@ const action: ActionType<TaskArgs> = async ({ oappConfig: oappConfigPath, logLev
         }))
 
     // At this point we are ready read data from the OApp
-    const contractFactory = createConnectedContractFactory()
-    const oAppFactory = createOAppFactory(contractFactory)
+    const oAppFactory = createOAppFactory(createProviderFactory())
 
     try {
         const enforcedOptions = await checkOAppEnforcedOptions(graph, oAppFactory)

--- a/packages/ua-devtools-evm-hardhat/src/tasks/oapp/peers.get.ts
+++ b/packages/ua-devtools-evm-hardhat/src/tasks/oapp/peers.get.ts
@@ -4,7 +4,7 @@ import { createLogger, printBoolean, printCrossTable, setDefaultLogLevel } from 
 import { SUBTASK_LZ_OAPP_CONFIG_LOAD, TASK_LZ_OAPP_PEERS_GET } from '@/constants/tasks'
 import { printLogo } from '@layerzerolabs/io-devtools/swag'
 import { OAppOmniGraph } from '@layerzerolabs/ua-devtools'
-import { createConnectedContractFactory, types } from '@layerzerolabs/devtools-evm-hardhat'
+import { createProviderFactory, types } from '@layerzerolabs/devtools-evm-hardhat'
 import { createOAppFactory } from '@layerzerolabs/ua-devtools-evm'
 import { checkOAppPeers } from '@layerzerolabs/ua-devtools'
 import { getNetworkNameForEid } from '@layerzerolabs/devtools-evm-hardhat'
@@ -43,8 +43,7 @@ const action: ActionType<TaskArgs> = async ({ oappConfig: oappConfigPath, logLev
 
     // At this point we are ready read data from the OApp
     logger.verbose(`Reading peers from OApps`)
-    const contractFactory = createConnectedContractFactory()
-    const oAppFactory = createOAppFactory(contractFactory)
+    const oAppFactory = createOAppFactory(createProviderFactory())
 
     try {
         const peers = await checkOAppPeers(graph, oAppFactory)

--- a/packages/ua-devtools-evm-hardhat/src/tasks/oapp/wire/subtask.configure.ts
+++ b/packages/ua-devtools-evm-hardhat/src/tasks/oapp/wire/subtask.configure.ts
@@ -1,6 +1,6 @@
 import { SUBTASK_LZ_OAPP_WIRE_CONFIGURE } from '@/constants'
 import { OmniGraphBuilder, OmniTransaction } from '@layerzerolabs/devtools'
-import { createConnectedContractFactory, types } from '@layerzerolabs/devtools-evm-hardhat'
+import { createProviderFactory, types } from '@layerzerolabs/devtools-evm-hardhat'
 import { createModuleLogger, printJson } from '@layerzerolabs/io-devtools'
 import { IOApp, OAppOmniGraph, configureOApp } from '@layerzerolabs/ua-devtools'
 import { createOAppFactory } from '@layerzerolabs/ua-devtools-evm'
@@ -11,7 +11,7 @@ import type { SubtaskConfigureTaskArgs } from './types'
 const action: ActionType<SubtaskConfigureTaskArgs<OAppOmniGraph, IOApp>> = async ({
     graph,
     configurator = configureOApp,
-    sdkFactory = createOAppFactory(createConnectedContractFactory()),
+    sdkFactory = createOAppFactory(createProviderFactory()),
 }): Promise<OmniTransaction[]> => {
     const logger = createModuleLogger(SUBTASK_LZ_OAPP_WIRE_CONFIGURE)
 

--- a/packages/ua-devtools-evm-hardhat/src/tasks/ownable/transfer.ownership.ts
+++ b/packages/ua-devtools-evm-hardhat/src/tasks/ownable/transfer.ownership.ts
@@ -6,10 +6,10 @@ import { OwnableOmniGraph } from '@layerzerolabs/ua-devtools'
 import {
     types,
     SUBTASK_LZ_SIGN_AND_SEND,
-    createConnectedContractFactory,
     createSignerFactory,
     createGnosisSignerFactory,
     formatOmniTransaction,
+    createProviderFactory,
 } from '@layerzerolabs/devtools-evm-hardhat'
 import { printLogo, printRecords } from '@layerzerolabs/io-devtools/swag'
 import { type SignAndSendResult } from '@layerzerolabs/devtools'
@@ -58,7 +58,7 @@ const action: ActionType<TaskArgs> = async (
     // At this point we are ready to create the list of transactions
     logger.verbose(`Creating a list of ownership transferring transactions`)
 
-    const createSdk = createOwnableFactory(createOAppFactory(createConnectedContractFactory()))
+    const createSdk = createOwnableFactory(createOAppFactory(createProviderFactory()))
     const transactions = await configureOwnable(graph, createSdk)
 
     // Flood users with debug output

--- a/packages/ua-devtools-evm/package.json
+++ b/packages/ua-devtools-evm/package.json
@@ -39,6 +39,7 @@
     "@ethersproject/bignumber": "^5.7.0",
     "@ethersproject/constants": "^5.7.0",
     "@ethersproject/contracts": "^5.7.0",
+    "@ethersproject/providers": "^5.7.2",
     "@layerzerolabs/devtools": "~0.3.24",
     "@layerzerolabs/devtools-evm": "~0.4.1",
     "@layerzerolabs/io-devtools": "~0.1.12",

--- a/packages/ua-devtools-evm/package.json
+++ b/packages/ua-devtools-evm/package.json
@@ -34,6 +34,7 @@
     "p-memoize": "~4.0.4"
   },
   "devDependencies": {
+    "@ethersproject/abi": "~5.7.0",
     "@ethersproject/address": "~5.7.0",
     "@ethersproject/bignumber": "^5.7.0",
     "@ethersproject/constants": "^5.7.0",
@@ -42,7 +43,10 @@
     "@layerzerolabs/devtools-evm": "~0.4.1",
     "@layerzerolabs/io-devtools": "~0.1.12",
     "@layerzerolabs/lz-definitions": "^2.3.34",
+    "@layerzerolabs/lz-evm-sdk-v1": "^2.3.24",
+    "@layerzerolabs/lz-evm-sdk-v2": "^2.3.24",
     "@layerzerolabs/lz-v2-utilities": "^2.3.34",
+    "@layerzerolabs/oapp-evm": "~0.0.2",
     "@layerzerolabs/protocol-devtools": "~0.4.2",
     "@layerzerolabs/protocol-devtools-evm": "~1.1.0",
     "@layerzerolabs/test-devtools": "~0.2.8",
@@ -59,13 +63,17 @@
     "zod": "^3.22.4"
   },
   "peerDependencies": {
+    "@ethersproject/abi": "^5.7.0",
     "@ethersproject/constants": "^5.7.0",
     "@ethersproject/contracts": "^5.7.0",
     "@layerzerolabs/devtools": "~0.3.24",
     "@layerzerolabs/devtools-evm": "~0.4.1",
     "@layerzerolabs/io-devtools": "~0.1.12",
     "@layerzerolabs/lz-definitions": "^2.3.3",
+    "@layerzerolabs/lz-evm-sdk-v1": "^2.3.24",
+    "@layerzerolabs/lz-evm-sdk-v2": "^2.3.24",
     "@layerzerolabs/lz-v2-utilities": "^2.3.3",
+    "@layerzerolabs/oapp-evm": "^0.0.2",
     "@layerzerolabs/protocol-devtools": "~0.4.2",
     "@layerzerolabs/protocol-devtools-evm": "~1.1.0",
     "@layerzerolabs/ua-devtools": "~1.0.3",

--- a/packages/ua-devtools-evm/src/erc20/abi.ts
+++ b/packages/ua-devtools-evm/src/erc20/abi.ts
@@ -1,0 +1,222 @@
+export const abi = [
+    {
+        constant: true,
+        inputs: [],
+        name: 'name',
+        outputs: [
+            {
+                name: '',
+                type: 'string',
+            },
+        ],
+        payable: false,
+        stateMutability: 'view',
+        type: 'function',
+    },
+    {
+        constant: false,
+        inputs: [
+            {
+                name: '_spender',
+                type: 'address',
+            },
+            {
+                name: '_value',
+                type: 'uint256',
+            },
+        ],
+        name: 'approve',
+        outputs: [
+            {
+                name: '',
+                type: 'bool',
+            },
+        ],
+        payable: false,
+        stateMutability: 'nonpayable',
+        type: 'function',
+    },
+    {
+        constant: true,
+        inputs: [],
+        name: 'totalSupply',
+        outputs: [
+            {
+                name: '',
+                type: 'uint256',
+            },
+        ],
+        payable: false,
+        stateMutability: 'view',
+        type: 'function',
+    },
+    {
+        constant: false,
+        inputs: [
+            {
+                name: '_from',
+                type: 'address',
+            },
+            {
+                name: '_to',
+                type: 'address',
+            },
+            {
+                name: '_value',
+                type: 'uint256',
+            },
+        ],
+        name: 'transferFrom',
+        outputs: [
+            {
+                name: '',
+                type: 'bool',
+            },
+        ],
+        payable: false,
+        stateMutability: 'nonpayable',
+        type: 'function',
+    },
+    {
+        constant: true,
+        inputs: [],
+        name: 'decimals',
+        outputs: [
+            {
+                name: '',
+                type: 'uint8',
+            },
+        ],
+        payable: false,
+        stateMutability: 'view',
+        type: 'function',
+    },
+    {
+        constant: true,
+        inputs: [
+            {
+                name: '_owner',
+                type: 'address',
+            },
+        ],
+        name: 'balanceOf',
+        outputs: [
+            {
+                name: 'balance',
+                type: 'uint256',
+            },
+        ],
+        payable: false,
+        stateMutability: 'view',
+        type: 'function',
+    },
+    {
+        constant: true,
+        inputs: [],
+        name: 'symbol',
+        outputs: [
+            {
+                name: '',
+                type: 'string',
+            },
+        ],
+        payable: false,
+        stateMutability: 'view',
+        type: 'function',
+    },
+    {
+        constant: false,
+        inputs: [
+            {
+                name: '_to',
+                type: 'address',
+            },
+            {
+                name: '_value',
+                type: 'uint256',
+            },
+        ],
+        name: 'transfer',
+        outputs: [
+            {
+                name: '',
+                type: 'bool',
+            },
+        ],
+        payable: false,
+        stateMutability: 'nonpayable',
+        type: 'function',
+    },
+    {
+        constant: true,
+        inputs: [
+            {
+                name: '_owner',
+                type: 'address',
+            },
+            {
+                name: '_spender',
+                type: 'address',
+            },
+        ],
+        name: 'allowance',
+        outputs: [
+            {
+                name: '',
+                type: 'uint256',
+            },
+        ],
+        payable: false,
+        stateMutability: 'view',
+        type: 'function',
+    },
+    {
+        payable: true,
+        stateMutability: 'payable',
+        type: 'fallback',
+    },
+    {
+        anonymous: false,
+        inputs: [
+            {
+                indexed: true,
+                name: 'owner',
+                type: 'address',
+            },
+            {
+                indexed: true,
+                name: 'spender',
+                type: 'address',
+            },
+            {
+                indexed: false,
+                name: 'value',
+                type: 'uint256',
+            },
+        ],
+        name: 'Approval',
+        type: 'event',
+    },
+    {
+        anonymous: false,
+        inputs: [
+            {
+                indexed: true,
+                name: 'from',
+                type: 'address',
+            },
+            {
+                indexed: true,
+                name: 'to',
+                type: 'address',
+            },
+            {
+                indexed: false,
+                name: 'value',
+                type: 'uint256',
+            },
+        ],
+        name: 'Transfer',
+        type: 'event',
+    },
+]

--- a/packages/ua-devtools-evm/src/erc20/factory.ts
+++ b/packages/ua-devtools-evm/src/erc20/factory.ts
@@ -1,19 +1,18 @@
 import pMemoize from 'p-memoize'
 
-import { OmniPoint } from '@layerzerolabs/devtools'
+import type { OmniPoint } from '@layerzerolabs/devtools'
 
 import { ERC20 } from './sdk'
-import { ERC20Factory } from './types'
+import type { ERC20Factory } from './types'
 
-import type { OmniContractFactory } from '@layerzerolabs/devtools-evm'
+import type { ProviderFactory } from '@layerzerolabs/devtools-evm'
 
 /**
  * Syntactic sugar that creates an instance of EVM `ERC20` SDK
- * based on an `OmniPoint` with help of an `OmniContractFactory`
+ * based on an `OmniPoint` with help of a `ProviderFactory`
  *
- * @param {OmniContractFactory} contractFactory
+ * @param {ProviderFactory} providerFactory
  * @returns {ERC20Factory<ERC20>}
  */
-export const createERC20Factory = <TOmniPoint = never>(
-    contractFactory: OmniContractFactory<TOmniPoint | OmniPoint>
-): ERC20Factory<ERC20, TOmniPoint> => pMemoize(async (point) => new ERC20(await contractFactory(point)))
+export const createERC20Factory = (providerFactory: ProviderFactory): ERC20Factory<ERC20, OmniPoint> =>
+    pMemoize(async (point) => new ERC20(await providerFactory(point.eid), point))

--- a/packages/ua-devtools-evm/src/erc20/sdk.ts
+++ b/packages/ua-devtools-evm/src/erc20/sdk.ts
@@ -1,11 +1,17 @@
-import { AsyncRetriable, type OmniAddress, type OmniTransaction, tapError } from '@layerzerolabs/devtools'
+import { AsyncRetriable, type OmniAddress, OmniPoint, type OmniTransaction, tapError } from '@layerzerolabs/devtools'
 
 import type { IERC20 } from './types'
 import { Ownable } from '@/ownable/sdk'
 import { z } from 'zod'
-import { BigNumberishBigIntSchema, BigNumberishNumberSchema } from '@layerzerolabs/devtools-evm'
+import { BigNumberishBigIntSchema, BigNumberishNumberSchema, Provider } from '@layerzerolabs/devtools-evm'
+import { abi as defaultAbi } from './abi'
+import { JsonFragment } from '@ethersproject/abi'
 
 export class ERC20 extends Ownable implements IERC20 {
+    constructor(provider: Provider, point: OmniPoint, abi: JsonFragment[] = defaultAbi) {
+        super(provider, point, abi)
+    }
+
     @AsyncRetriable()
     async getDecimals(): Promise<number> {
         this.logger.verbose(`Getting token decimals`)

--- a/packages/ua-devtools-evm/src/lzapp/abi.ts
+++ b/packages/ua-devtools-evm/src/lzapp/abi.ts
@@ -1,0 +1,19 @@
+export const abi = [
+    {
+        inputs: [{ internalType: 'uint16', name: '_remoteChainId', type: 'uint16' }],
+        name: 'getTrustedRemoteAddress',
+        outputs: [{ internalType: 'bytes', name: '', type: 'bytes' }],
+        stateMutability: 'view',
+        type: 'function',
+    },
+    {
+        inputs: [
+            { internalType: 'uint16', name: '_remoteChainId', type: 'uint16' },
+            { internalType: 'bytes', name: '_remoteAddress', type: 'bytes' },
+        ],
+        name: 'setTrustedRemoteAddress',
+        outputs: [],
+        stateMutability: 'nonpayable',
+        type: 'function',
+    },
+]

--- a/packages/ua-devtools-evm/src/lzapp/factory.ts
+++ b/packages/ua-devtools-evm/src/lzapp/factory.ts
@@ -1,14 +1,14 @@
 import pMemoize from 'p-memoize'
 import type { LzAppFactory } from '@layerzerolabs/ua-devtools'
-import type { OmniContractFactory } from '@layerzerolabs/devtools-evm'
+import type { ProviderFactory } from '@layerzerolabs/devtools-evm'
 import { LzApp } from './sdk'
 
 /**
  * Syntactic sugar that creates an instance of EVM `LZApp` SDK
- * based on an `OmniPoint` with help of an `OmniContractFactory`
+ * based on an `OmniPoint` with help of a `ProviderFactory`
  *
- * @param {OmniContractFactory} contractFactory
+ * @param {ProviderFactory} providerFactory
  * @returns {LzAppFactory<LZApp>}
  */
-export const createLzAppFactory = (contractFactory: OmniContractFactory): LzAppFactory<LzApp> =>
-    pMemoize(async (point) => new LzApp(await contractFactory(point)))
+export const createLzAppFactory = (providerFactory: ProviderFactory): LzAppFactory<LzApp> =>
+    pMemoize(async (point) => new LzApp(await providerFactory(point.eid), point))

--- a/packages/ua-devtools-evm/src/lzapp/sdk.ts
+++ b/packages/ua-devtools-evm/src/lzapp/sdk.ts
@@ -7,14 +7,16 @@ import {
     ignoreZero,
     makeBytes32,
     AsyncRetriable,
+    OmniPoint,
 } from '@layerzerolabs/devtools'
-import { type OmniContract, parseGenericError } from '@layerzerolabs/devtools-evm'
+import { parseGenericError, Provider } from '@layerzerolabs/devtools-evm'
 import type { EndpointId } from '@layerzerolabs/lz-definitions'
 import { OmniSDK } from '@layerzerolabs/devtools-evm'
+import { abi } from './abi'
 
 export class LzApp extends OmniSDK implements ILzApp {
-    constructor(contract: OmniContract) {
-        super(contract)
+    constructor(provider: Provider, point: OmniPoint) {
+        super(provider, point, abi)
     }
 
     @AsyncRetriable()

--- a/packages/ua-devtools-evm/src/oapp/abi.ts
+++ b/packages/ua-devtools-evm/src/oapp/abi.ts
@@ -1,0 +1,10 @@
+import { abi as defaultAbi } from '@layerzerolabs/oapp-evm/artifacts/OApp.sol/OApp.json'
+import { abi as defaultOptionsType3Abi } from '@layerzerolabs/oapp-evm/artifacts/OAppOptionsType3.sol/OAppOptionsType3.json'
+
+// Even though duplicated fragments don't throw errors, they still pollute the interface with warning console.logs
+// To prevent this, we'll run a simple deduplication algorithm - use JSON encoded values as hashes
+//
+// We do this because both ABIs define Ownable methods & events
+export const abi = Object.values(
+    Object.fromEntries([...defaultAbi, ...defaultOptionsType3Abi].map((abi) => [JSON.stringify(abi), abi]))
+)

--- a/packages/ua-devtools-evm/src/oapp/factory.ts
+++ b/packages/ua-devtools-evm/src/oapp/factory.ts
@@ -1,16 +1,14 @@
 import pMemoize from 'p-memoize'
 import type { OAppFactory } from '@layerzerolabs/ua-devtools'
-import type { OmniContractFactory } from '@layerzerolabs/devtools-evm'
+import type { ProviderFactory } from '@layerzerolabs/devtools-evm'
 import { OApp } from './sdk'
 
 /**
  * Syntactic sugar that creates an instance of EVM `OApp` SDK
- * based on an `OmniPoint` with help of an `OmniContractFactory`
- * and an (optional) `EndpointV2Factory`
+ * based on an `OmniPoint` with help of a `ProviderFactory`
  *
- * @param {OmniContractFactory} contractFactory
- * @param {EndpointV2Factory} [EndpointV2Factory]
+ * @param {OmniContractFactory} providerFactory
  * @returns {EndpointV2Factory<EndpointV2>}
  */
-export const createOAppFactory = (contractFactory: OmniContractFactory): OAppFactory<OApp> =>
-    pMemoize(async (point) => new OApp(await contractFactory(point)))
+export const createOAppFactory = (providerFactory: ProviderFactory): OAppFactory<OApp> =>
+    pMemoize(async (point) => new OApp(await providerFactory(point.eid), point))

--- a/packages/ua-devtools-evm/src/oapp/sdk.ts
+++ b/packages/ua-devtools-evm/src/oapp/sdk.ts
@@ -19,7 +19,7 @@ import { printJson } from '@layerzerolabs/io-devtools'
 import { mapError, AsyncRetriable } from '@layerzerolabs/devtools'
 import { Ownable } from '@/ownable/sdk'
 import { EndpointV2 } from '@layerzerolabs/protocol-devtools-evm'
-import { abi as defaultAbi } from '@layerzerolabs/oapp-evm/artifacts/OApp.sol/OApp.json'
+import { abi as defaultAbi } from './abi'
 
 export class OApp extends Ownable implements IOApp {
     constructor(provider: Provider, point: OmniPoint, abi: JsonFragment[] = defaultAbi) {

--- a/packages/ua-devtools-evm/src/oapp/sdk.ts
+++ b/packages/ua-devtools-evm/src/oapp/sdk.ts
@@ -9,7 +9,9 @@ import {
     Bytes,
     normalizePeer,
     denormalizePeer,
+    OmniPoint,
 } from '@layerzerolabs/devtools'
+import type { JsonFragment } from '@ethersproject/abi'
 import { formatOmniContract, BigNumberishBigIntSchema, Provider } from '@layerzerolabs/devtools-evm'
 import type { EndpointId } from '@layerzerolabs/lz-definitions'
 import type { IEndpointV2 } from '@layerzerolabs/protocol-devtools'
@@ -17,8 +19,13 @@ import { printJson } from '@layerzerolabs/io-devtools'
 import { mapError, AsyncRetriable } from '@layerzerolabs/devtools'
 import { Ownable } from '@/ownable/sdk'
 import { EndpointV2 } from '@layerzerolabs/protocol-devtools-evm'
+import { abi as defaultAbi } from '@layerzerolabs/oapp-evm/artifacts/OApp.sol/OApp.json'
 
 export class OApp extends Ownable implements IOApp {
+    constructor(provider: Provider, point: OmniPoint, abi: JsonFragment[] = defaultAbi) {
+        super(provider, point, abi)
+    }
+
     @AsyncRetriable()
     async getEndpointSDK(): Promise<IEndpointV2> {
         this.logger.debug(`Getting EndpointV2 SDK`)

--- a/packages/ua-devtools-evm/src/ownable/abi.ts
+++ b/packages/ua-devtools-evm/src/ownable/abi.ts
@@ -1,0 +1,52 @@
+export const abi = [
+    {
+        type: 'function',
+        name: 'owner',
+        inputs: [],
+        outputs: [{ name: '', type: 'address', internalType: 'address' }],
+        stateMutability: 'view',
+    },
+    {
+        type: 'function',
+        name: 'renounceOwnership',
+        inputs: [],
+        outputs: [],
+        stateMutability: 'nonpayable',
+    },
+    {
+        type: 'function',
+        name: 'transferOwnership',
+        inputs: [{ name: 'newOwner', type: 'address', internalType: 'address' }],
+        outputs: [],
+        stateMutability: 'nonpayable',
+    },
+    {
+        type: 'event',
+        name: 'OwnershipTransferred',
+        inputs: [
+            {
+                name: 'previousOwner',
+                type: 'address',
+                indexed: true,
+                internalType: 'address',
+            },
+            {
+                name: 'newOwner',
+                type: 'address',
+                indexed: true,
+                internalType: 'address',
+            },
+        ],
+        anonymous: false,
+    },
+    {
+        type: 'error',
+        name: 'OwnableInvalidOwner',
+        inputs: [{ name: 'owner', type: 'address', internalType: 'address' }],
+    },
+    {
+        type: 'error',
+        name: 'OwnableUnauthorizedAccount',
+        inputs: [{ name: 'account', type: 'address', internalType: 'address' }],
+    },
+]

--- a/packages/ua-devtools-evm/src/ownable/sdk.ts
+++ b/packages/ua-devtools-evm/src/ownable/sdk.ts
@@ -1,10 +1,16 @@
-import type { OmniAddress, OmniTransaction } from '@layerzerolabs/devtools'
-import { OmniSDK } from '@layerzerolabs/devtools-evm'
+import type { OmniAddress, OmniPoint, OmniTransaction } from '@layerzerolabs/devtools'
+import { OmniSDK, Provider } from '@layerzerolabs/devtools-evm'
 import type { IOwnable } from '@layerzerolabs/ua-devtools'
 import { AsyncRetriable } from '@layerzerolabs/devtools'
 import { OwnableMixin } from './mixin'
+import { abi as defaultAbi } from './abi'
+import { JsonFragment } from '@ethersproject/abi'
 
 export class Ownable extends OmniSDK implements IOwnable {
+    constructor(provider: Provider, point: OmniPoint, abi: JsonFragment[] = defaultAbi) {
+        super(provider, point, abi)
+    }
+
     @AsyncRetriable()
     async getOwner(): Promise<OmniAddress | undefined> {
         return OwnableMixin.getOwner.call(this)

--- a/packages/ua-devtools-evm/test/erc20/sdk.test.ts
+++ b/packages/ua-devtools-evm/test/erc20/sdk.test.ts
@@ -1,41 +1,21 @@
 import fc from 'fast-check'
-import { endpointArbitrary, evmAddressArbitrary } from '@layerzerolabs/test-devtools'
-import { Contract } from '@ethersproject/contracts'
+import { evmAddressArbitrary, pointArbitrary } from '@layerzerolabs/test-devtools'
 import { ERC20 } from '@/erc20/sdk'
-import { OmniContract } from '@layerzerolabs/devtools-evm'
-import { BigNumber } from '@ethersproject/bignumber/lib/bignumber'
+import { JsonRpcProvider } from '@ethersproject/providers'
 
 describe('erc20/sdk', () => {
-    const jestFunctionArbitrary = fc.anything().map(() => jest.fn())
-
-    const erc20ContractArbitrary = fc.record({
-        address: evmAddressArbitrary,
-        name: jestFunctionArbitrary,
-        decimals: jestFunctionArbitrary,
-        symbol: jestFunctionArbitrary,
-        allowance: jestFunctionArbitrary,
-        balanceOf: jestFunctionArbitrary,
-        interface: fc.record({
-            encodeFunctionData: jestFunctionArbitrary,
-        }),
-    }) as fc.Arbitrary<unknown> as fc.Arbitrary<Contract>
-
-    const omniContractArbitrary: fc.Arbitrary<OmniContract> = fc.record({
-        eid: endpointArbitrary,
-        contract: erc20ContractArbitrary,
-    })
-
     describe('getName', () => {
         it('should return the contract name', async () => {
             await fc.assert(
-                fc.asyncProperty(omniContractArbitrary, fc.string(), async (omniContract, name) => {
-                    omniContract.contract.name.mockResolvedValue(name)
+                fc.asyncProperty(pointArbitrary, fc.string(), async (point, name) => {
+                    const provider = new JsonRpcProvider()
+                    const sdk = new ERC20(provider, point)
 
-                    const sdk = new ERC20(omniContract)
+                    jest.spyOn(provider, 'call').mockResolvedValue(
+                        sdk.contract.contract.interface.encodeFunctionResult('name', [name])
+                    )
 
                     await expect(sdk.getName()).resolves.toBe(name)
-
-                    expect(omniContract.contract.name).toHaveBeenCalledTimes(1)
                 })
             )
         })
@@ -44,14 +24,15 @@ describe('erc20/sdk', () => {
     describe('getSymbol', () => {
         it('should return the contract symbol', async () => {
             await fc.assert(
-                fc.asyncProperty(omniContractArbitrary, fc.string(), async (omniContract, symbol) => {
-                    omniContract.contract.symbol.mockResolvedValue(symbol)
+                fc.asyncProperty(pointArbitrary, fc.string(), async (point, symbol) => {
+                    const provider = new JsonRpcProvider()
+                    const sdk = new ERC20(provider, point)
 
-                    const sdk = new ERC20(omniContract)
+                    jest.spyOn(provider, 'call').mockResolvedValue(
+                        sdk.contract.contract.interface.encodeFunctionResult('symbol', [symbol])
+                    )
 
                     await expect(sdk.getSymbol()).resolves.toBe(symbol)
-
-                    expect(omniContract.contract.symbol).toHaveBeenCalledTimes(1)
                 })
             )
         })
@@ -60,14 +41,15 @@ describe('erc20/sdk', () => {
     describe('getDecimals', () => {
         it('should return the contract decimals', async () => {
             await fc.assert(
-                fc.asyncProperty(omniContractArbitrary, fc.integer({ min: 1 }), async (omniContract, decimals) => {
-                    omniContract.contract.decimals.mockResolvedValue(decimals)
+                fc.asyncProperty(pointArbitrary, fc.integer({ min: 1, max: 255 }), async (point, decimals) => {
+                    const provider = new JsonRpcProvider()
+                    const sdk = new ERC20(provider, point)
 
-                    const sdk = new ERC20(omniContract)
+                    jest.spyOn(provider, 'call').mockResolvedValue(
+                        sdk.contract.contract.interface.encodeFunctionResult('decimals', [decimals])
+                    )
 
                     await expect(sdk.getDecimals()).resolves.toBe(decimals)
-
-                    expect(omniContract.contract.decimals).toHaveBeenCalledTimes(1)
                 })
             )
         })
@@ -77,18 +59,18 @@ describe('erc20/sdk', () => {
         it('should return the user balance', async () => {
             await fc.assert(
                 fc.asyncProperty(
-                    omniContractArbitrary,
+                    pointArbitrary,
                     evmAddressArbitrary,
                     fc.bigInt({ min: BigInt(0) }),
-                    async (omniContract, user, balance) => {
-                        omniContract.contract.balanceOf.mockResolvedValue(BigNumber.from(balance))
+                    async (point, user, balance) => {
+                        const provider = new JsonRpcProvider()
+                        const sdk = new ERC20(provider, point)
 
-                        const sdk = new ERC20(omniContract)
+                        jest.spyOn(provider, 'call').mockResolvedValue(
+                            sdk.contract.contract.interface.encodeFunctionResult('balanceOf', [balance])
+                        )
 
                         await expect(sdk.getBalanceOf(user)).resolves.toBe(balance)
-
-                        expect(omniContract.contract.balanceOf).toHaveBeenCalledTimes(1)
-                        expect(omniContract.contract.balanceOf).toHaveBeenCalledWith(user)
                     }
                 )
             )
@@ -99,19 +81,19 @@ describe('erc20/sdk', () => {
         it('should return the user balance', async () => {
             await fc.assert(
                 fc.asyncProperty(
-                    omniContractArbitrary,
+                    pointArbitrary,
                     evmAddressArbitrary,
                     evmAddressArbitrary,
                     fc.bigInt({ min: BigInt(0) }),
-                    async (omniContract, owner, spender, allowance) => {
-                        omniContract.contract.allowance.mockResolvedValue(BigNumber.from(allowance))
+                    async (point, owner, spender, allowance) => {
+                        const provider = new JsonRpcProvider()
+                        const sdk = new ERC20(provider, point)
 
-                        const sdk = new ERC20(omniContract)
+                        jest.spyOn(provider, 'call').mockResolvedValue(
+                            sdk.contract.contract.interface.encodeFunctionResult('allowance', [allowance])
+                        )
 
                         await expect(sdk.getAllowance(owner, spender)).resolves.toBe(allowance)
-
-                        expect(omniContract.contract.allowance).toHaveBeenCalledTimes(1)
-                        expect(omniContract.contract.allowance).toHaveBeenCalledWith(owner, spender)
                     }
                 )
             )

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2141,6 +2141,9 @@ importers:
       '@ethersproject/contracts':
         specifier: ^5.7.0
         version: 5.7.0
+      '@ethersproject/providers':
+        specifier: ^5.7.2
+        version: 5.7.2
       '@layerzerolabs/devtools':
         specifier: ~0.3.24
         version: link:../devtools

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2126,6 +2126,9 @@ importers:
         specifier: ~4.0.4
         version: 4.0.4
     devDependencies:
+      '@ethersproject/abi':
+        specifier: ~5.7.0
+        version: 5.7.0
       '@ethersproject/address':
         specifier: ~5.7.0
         version: 5.7.0
@@ -2150,9 +2153,18 @@ importers:
       '@layerzerolabs/lz-definitions':
         specifier: ^2.3.34
         version: 2.3.34
+      '@layerzerolabs/lz-evm-sdk-v1':
+        specifier: ^2.3.24
+        version: 2.3.34
+      '@layerzerolabs/lz-evm-sdk-v2':
+        specifier: ^2.3.24
+        version: 2.3.34
       '@layerzerolabs/lz-v2-utilities':
         specifier: ^2.3.34
         version: 2.3.34
+      '@layerzerolabs/oapp-evm':
+        specifier: ~0.0.2
+        version: link:../oapp-evm
       '@layerzerolabs/protocol-devtools':
         specifier: ~0.4.2
         version: link:../protocol-devtools

--- a/tests/devtools-cli-test/test/commands/oapp/__data__/setups/valid.setup.ts
+++ b/tests/devtools-cli-test/test/commands/oapp/__data__/setups/valid.setup.ts
@@ -1,8 +1,4 @@
-import {
-    createConnectedContractFactory,
-    createSignerFactory,
-    createDefaultContext,
-} from '@layerzerolabs/devtools-evm-hardhat'
+import { createSignerFactory, createDefaultContext, createProviderFactory } from '@layerzerolabs/devtools-evm-hardhat'
 import { createOAppFactory } from '@layerzerolabs/ua-devtools-evm'
 
 import type { CLISetup } from '@layerzerolabs/devtools-cli'
@@ -19,7 +15,7 @@ createDefaultContext()
  * and will be available
  */
 const setup: CLISetup = {
-    createSdk: createOAppFactory(createConnectedContractFactory()),
+    createSdk: createOAppFactory(createProviderFactory()),
     createSigner: createSignerFactory(),
 }
 

--- a/tests/ua-devtools-evm-hardhat-test/layerzero.config.with-custom-configuration.ts
+++ b/tests/ua-devtools-evm-hardhat-test/layerzero.config.with-custom-configuration.ts
@@ -51,10 +51,11 @@ const MyCustomNodeConfigSchema = OAppNodeConfigSchema.extend({
     customProperty: UIntBigIntSchema,
 })
 
-export const MyCustomOmniGraphHardhatSchema: Zod.ZodSchema<MyCustomOmniGraphHardhat> = createOmniGraphHardhatSchema(
-    createOmniNodeHardhatSchema(MyCustomNodeConfigSchema),
-    createOmniEdgeHardhatSchema(OAppEdgeConfigSchema.optional())
-)
+export const MyCustomOmniGraphHardhatSchema: Zod.ZodSchema<MyCustomOmniGraphHardhat, Zod.ZodTypeDef, unknown> =
+    createOmniGraphHardhatSchema(
+        createOmniNodeHardhatSchema(MyCustomNodeConfigSchema),
+        createOmniEdgeHardhatSchema(OAppEdgeConfigSchema.optional())
+    )
 
 //   .-.-.   .-.-.   .-.-.   .-.-.   .-.-.   .-.-.   .-.-.   .-.-
 //  / / \ \ / / \ \ / / \ \ / / \ \ / / \ \ / / \ \ / / \ \ / / \

--- a/tests/ua-devtools-evm-hardhat-test/test/oapp/check.test.ts
+++ b/tests/ua-devtools-evm-hardhat-test/test/oapp/check.test.ts
@@ -1,7 +1,11 @@
 import 'hardhat'
 import { OAppOmniGraph } from '@layerzerolabs/ua-devtools'
 import { createOAppFactory } from '@layerzerolabs/ua-devtools-evm'
-import { createConnectedContractFactory, createSignerFactory } from '@layerzerolabs/devtools-evm-hardhat'
+import {
+    createConnectedContractFactory,
+    createProviderFactory,
+    createSignerFactory,
+} from '@layerzerolabs/devtools-evm-hardhat'
 import { EndpointId } from '@layerzerolabs/lz-definitions'
 import { deployContract, setupDefaultEndpointV2 } from '@layerzerolabs/test-setup-devtools-evm-hardhat'
 import { checkOAppPeers } from '@layerzerolabs/ua-devtools'
@@ -26,8 +30,7 @@ describe('oapp/check', () => {
                 contracts: [],
                 connections: [],
             }
-            const contractFactory = createConnectedContractFactory()
-            const sdkFactory = createOAppFactory(contractFactory)
+            const sdkFactory = createOAppFactory(createProviderFactory())
             const oAppPeers = await checkOAppPeers(graph, sdkFactory)
 
             expect(oAppPeers).toEqual([])
@@ -62,7 +65,7 @@ describe('oapp/check', () => {
                     },
                 ],
             }
-            const sdkFactory = createOAppFactory(contractFactory)
+            const sdkFactory = createOAppFactory(createProviderFactory())
             const oAppPeers = await checkOAppPeers(graph, sdkFactory)
 
             expect(oAppPeers).toEqual([
@@ -79,7 +82,7 @@ describe('oapp/check', () => {
 
         it('should return one truthy value for connected peers', async () => {
             const contractFactory = createConnectedContractFactory()
-            const sdkFactory = createOAppFactory(contractFactory)
+            const sdkFactory = createOAppFactory(createProviderFactory())
 
             const ethContract = await contractFactory(ethPointHardhat)
             const avaxContract = await contractFactory(avaxPointHardhat)
@@ -132,7 +135,7 @@ describe('oapp/check', () => {
 
         it('should return all truthy values for connected peers', async () => {
             const contractFactory = createConnectedContractFactory()
-            const sdkFactory = createOAppFactory(contractFactory)
+            const sdkFactory = createOAppFactory(createProviderFactory())
 
             const ethContract = await contractFactory(ethPointHardhat)
             const avaxContract = await contractFactory(avaxPointHardhat)

--- a/tests/ua-devtools-evm-hardhat-test/test/oapp/config.test.ts
+++ b/tests/ua-devtools-evm-hardhat-test/test/oapp/config.test.ts
@@ -70,7 +70,7 @@ describe('oapp/config', () => {
 
         contractFactory = createConnectedContractFactory()
         signAndSend = createSignAndSend(createSignerFactory())
-        oappSdkFactory = createOAppFactory(contractFactory)
+        oappSdkFactory = createOAppFactory(createProviderFactory())
 
         ethContract = await contractFactory(ethPointHardhat)
         avaxContract = await contractFactory(avaxPointHardhat)

--- a/tests/ua-devtools-evm-hardhat-test/test/omnicounter/options.test.ts
+++ b/tests/ua-devtools-evm-hardhat-test/test/omnicounter/options.test.ts
@@ -101,7 +101,7 @@ describe('oapp/options', () => {
 
         providerFactory = createProviderFactory()
         contractFactory = createConnectedContractFactory()
-        const sdkFactory = createOmniCounterFactory(contractFactory)
+        const sdkFactory = createOmniCounterFactory(providerFactory)
         const signerFactory = createSignerFactory()
 
         const ethPoint = omniContractToPoint(await contractFactory(ethOmniCounter))

--- a/tests/ua-devtools-evm-hardhat-test/test/ownable/config.test.ts
+++ b/tests/ua-devtools-evm-hardhat-test/test/ownable/config.test.ts
@@ -2,6 +2,7 @@ import 'hardhat'
 import { EndpointId } from '@layerzerolabs/lz-definitions'
 import {
     createConnectedContractFactory,
+    createProviderFactory,
     createSignerFactory,
     OmniContractFactoryHardhat,
 } from '@layerzerolabs/devtools-evm-hardhat'
@@ -36,7 +37,7 @@ describe('ownable/config', () => {
         await deployContract('OApp')
 
         contractFactory = createConnectedContractFactory()
-        ownableFactory = createOwnableFactory(createOAppFactory(contractFactory))
+        ownableFactory = createOwnableFactory(createOAppFactory(createProviderFactory()))
 
         ethContract = await contractFactory(ethPointHardhat)
         avaxContract = await contractFactory(avaxPointHardhat)

--- a/tests/ua-devtools-evm-hardhat-test/test/task/oapp/transfer.ownership.test.ts
+++ b/tests/ua-devtools-evm-hardhat-test/test/task/oapp/transfer.ownership.test.ts
@@ -19,7 +19,7 @@ const promptToContinueMock = promptToContinue as jest.Mock
 
 describe(`task ${TASK_LZ_OWNABLE_TRANSFER_OWNERSHIP}`, () => {
     // Helper matcher object that checks for OmniPoint objects
-    const expectOmniPoint = { address: expect.any(String), eid: expect.any(Number) }
+    const expectOmniPoint = expect.objectContaining({ address: expect.any(String), eid: expect.any(Number) })
     // Helper matcher object that checks for OmniTransaction objects
     const expectTransaction = { data: expect.any(String), point: expectOmniPoint, description: expect.any(String) }
     const expectTransactionWithReceipt = { receipt: expect.any(Object), transaction: expectTransaction }

--- a/tests/ua-devtools-evm-hardhat-test/test/task/oapp/wire.test.ts
+++ b/tests/ua-devtools-evm-hardhat-test/test/task/oapp/wire.test.ts
@@ -38,7 +38,7 @@ const createSignerFactoryMock = createSignerFactory as jest.Mock
 
 describe(`task ${TASK_LZ_OAPP_WIRE}`, () => {
     // Helper matcher object that checks for OmniPoint objects
-    const expectOmniPoint = { address: expect.any(String), eid: expect.any(Number) }
+    const expectOmniPoint = expect.objectContaining({ address: expect.any(String), eid: expect.any(Number) })
     // Helper matcher object that checks for OmniTransaction objects
     const expectTransaction = { data: expect.any(String), point: expectOmniPoint, description: expect.any(String) }
     const expectTransactionWithReceipt = { receipt: expect.any(Object), transaction: expectTransaction }

--- a/tests/ua-devtools-evm-hardhat-v1-test/test/lzapp/config.test.ts
+++ b/tests/ua-devtools-evm-hardhat-v1-test/test/lzapp/config.test.ts
@@ -1,6 +1,10 @@
 import 'hardhat'
 import { avaxLzApp, deployLzApp, ethLzApp } from '../__utils__/lzapp'
-import { createConnectedContractFactory, OmniContractFactoryHardhat } from '@layerzerolabs/devtools-evm-hardhat'
+import {
+    createConnectedContractFactory,
+    createProviderFactory,
+    OmniContractFactoryHardhat,
+} from '@layerzerolabs/devtools-evm-hardhat'
 import { configureLzApp, ILzApp, LzAppFactory, LzAppOmniGraph } from '@layerzerolabs/ua-devtools'
 import { OmniContract, omniContractToPoint } from '@layerzerolabs/devtools-evm'
 import { deployEndpoint } from '../__utils__/endpoint'
@@ -26,7 +30,7 @@ describe('lzapp/config', () => {
         await deployLzApp()
 
         contractFactory = createConnectedContractFactory()
-        lzappSdkFactory = createLzAppFactory(contractFactory)
+        lzappSdkFactory = createLzAppFactory(createProviderFactory())
 
         ethContract = await contractFactory(ethLzApp)
         avaxContract = await contractFactory(avaxLzApp)


### PR DESCRIPTION
### In this PR

- The constructors of and factories for the UA SDKs are modified to accept a provider and an ABI. It is still possible to pass a custom ABI through, as demonstrated by the updated example for custom SDK
- It does not seem like I can reduce the amount of files changed since the switch from contract factory to provider factory is required across the board in many tests and tasks