### PR TITLE
🧹 Consistent task naming

### DIFF
--- a/.changeset/blue-brooms-talk.md
+++ b/.changeset/blue-brooms-talk.md
@@ -1,0 +1,6 @@
+---
+"@layerzerolabs/devtools-evm-hardhat-test": patch
+"@layerzerolabs/devtools-evm-hardhat": patch
+---
+
+Renamed lz:validate-safe-configs and lz:validate-rpcs to lz:healthcheck:validate:safe-configs and lz:healthcheck:validate:rpcs, respectively

--- a/packages/devtools-evm-hardhat/src/constants/tasks.ts
+++ b/packages/devtools-evm-hardhat/src/constants/tasks.ts
@@ -10,6 +10,6 @@ export const TASK_LZ_TEST_SIMULATION_LOGS = 'lz:test:simulation:logs'
 
 export const TASK_LZ_TEST_SIMULATION_STOP = 'lz:test:simulation:stop'
 
-export const TASK_LZ_VALIDATE_SAFE_CONFIGS = 'lz:validate-safe-configs' // TODO rename this to lz:validate:safe-configs in followup PR
+export const TASK_LZ_VALIDATE_SAFE_CONFIGS = 'lz:healthcheck:validate:safe-configs'
 
-export const TASK_LZ_VALIDATE_RPCS = 'lz:validate-rpcs' // TODO rename this to lz:validate:rpcs in followup PR
+export const TASK_LZ_VALIDATE_RPCS = 'lz:healthcheck:validate:rpcs'

--- a/tests/devtools-evm-hardhat-test/test/task/validate.rpcs.test.expectations/validate-incorrect-https-rpc.exp
+++ b/tests/devtools-evm-hardhat-test/test/task/validate.rpcs.test.expectations/validate-incorrect-https-rpc.exp
@@ -30,7 +30,7 @@ set timeout 60
 
 match_max 100000
 
-spawn npx hardhat --config hardhat.config.with-incorrect-https-rpc.ts lz:validate-rpcs
+spawn npx hardhat --config hardhat.config.with-incorrect-https-rpc.ts lz:healthcheck:validate:rpcs
 
 expect "========== RPC URL validation failed for network(s): arbitrum"
 

--- a/tests/devtools-evm-hardhat-test/test/task/validate.rpcs.test.expectations/validate-incorrect-wss-rpc.exp
+++ b/tests/devtools-evm-hardhat-test/test/task/validate.rpcs.test.expectations/validate-incorrect-wss-rpc.exp
@@ -30,7 +30,7 @@ set timeout 60
 
 match_max 100000
 
-spawn npx hardhat --config hardhat.config.with-incorrect-wss-rpc.ts lz:validate-rpcs
+spawn npx hardhat --config hardhat.config.with-incorrect-wss-rpc.ts lz:healthcheck:validate:rpcs
 
 expect "========== RPC URL validation failed for network(s): arbitrum" 
 

--- a/tests/devtools-evm-hardhat-test/test/task/validate.rpcs.test.expectations/validate-invalid-rpc.exp
+++ b/tests/devtools-evm-hardhat-test/test/task/validate.rpcs.test.expectations/validate-invalid-rpc.exp
@@ -30,7 +30,7 @@ set timeout 60
 
 match_max 100000
 
-spawn npx hardhat --config hardhat.config.with-invalid-rpc.ts lz:validate-rpcs
+spawn npx hardhat --config hardhat.config.with-invalid-rpc.ts lz:healthcheck:validate:rpcs
 
 expect "Error fetching provider for network: arbitrum"
 expect "========== RPC URL validation failed for network(s): arbitrum"

--- a/tests/devtools-evm-hardhat-test/test/task/validate.rpcs.test.expectations/validate-multiple-rpcs.exp
+++ b/tests/devtools-evm-hardhat-test/test/task/validate.rpcs.test.expectations/validate-multiple-rpcs.exp
@@ -30,7 +30,7 @@ set timeout 60
 
 match_max 100000
 
