### PR TITLE
🧹 Adjust docker build

### DIFF
--- a/.github/workflows/reusable-publish-docker.yaml
+++ b/.github/workflows/reusable-publish-docker.yaml
@@ -56,7 +56,16 @@ jobs:
         with:
           provenance: false
           context: .
-          platforms: linux/amd64,linux/arm64
+          # linux/arm64 platform build is timing out on github runners
+          # most probably due to memory limitations of the runner
+          #
+          # Since this platform is only used on local M1/2/3 machines
+          # and can be built locally, we'll disable the CI/CD build
+          # instead of going for much more complex distributed matrix build
+          #
+          # See more about how the build can be distributed here
+          # https://docs.docker.com/build/ci/github-actions/multi-platform/
+          platforms: linux/amd64
           push: true
           target: base
           tags: ${{ steps.meta.outputs.tags }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,6 +45,9 @@ FROM node:$NODE_VERSION AS base
 
 ARG RUST_TOOLCHAIN_VERSION=1.75.0
 ARG SOLANA_VERSION=1.18.17
+ARG SVM_RS_VERSION=0.5.4
+ARG ANCHOR_VERSION=0.30.1
+ARG SOLC_VERSION=0.8.22
 
 WORKDIR /app
 
@@ -90,17 +93,18 @@ RUN rm -rf ./solana-*
 RUN cargo install --git https://github.com/coral-xyz/anchor avm
 
 # Install anchor
-RUN avm install latest && avm use latest
+RUN avm install ${ANCHOR_VERSION}
+RUN avm use ${ANCHOR_VERSION}
 
 # Install foundry
 RUN curl -L https://foundry.paradigm.xyz | bash
 RUN foundryup
 
 # Install SVM, Solidity version manager
-RUN cargo install svm-rs
+RUN cargo install svm-rs@${SVM_RS_VERSION}
 
 # Install solc 0.8.22
-RUN svm install 0.8.22
+RUN svm install ${SOLC_VERSION}
 
 # Install docker
 RUN curl -sSL https://get.docker.com/ | sh


### PR DESCRIPTION
### In this PR

- Specify precise versions of `svm-rs`, `solc` (already there, just moved it to `ARG`) and `anchor` dependencies
- Disable github build for `linux/arm64`. This build is timing out even on the larger runner and at this point I don't want to be introducing a more complex matrix-based build outlined [here](https://docs.docker.com/build/ci/github-actions/multi-platform/). The images for `linux/arm64` are used for M1/2/3 developer machines which can build these much faster than the github machine since it needs to emulate.