### PR TITLE
Updated tests

### DIFF
--- a/packages/oft-evm/contracts/NativeOFTAdapter.sol
+++ b/packages/oft-evm/contracts/NativeOFTAdapter.sol
@@ -16,7 +16,7 @@ import { MessagingFee, MessagingReceipt, OFTCore, OFTReceipt, SendParam } from "
  */
 abstract contract NativeOFTAdapter is OFTCore {
 
-    error InsufficientMessageValue(uint256 provided, uint256 required);
+    error IncorrectMessageValue(uint256 provided, uint256 required);
     error CreditFailed();
 
     /**
@@ -68,11 +68,11 @@ abstract contract NativeOFTAdapter is OFTCore {
         MessagingFee calldata _fee,
         address _refundAddress
     ) public payable virtual override returns (MessagingReceipt memory msgReceipt, OFTReceipt memory oftReceipt) {
-        // @dev Ensure the native funds in msg.value are enough to cover the fees and amount to send (with dust removed).
+        // @dev Ensure the native funds in msg.value are exactly enough to cover the fees and amount to send (with dust removed).
         // @dev This will revert if the _sendParam.amountLD contains any dust
         uint256 requiredMsgValue = _fee.nativeFee + _removeDust(_sendParam.amountLD);
         if (msg.value != requiredMsgValue) {
-            revert InsufficientMessageValue(msg.value, requiredMsgValue);
+            revert IncorrectMessageValue(msg.value, requiredMsgValue);
         }
 
         return super.send(_sendParam, _fee, _refundAddress);


### PR DESCRIPTION
## In this PR:
- Added test case for when extra `msg.value` is provided (should revert)
- Updated `InsufficientMessageValue` error to `IncorrectMessageValue` since this error will be thrown even if there is extra `msg.value` provided
- Added comments to tests
- See conversation [here](https://github.com/LayerZero-Labs/devtools/pull/838#discussion_r1738903529)