-spawn npx hardhat --config hardhat.config.with-multiple-rpcs.ts lz:validate-rpcs
+spawn npx hardhat --config hardhat.config.with-multiple-rpcs.ts lz:healthcheck:validate:rpcs
 
 expect "========== All RPC URLs are valid!"
 

--- a/tests/devtools-evm-hardhat-test/test/task/validate.rpcs.test.expectations/validate-rpc-for-network-without-eid.exp
+++ b/tests/devtools-evm-hardhat-test/test/task/validate.rpcs.test.expectations/validate-rpc-for-network-without-eid.exp
@@ -30,7 +30,7 @@ set timeout 60
 
 match_max 100000
 
-spawn npx hardhat --config hardhat.config.with-network-without-eid.ts lz:validate-rpcs
+spawn npx hardhat --config hardhat.config.with-network-without-eid.ts lz:healthcheck:validate:rpcs
 
 expect "No eid found for network localhost, skipping" 
 expect "========== All RPC URLs are valid!" 

--- a/tests/devtools-evm-hardhat-test/test/task/validate.rpcs.test.expectations/validate-rpc-timeout.exp
+++ b/tests/devtools-evm-hardhat-test/test/task/validate.rpcs.test.expectations/validate-rpc-timeout.exp
@@ -30,7 +30,7 @@ set timeout 60
 
 match_max 100000
 
-spawn npx hardhat --config hardhat.config.with-valid-https-rpc.ts lz:validate-rpcs --timeout 10
+spawn npx hardhat --config hardhat.config.with-valid-https-rpc.ts lz:healthcheck:validate:rpcs --timeout 10
 
 expect "========== RPC URL validation failed for network(s): arbitrum"
 

--- a/tests/devtools-evm-hardhat-test/test/task/validate.rpcs.test.expectations/validate-unresponsive-https-rpc.exp
+++ b/tests/devtools-evm-hardhat-test/test/task/validate.rpcs.test.expectations/validate-unresponsive-https-rpc.exp
@@ -30,7 +30,7 @@ set timeout 60
 
 match_max 100000
 
-spawn npx hardhat --config hardhat.config.with-unresponsive-https-rpc.ts lz:validate-rpcs
+spawn npx hardhat --config hardhat.config.with-unresponsive-https-rpc.ts lz:healthcheck:validate:rpcs
 
 expect "========== RPC URL validation failed for network(s): arbitrum"
 

--- a/tests/devtools-evm-hardhat-test/test/task/validate.rpcs.test.expectations/validate-unresponsive-wss-rpc.exp
+++ b/tests/devtools-evm-hardhat-test/test/task/validate.rpcs.test.expectations/validate-unresponsive-wss-rpc.exp
@@ -30,7 +30,7 @@ set timeout 60
 
 match_max 100000
 
-spawn npx hardhat --config hardhat.config.with-unresponsive-wss-rpc.ts lz:validate-rpcs
+spawn npx hardhat --config hardhat.config.with-unresponsive-wss-rpc.ts lz:healthcheck:validate:rpcs
 
 expect "========== RPC URL validation failed for network(s): arbitrum"
 

--- a/tests/devtools-evm-hardhat-test/test/task/validate.rpcs.test.expectations/validate-valid-https-rpc.exp
+++ b/tests/devtools-evm-hardhat-test/test/task/validate.rpcs.test.expectations/validate-valid-https-rpc.exp
@@ -30,7 +30,7 @@ set timeout 60
 
 match_max 100000
 
-spawn npx hardhat --config hardhat.config.with-valid-https-rpc.ts lz:validate-rpcs
+spawn npx hardhat --config hardhat.config.with-valid-https-rpc.ts lz:healthcheck:validate:rpcs
 
 expect "========== All RPC URLs are valid!"
 

--- a/tests/devtools-evm-hardhat-test/test/task/validate.rpcs.test.expectations/validate-valid-wss-rpc.exp
+++ b/tests/devtools-evm-hardhat-test/test/task/validate.rpcs.test.expectations/validate-valid-wss-rpc.exp
@@ -30,7 +30,7 @@ set timeout 60
 
 match_max 100000
 
