### PR TITLE
🪲 Allow default ULN config to be set for Solana

### DIFF
--- a/.changeset/curly-years-smile.md
+++ b/.changeset/curly-years-smile.md
@@ -1,0 +1,5 @@
+---
+"@layerzerolabs/protocol-devtools-solana": patch
+---
+
+Treat special case of 0 confirmations for Solana ULN configs


### PR DESCRIPTION
### In this PR

- For Solana we need to treat `0` in confirmations a bit differently. `0` in Solana means the config has not been set yet. If a user tries to set it to `0` (which in Solana means please use defaults), the current implementation would compare these and conclude they are equal. I reality, they are not equal as far as meaning is concerned so a special case needs to be added