-spawn npx hardhat --config hardhat.config.with-valid-wss-rpc.ts lz:validate-rpcs
+spawn npx hardhat --config hardhat.config.with-valid-wss-rpc.ts lz:healthcheck:validate:rpcs
 
 expect "========== All RPC URLs are valid!"
 

--- a/tests/devtools-evm-hardhat-test/test/task/validate.safe.configs.test.expectations/validate-invalid-safe-configs.exp
+++ b/tests/devtools-evm-hardhat-test/test/task/validate.safe.configs.test.expectations/validate-invalid-safe-configs.exp
@@ -30,7 +30,7 @@ set timeout 60
 
 match_max 100000
 
-spawn npx hardhat --config hardhat.config.with-invalid-safe-networks.ts lz:validate-safe-configs
+spawn npx hardhat --config hardhat.config.with-invalid-safe-networks.ts lz:healthcheck:validate:safe-configs
 
 expect "Safe config validation failed for network: ethereum"
 

--- a/tests/devtools-evm-hardhat-test/test/task/validate.safe.configs.test.expectations/validate-missing-safe-address.exp
+++ b/tests/devtools-evm-hardhat-test/test/task/validate.safe.configs.test.expectations/validate-missing-safe-address.exp
@@ -30,7 +30,7 @@ set timeout 60
 
 match_max 100000
 
-spawn npx hardhat --config hardhat.config.with-missing-safe-address.ts lz:validate-safe-configs
+spawn npx hardhat --config hardhat.config.with-missing-safe-address.ts lz:healthcheck:validate:safe-configs
 
 expect "Missing safeAddress"
 expect "Safe config validation failed for network: ethereum"

--- a/tests/devtools-evm-hardhat-test/test/task/validate.safe.configs.test.expectations/validate-missing-safe-url.exp
+++ b/tests/devtools-evm-hardhat-test/test/task/validate.safe.configs.test.expectations/validate-missing-safe-url.exp
@@ -30,7 +30,7 @@ set timeout 60
 
 match_max 100000
 
-spawn npx hardhat --config hardhat.config.with-missing-safe-url.ts lz:validate-safe-configs
+spawn npx hardhat --config hardhat.config.with-missing-safe-url.ts lz:healthcheck:validate:safe-configs
 
 expect "Missing safeUrl"
 expect "Safe config validation failed for network: ethereum"

--- a/tests/devtools-evm-hardhat-test/test/task/validate.safe.configs.test.expectations/validate-no-safe-configs.exp
+++ b/tests/devtools-evm-hardhat-test/test/task/validate.safe.configs.test.expectations/validate-no-safe-configs.exp
@@ -31,7 +31,7 @@ set timeout 60
 
 match_max 100000
 
-spawn npx hardhat --config hardhat.config.ts lz:validate-safe-configs
+spawn npx hardhat --config hardhat.config.ts lz:healthcheck:validate:safe-configs
 
 expect "All safe configs are valid!"
 

--- a/tests/devtools-evm-hardhat-test/test/task/validate.safe.configs.test.expectations/validate-valid-safe-configs.exp
+++ b/tests/devtools-evm-hardhat-test/test/task/validate.safe.configs.test.expectations/validate-valid-safe-configs.exp
@@ -31,7 +31,7 @@ set timeout 60
 
 match_max 100000
 
-spawn npx hardhat --config hardhat.config.with-valid-safe-networks.ts lz:validate-safe-configs
+spawn npx hardhat --config hardhat.config.with-valid-safe-networks.ts lz:healthcheck:validate:safe-configs
 
 expect "All safe configs are valid!"
 


### PR DESCRIPTION
## In this PR:
- Updated task names from `lz:validate-safe-configs` and `lz:validate-rpcs` to `lz:healthcheck:validate:safe-configs` and `lz:healthcheck:validate:rpcs`, respectively.
- Updated references within tests