### PR TITLE
🪲 Fix hardhat runtime environment factory

### DIFF
--- a/.changeset/tall-books-jam.md
+++ b/.changeset/tall-books-jam.md
@@ -1,0 +1,5 @@
+---
+"@layerzerolabs/test-devtools-evm-hardhat": minor
+---
+
+Update Hardhat Runtime Environemnt constructor

--- a/.changeset/thirty-files-live.md
+++ b/.changeset/thirty-files-live.md
@@ -1,0 +1,21 @@
+---
+"@layerzerolabs/test-setup-devtools-evm-hardhat": minor
+"@layerzerolabs/ua-devtools-evm-hardhat-v1-test": minor
+"@layerzerolabs/test-devtools-evm-hardhat": minor
+"@layerzerolabs/ua-devtools-evm-hardhat-test": minor
+"@layerzerolabs/ua-devtools-evm-hardhat": minor
+"@layerzerolabs/devtools-evm-hardhat-test": minor
+"@layerzerolabs/devtools-evm-hardhat": minor
+"@layerzerolabs/export-deployments-test": minor
+"@layerzerolabs/toolbox-hardhat": minor
+"@layerzerolabs/devtools-cli-test": minor
+"@layerzerolabs/devtools-evm-test": minor
+"@layerzerolabs/oft-adapter-example": minor
+"@layerzerolabs/oft-solana-example": minor
+"@layerzerolabs/test-evm-node": minor
+"@layerzerolabs/onft721-example": minor
+"@layerzerolabs/oapp-example": minor
+"@layerzerolabs/oft-example": minor
+---
+
+Update hardhat runtime environment factory to match the new environment constuctor

--- a/examples/oapp/package.json
+++ b/examples/oapp/package.json
@@ -47,7 +47,7 @@
     "eslint": "^8.55.0",
     "eslint-plugin-jest-extended": "~2.0.0",
     "ethers": "^5.7.2",
-    "hardhat": "^2.22.3",
+    "hardhat": "^2.22.10",
     "hardhat-contract-sizer": "^2.10.0",
     "hardhat-deploy": "^0.12.1",
     "mocha": "^10.2.0",

--- a/examples/oft-adapter/package.json
+++ b/examples/oft-adapter/package.json
@@ -48,7 +48,7 @@
     "eslint": "^8.55.0",
     "eslint-plugin-jest-extended": "~2.0.0",
     "ethers": "^5.7.2",
-    "hardhat": "^2.22.3",
+    "hardhat": "^2.22.10",
     "hardhat-contract-sizer": "^2.10.0",
     "hardhat-deploy": "^0.12.1",
     "mocha": "^10.2.0",

--- a/examples/oft-solana/package.json
+++ b/examples/oft-solana/package.json
@@ -78,7 +78,7 @@
     "eslint-plugin-jest-extended": "~2.0.0",
     "ethers": "^5.7.2",
     "fp-ts": "^2.16.2",
-    "hardhat": "^2.22.3",
+    "hardhat": "^2.22.10",
     "hardhat-contract-sizer": "^2.10.0",
     "hardhat-deploy": "^0.12.1",
     "jest": "^29.7.0",

--- a/examples/oft/package.json
+++ b/examples/oft/package.json
@@ -49,7 +49,7 @@
     "eslint": "^8.55.0",
     "eslint-plugin-jest-extended": "~2.0.0",
     "ethers": "^5.7.2",
-    "hardhat": "^2.22.3",
+    "hardhat": "^2.22.10",
     "hardhat-contract-sizer": "^2.10.0",
     "hardhat-deploy": "^0.12.1",
     "mocha": "^10.2.0",

--- a/examples/onft721/package.json
+++ b/examples/onft721/package.json
@@ -46,7 +46,7 @@
     "dotenv": "^16.4.1",
     "eslint-plugin-jest-extended": "~2.0.0",
     "ethers": "^5.7.2",
-    "hardhat": "^2.22.3",
+    "hardhat": "^2.22.10",
     "hardhat-contract-sizer": "^2.10.0",
     "hardhat-deploy": "^0.12.1",
     "mocha": "^10.2.0",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     ]
   },
   "resolutions": {
-    "es5-ext": "https://github.com/LayerZero-Labs/es5-ext",
+    "es5-ext": "git://github.com/LayerZero-Labs/es5-ext",
     "ethers": "^5.7.2",
     "hardhat-deploy": "^0.12.1",
     "rustbn.js": "^0.3.0"

--- a/packages/devtools-evm-hardhat/package.json
+++ b/packages/devtools-evm-hardhat/package.json
@@ -68,7 +68,7 @@
     "@types/jest": "^29.5.12",
     "fast-check": "^3.15.1",
     "fp-ts": "^2.16.2",
-    "hardhat": "^2.22.3",
+    "hardhat": "^2.22.10",
     "hardhat-deploy": "^0.12.1",
     "jest": "^29.7.0",
     "p-memoize": "~4.0.1",
@@ -89,7 +89,7 @@
     "@layerzerolabs/lz-definitions": "^2.3.3",
     "@nomiclabs/hardhat-ethers": "^2.2.3",
     "fp-ts": "^2.16.2",
-    "hardhat": "^2.22.3",
+    "hardhat": "^2.22.10",
     "hardhat-deploy": "^0.12.1"
   },
   "publishConfig": {

--- a/packages/devtools-evm-hardhat/src/runtime.ts
+++ b/packages/devtools-evm-hardhat/src/runtime.ts
@@ -54,7 +54,6 @@ export const createDefaultContext = (hardhatArguments: Partial<HardhatArguments>
         taskDefinitions,
         scopesDefinitions,
         envExtenders,
-        ctx.experimentalHardhatNetworkMessageTraceHooks,
         userConfig,
         providerExtenders
     )
@@ -133,7 +132,6 @@ export const getHreByNetworkName: GetByNetwork<HardhatRuntimeEnvironment> = pMem
             environment.tasks,
             environment.scopes,
             context.environmentExtenders,
-            context.experimentalHardhatNetworkMessageTraceHooks,
             environment.userConfig,
             context.providerExtenders
             // This is a bit annoying - the environmentExtenders are not stronly typed

--- a/packages/test-devtools-evm-hardhat/package.json
+++ b/packages/test-devtools-evm-hardhat/package.json
@@ -41,7 +41,7 @@
     "@layerzerolabs/oft-evm": "^0.0.11",
     "@openzeppelin/contracts": "^4.9.5",
     "@openzeppelin/contracts-upgradeable": "^4.9.5",
-    "hardhat": "^2.22.3",
+    "hardhat": "^2.22.10",
     "solidity-bytes-utils": "^0.8.2",
     "ts-node": "^10.9.2",
     "tslib": "~2.6.2",
@@ -49,7 +49,7 @@
     "typescript": "^5.4.4"
   },
   "peerDependencies": {
-    "hardhat": "^2.22.3",
+    "hardhat": "^2.22.10",
     "solidity-bytes-utils": "^0.8.2"
   },
   "publishConfig": {

--- a/packages/test-devtools-evm-hardhat/src/runtime.ts
+++ b/packages/test-devtools-evm-hardhat/src/runtime.ts
@@ -26,7 +26,6 @@ export const getTestHre = (args: Partial<HardhatArguments>): HardhatRuntimeEnvir
         environment.tasks,
         environment.scopes,
         context.environmentExtenders,
-        context.experimentalHardhatNetworkMessageTraceHooks,
         userConfig,
         context.providerExtenders
         // This is a bit annoying - the environmentExtenders are not stronly typed

--- a/packages/toolbox-hardhat/package.json
+++ b/packages/toolbox-hardhat/package.json
@@ -62,7 +62,7 @@
     "@swc/jest": "^0.2.36",
     "@types/jest": "^29.5.12",
     "ethers": "^5.7.2",
-    "hardhat": "^2.22.3",
+    "hardhat": "^2.22.10",
     "hardhat-deploy": "^0.12.1",
     "jest": "^29.7.0",
     "ts-node": "^10.9.2",
@@ -72,7 +72,7 @@
   "peerDependencies": {
     "@nomicfoundation/hardhat-ethers": "^3.0.2",
     "ethers": "^5.7.2",
-    "hardhat": "^2.22.3",
+    "hardhat": "^2.22.10",
     "hardhat-deploy": "^0.12.1"
   },
   "publishConfig": {

--- a/packages/ua-devtools-evm-hardhat/package.json
+++ b/packages/ua-devtools-evm-hardhat/package.json
@@ -61,7 +61,7 @@
     "dotenv": "^16.4.1",
     "ethers": "^5.7.2",
     "fast-check": "^3.15.1",
-    "hardhat": "^2.22.3",
+    "hardhat": "^2.22.10",
     "hardhat-deploy": "^0.12.1",
     "jest": "^29.7.0",
     "ts-node": "^10.9.2",
@@ -83,7 +83,7 @@
     "@layerzerolabs/ua-devtools": "~1.0.5",
     "@layerzerolabs/ua-devtools-evm": "~3.0.1",
     "ethers": "^5.7.2",
-    "hardhat": "^2.22.3",
+    "hardhat": "^2.22.10",
     "hardhat-deploy": "^0.12.1"
   },
   "publishConfig": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -118,10 +118,10 @@ importers:
         version: link:../../packages/toolbox-hardhat
       '@nomicfoundation/hardhat-ethers':
         specifier: ^3.0.5
-        version: 3.0.5(ethers@5.7.2)(hardhat@2.22.3)
+        version: 3.0.5(ethers@5.7.2)(hardhat@2.22.10)
       '@nomiclabs/hardhat-ethers':
         specifier: ^2.2.3
-        version: 2.2.3(ethers@5.7.2)(hardhat@2.22.3)
+        version: 2.2.3(ethers@5.7.2)(hardhat@2.22.10)
       '@openzeppelin/contracts':
         specifier: ^5.0.2
         version: 5.0.2
@@ -156,11 +156,11 @@ importers:
         specifier: ^5.7.2
         version: 5.7.2
       hardhat:
-        specifier: ^2.22.3
-        version: 2.22.3(ts-node@10.9.2)(typescript@5.5.4)
+        specifier: ^2.22.10
+        version: 2.22.10(ts-node@10.9.2)(typescript@5.5.4)
       hardhat-contract-sizer:
         specifier: ^2.10.0
-        version: 2.10.0(hardhat@2.22.3)
+        version: 2.10.0(hardhat@2.22.10)
       hardhat-deploy:
         specifier: ^0.12.1
         version: 0.12.1
@@ -232,10 +232,10 @@ importers:
         version: link:../../packages/toolbox-hardhat
       '@nomicfoundation/hardhat-ethers':
         specifier: ^3.0.5
-        version: 3.0.5(ethers@5.7.2)(hardhat@2.22.3)
+        version: 3.0.5(ethers@5.7.2)(hardhat@2.22.10)
       '@nomiclabs/hardhat-ethers':
         specifier: ^2.2.3
-        version: 2.2.3(ethers@5.7.2)(hardhat@2.22.3)
+        version: 2.2.3(ethers@5.7.2)(hardhat@2.22.10)
       '@openzeppelin/contracts':
         specifier: ^5.0.2
         version: 5.0.2
@@ -270,11 +270,11 @@ importers:
         specifier: ^5.7.2
         version: 5.7.2
       hardhat:
-        specifier: ^2.22.3
-        version: 2.22.3(ts-node@10.9.2)(typescript@5.5.4)
+        specifier: ^2.22.10
+        version: 2.22.10(ts-node@10.9.2)(typescript@5.5.4)
       hardhat-contract-sizer:
         specifier: ^2.10.0
-        version: 2.10.0(hardhat@2.22.3)
+        version: 2.10.0(hardhat@2.22.10)
       hardhat-deploy:
         specifier: ^0.12.1
         version: 0.12.1
@@ -343,10 +343,10 @@ importers:
         version: link:../../packages/toolbox-hardhat
       '@nomicfoundation/hardhat-ethers':
         specifier: ^3.0.5
-        version: 3.0.5(ethers@5.7.2)(hardhat@2.22.3)
+        version: 3.0.5(ethers@5.7.2)(hardhat@2.22.10)
       '@nomiclabs/hardhat-ethers':
         specifier: ^2.2.3
-        version: 2.2.3(ethers@5.7.2)(hardhat@2.22.3)
+        version: 2.2.3(ethers@5.7.2)(hardhat@2.22.10)
       '@openzeppelin/contracts':
         specifier: ^5.0.2
         version: 5.0.2
@@ -381,11 +381,11 @@ importers:
         specifier: ^5.7.2
         version: 5.7.2
       hardhat:
-        specifier: ^2.22.3
-        version: 2.22.3(ts-node@10.9.2)(typescript@5.5.4)
+        specifier: ^2.22.10
+        version: 2.22.10(ts-node@10.9.2)(typescript@5.5.4)
       hardhat-contract-sizer:
         specifier: ^2.10.0
-        version: 2.10.0(hardhat@2.22.3)
+        version: 2.10.0(hardhat@2.22.10)
       hardhat-deploy:
         specifier: ^0.12.1
         version: 0.12.4
@@ -514,10 +514,10 @@ importers:
         version: 0.9.2(@metaplex-foundation/umi@0.9.2)(@solana/web3.js@1.95.2)
       '@nomicfoundation/hardhat-ethers':
         specifier: ^3.0.5
-        version: 3.0.5(ethers@5.7.2)(hardhat@2.22.3)
+        version: 3.0.5(ethers@5.7.2)(hardhat@2.22.10)
       '@nomiclabs/hardhat-ethers':
         specifier: ^2.2.3
-        version: 2.2.3(ethers@5.7.2)(hardhat@2.22.3)
+        version: 2.2.3(ethers@5.7.2)(hardhat@2.22.10)
       '@openzeppelin/contracts':
         specifier: ^5.0.2
         version: 5.0.2
@@ -579,11 +579,11 @@ importers:
         specifier: ^2.16.2
         version: 2.16.2
       hardhat:
-        specifier: ^2.22.3
-        version: 2.22.3(ts-node@10.9.2)(typescript@5.5.4)
+        specifier: ^2.22.10
+        version: 2.22.10(ts-node@10.9.2)(typescript@5.5.4)
       hardhat-contract-sizer:
         specifier: ^2.10.0
-        version: 2.10.0(hardhat@2.22.3)
+        version: 2.10.0(hardhat@2.22.10)
       hardhat-deploy:
         specifier: ^0.12.1
         version: 0.12.4
@@ -655,10 +655,10 @@ importers:
         version: link:../../packages/toolbox-hardhat
       '@nomicfoundation/hardhat-ethers':
         specifier: ^3.0.5
-        version: 3.0.5(ethers@5.7.2)(hardhat@2.22.3)
+        version: 3.0.5(ethers@5.7.2)(hardhat@2.22.10)
       '@nomiclabs/hardhat-ethers':
         specifier: ^2.2.3
-        version: 2.2.3(ethers@5.7.2)(hardhat@2.22.3)
+        version: 2.2.3(ethers@5.7.2)(hardhat@2.22.10)
       '@openzeppelin/contracts':
         specifier: ^5.0.2
         version: 5.0.2
@@ -690,11 +690,11 @@ importers:
         specifier: ^5.7.2
         version: 5.7.2
       hardhat:
-        specifier: ^2.22.3
-        version: 2.22.3(ts-node@10.9.2)(typescript@5.5.4)
+        specifier: ^2.22.10
+        version: 2.22.10(ts-node@10.9.2)(typescript@5.5.4)
       hardhat-contract-sizer:
         specifier: ^2.10.0
-        version: 2.10.0(hardhat@2.22.3)
+        version: 2.10.0(hardhat@2.22.10)
       hardhat-deploy:
         specifier: ^0.12.1
         version: 0.12.4
@@ -1172,7 +1172,7 @@ importers:
         version: link:../test-devtools-evm-hardhat
       '@nomiclabs/hardhat-ethers':
         specifier: ^2.2.3
-        version: 2.2.3(ethers@5.7.2)(hardhat@2.22.3)
+        version: 2.2.3(ethers@5.7.2)(hardhat@2.22.10)
       '@swc/core':
         specifier: ^1.4.0
         version: 1.4.0
@@ -1189,8 +1189,8 @@ importers:
         specifier: ^2.16.2
         version: 2.16.2
       hardhat:
-        specifier: ^2.22.3
-        version: 2.22.3(ts-node@10.9.2)(typescript@5.5.4)
+        specifier: ^2.22.10
+        version: 2.22.10(ts-node@10.9.2)(typescript@5.5.4)
       hardhat-deploy:
         specifier: ^0.12.1
         version: 0.12.1
@@ -1891,8 +1891,8 @@ importers:
         specifier: ^4.9.5
         version: 4.9.5
       hardhat:
-        specifier: ^2.22.3
-        version: 2.22.3(ts-node@10.9.2)(typescript@5.5.4)
+        specifier: ^2.22.10
+        version: 2.22.10(ts-node@10.9.2)(typescript@5.5.4)
       solidity-bytes-utils:
         specifier: ^0.8.2
         version: 0.8.2
@@ -2021,7 +2021,7 @@ importers:
         version: link:../ua-devtools-evm-hardhat
       '@nomicfoundation/hardhat-ethers':
         specifier: ^3.0.2
-        version: 3.0.5(ethers@5.7.2)(hardhat@2.22.3)
+        version: 3.0.5(ethers@5.7.2)(hardhat@2.22.10)
       fp-ts:
         specifier: ^2.16.2
         version: 2.16.2
@@ -2057,8 +2057,8 @@ importers:
         specifier: ^5.7.2
         version: 5.7.2
       hardhat:
-        specifier: ^2.22.3
-        version: 2.22.3(ts-node@10.9.2)(typescript@5.5.4)
+        specifier: ^2.22.10
+        version: 2.22.10(ts-node@10.9.2)(typescript@5.5.4)
       hardhat-deploy:
         specifier: ^0.12.1
         version: 0.12.1
@@ -2275,8 +2275,8 @@ importers:
         specifier: ^3.15.1
         version: 3.15.1
       hardhat:
-        specifier: ^2.22.3
-        version: 2.22.3(ts-node@10.9.2)(typescript@5.5.4)
+        specifier: ^2.22.10
+        version: 2.22.10(ts-node@10.9.2)(typescript@5.5.4)
       hardhat-deploy:
         specifier: ^0.12.1
         version: 0.12.1
@@ -2523,10 +2523,10 @@ importers:
         version: link:../../packages/ua-devtools-evm-hardhat
       '@nomicfoundation/hardhat-ethers':
         specifier: ^3.0.5
-        version: 3.0.5(ethers@5.7.2)(hardhat@2.22.3)
+        version: 3.0.5(ethers@5.7.2)(hardhat@2.22.10)
       '@nomiclabs/hardhat-ethers':
         specifier: ^2.2.3
-        version: 2.2.3(ethers@5.7.2)(hardhat@2.22.3)
+        version: 2.2.3(ethers@5.7.2)(hardhat@2.22.10)
       '@openzeppelin/contracts':
         specifier: ^5.0.2
         version: 5.0.2
@@ -2546,8 +2546,8 @@ importers:
         specifier: ^3.15.1
         version: 3.15.1
       hardhat:
-        specifier: ^2.22.3
-        version: 2.22.3(ts-node@10.9.2)(typescript@5.5.4)
+        specifier: ^2.22.10
+        version: 2.22.10(ts-node@10.9.2)(typescript@5.5.4)
       hardhat-deploy:
         specifier: ^0.12.1
         version: 0.12.4
@@ -2652,10 +2652,10 @@ importers:
         version: link:../../packages/toolbox-hardhat
       '@nomicfoundation/hardhat-ethers':
         specifier: ^3.0.5
-        version: 3.0.5(ethers@5.7.2)(hardhat@2.22.3)
+        version: 3.0.5(ethers@5.7.2)(hardhat@2.22.10)
       '@nomiclabs/hardhat-ethers':
         specifier: ^2.2.3
-        version: 2.2.3(ethers@5.7.2)(hardhat@2.22.3)
+        version: 2.2.3(ethers@5.7.2)(hardhat@2.22.10)
       '@openzeppelin/contracts':
         specifier: ^4.9.5
         version: 4.9.5
@@ -2678,8 +2678,8 @@ importers:
         specifier: ^3.15.1
         version: 3.15.1
       hardhat:
-        specifier: ^2.22.3
-        version: 2.22.3(ts-node@10.9.2)(typescript@5.5.4)
+        specifier: ^2.22.10
+        version: 2.22.10(ts-node@10.9.2)(typescript@5.5.4)
       hardhat-deploy:
         specifier: ^0.12.1
         version: 0.12.1
@@ -2730,10 +2730,10 @@ importers:
         version: link:../../packages/test-devtools
       '@nomicfoundation/hardhat-ethers':
         specifier: ^3.0.5
-        version: 3.0.5(ethers@5.7.2)(hardhat@2.22.3)
+        version: 3.0.5(ethers@5.7.2)(hardhat@2.22.10)
       '@nomiclabs/hardhat-ethers':
         specifier: ^2.2.3
-        version: 2.2.3(ethers@5.7.2)(hardhat@2.22.3)
+        version: 2.2.3(ethers@5.7.2)(hardhat@2.22.10)
       '@swc/core':
         specifier: ^1.4.0
         version: 1.4.0
@@ -2750,8 +2750,8 @@ importers:
         specifier: ^3.15.1
         version: 3.15.1
       hardhat:
-        specifier: ^2.22.3
-        version: 2.22.3(ts-node@10.9.2)(typescript@5.5.4)
+        specifier: ^2.22.10
+        version: 2.22.10(ts-node@10.9.2)(typescript@5.5.4)
       jest:
         specifier: ^29.7.0
         version: 29.7.0(@types/node@18.18.14)(ts-node@10.9.2)
@@ -2781,10 +2781,10 @@ importers:
         version: link:../../packages/toolbox-hardhat
       '@nomicfoundation/hardhat-ethers':
         specifier: ^3.0.5
-        version: 3.0.5(ethers@5.7.2)(hardhat@2.22.3)
+        version: 3.0.5(ethers@5.7.2)(hardhat@2.22.10)
       '@nomiclabs/hardhat-ethers':
         specifier: ^2.2.3
-        version: 2.2.3(ethers@5.7.2)(hardhat@2.22.3)
+        version: 2.2.3(ethers@5.7.2)(hardhat@2.22.10)
       '@openzeppelin/contracts':
         specifier: ^5.0.2
         version: 5.0.2
@@ -2804,8 +2804,8 @@ importers:
         specifier: ^3.15.1
         version: 3.15.1
       hardhat:
-        specifier: ^2.22.3
-        version: 2.22.3(ts-node@10.9.2)(typescript@5.5.4)
+        specifier: ^2.22.10
+        version: 2.22.10(ts-node@10.9.2)(typescript@5.5.4)
       hardhat-deploy:
         specifier: ^0.12.1
         version: 0.12.1
@@ -2831,8 +2831,8 @@ importers:
   tests/test-evm-node:
     dependencies:
       hardhat:
-        specifier: ^2.22.3
-        version: 2.22.3(ts-node@10.9.2)(typescript@5.5.4)
+        specifier: ^2.22.10
+        version: 2.22.10(ts-node@10.9.2)(typescript@5.5.4)
       ts-node:
         specifier: ^10.9.2
         version: 10.9.2(@swc/core@1.4.0)(@types/node@18.18.14)(typescript@5.5.4)
@@ -2882,8 +2882,8 @@ importers:
         specifier: ^5.7.2
         version: 5.7.2
       hardhat:
-        specifier: ^2.22.3
-        version: 2.22.3(ts-node@10.9.2)(typescript@5.5.4)
+        specifier: ^2.22.10
+        version: 2.22.10(ts-node@10.9.2)(typescript@5.5.4)
       hardhat-deploy:
         specifier: ^0.12.1
         version: 0.12.2
@@ -2991,10 +2991,10 @@ importers:
         version: link:../../packages/ua-devtools-evm-hardhat
       '@nomicfoundation/hardhat-ethers':
         specifier: ^3.0.5
-        version: 3.0.5(ethers@5.7.2)(hardhat@2.22.3)
+        version: 3.0.5(ethers@5.7.2)(hardhat@2.22.10)
       '@nomiclabs/hardhat-ethers':
         specifier: ^2.2.3
-        version: 2.2.3(ethers@5.7.2)(hardhat@2.22.3)
+        version: 2.2.3(ethers@5.7.2)(hardhat@2.22.10)
       '@openzeppelin/contracts':
         specifier: ^5.0.2
         version: 5.0.2
@@ -3014,8 +3014,8 @@ importers:
         specifier: ^3.15.1
         version: 3.15.1
       hardhat:
-        specifier: ^2.22.3
-        version: 2.22.3(ts-node@10.9.2)(typescript@5.5.4)
+        specifier: ^2.22.10
+        version: 2.22.10(ts-node@10.9.2)(typescript@5.5.4)
       hardhat-deploy:
         specifier: ^0.12.1
         version: 0.12.1
@@ -3135,10 +3135,10 @@ importers:
         version: link:../../packages/ua-devtools-evm-hardhat
       '@nomicfoundation/hardhat-ethers':
         specifier: ^3.0.5
-        version: 3.0.5(ethers@5.7.2)(hardhat@2.22.3)
+        version: 3.0.5(ethers@5.7.2)(hardhat@2.22.10)
       '@nomiclabs/hardhat-ethers':
         specifier: ^2.2.3
-        version: 2.2.3(ethers@5.7.2)(hardhat@2.22.3)
+        version: 2.2.3(ethers@5.7.2)(hardhat@2.22.10)
       '@openzeppelin/contracts':
         specifier: ^5.0.2
         version: 5.0.2
@@ -3158,8 +3158,8 @@ importers:
         specifier: ^3.15.1
         version: 3.15.1
       hardhat:
-        specifier: ^2.22.3
-        version: 2.22.3(ts-node@10.9.2)(typescript@5.5.4)
+        specifier: ^2.22.10
+        version: 2.22.10(ts-node@10.9.2)(typescript@5.5.4)
       hardhat-deploy:
         specifier: ^0.12.1
         version: 0.12.1
@@ -5662,73 +5662,45 @@ packages:
       fastq: 1.16.0
     dev: true
 
-  /@nomicfoundation/edr-darwin-arm64@0.3.5:
-    resolution: {integrity: sha512-gIXUIiPMUy6roLHpNlxf15DumU7/YhffUf7XIB+WUjMecaySfTGyZsTGnCMJZqrDyiYqWPyPKwCV/2u/jqFAUg==}
+  /@nomicfoundation/edr-darwin-arm64@0.5.2:
+    resolution: {integrity: sha512-Gm4wOPKhbDjGTIRyFA2QUAPfCXA1AHxYOKt3yLSGJkQkdy9a5WW+qtqKeEKHc/+4wpJSLtsGQfpzyIzggFfo/A==}
     engines: {node: '>= 18'}
-    cpu: [arm64]
-    os: [darwin]
-    requiresBuild: true
-    optional: true
 
-  /@nomicfoundation/edr-darwin-x64@0.3.5:
-    resolution: {integrity: sha512-0MrpOCXUK8gmplpYZ2Cy0holHEylvWoNeecFcrP2WJ5DLQzrB23U5JU2MvUzOJ7aL76Za1VXNBWi/UeTWdHM+w==}
+  /@nomicfoundation/edr-darwin-x64@0.5.2:
+    resolution: {integrity: sha512-ClyABq2dFCsrYEED3/UIO0c7p4H1/4vvlswFlqUyBpOkJccr75qIYvahOSJRM62WgUFRhbSS0OJXFRwc/PwmVg==}
     engines: {node: '>= 18'}
-    cpu: [x64]
-    os: [darwin]
-    requiresBuild: true
-    optional: true
 
-  /@nomicfoundation/edr-linux-arm64-gnu@0.3.5:
-    resolution: {integrity: sha512-aw9f7AZMiY1dZFNePJGKho2k+nEgFgzUAyyukiKfSqUIMXoFXMf1U3Ujv848czrSq9c5XGcdDa2xnEf3daU3xg==}
+  /@nomicfoundation/edr-linux-arm64-gnu@0.5.2:
+    resolution: {integrity: sha512-HWMTVk1iOabfvU2RvrKLDgtFjJZTC42CpHiw2h6rfpsgRqMahvIlx2jdjWYzFNy1jZKPTN1AStQ/91MRrg5KnA==}
     engines: {node: '>= 18'}
-    cpu: [arm64]
-    os: [linux]
-    requiresBuild: true
-    optional: true
 
-  /@nomicfoundation/edr-linux-arm64-musl@0.3.5:
-    resolution: {integrity: sha512-cVFRQjyABBlsbDj+XTczYBfrCHprZ6YNzN8gGGSqAh+UGIJkAIRomK6ar27GyJLNx3HkgbuDoi/9kA0zOo/95w==}
+  /@nomicfoundation/edr-linux-arm64-musl@0.5.2:
+    resolution: {integrity: sha512-CwsQ10xFx/QAD5y3/g5alm9+jFVuhc7uYMhrZAu9UVF+KtVjeCvafj0PaVsZ8qyijjqVuVsJ8hD1x5ob7SMcGg==}
     engines: {node: '>= 18'}
-    cpu: [arm64]
-    os: [linux]
-    requiresBuild: true
-    optional: true
 
-  /@nomicfoundation/edr-linux-x64-gnu@0.3.5:
-    resolution: {integrity: sha512-CjOg85DfR1Vt0fQWn5U0qi26DATK9tVzo3YOZEyI0JBsnqvk43fUTPv3uUAWBrPIRg5O5kOc9xG13hSpCBBxBg==}
+  /@nomicfoundation/edr-linux-x64-gnu@0.5.2:
+    resolution: {integrity: sha512-CWVCEdhWJ3fmUpzWHCRnC0/VLBDbqtqTGTR6yyY1Ep3S3BOrHEAvt7h5gx85r2vLcztisu2vlDq51auie4IU1A==}
     engines: {node: '>= 18'}
-    cpu: [x64]
-    os: [linux]
-    requiresBuild: true
-    optional: true
 
-  /@nomicfoundation/edr-linux-x64-musl@0.3.5:
-    resolution: {integrity: sha512-hvX8bBGpBydAVevzK8jsu2FlqVZK1RrCyTX6wGHnltgMuBaoGLHYtNHiFpteOaJw2byYMiORc2bvj+98LhJ0Ew==}
+  /@nomicfoundation/edr-linux-x64-musl@0.5.2:
+    resolution: {integrity: sha512-+aJDfwhkddy2pP5u1ISg3IZVAm0dO836tRlDTFWtvvSMQ5hRGqPcWwlsbobhDQsIxhPJyT7phL0orCg5W3WMeA==}
     engines: {node: '>= 18'}
-    cpu: [x64]
-    os: [linux]
-    requiresBuild: true
-    optional: true
 
-  /@nomicfoundation/edr-win32-x64-msvc@0.3.5:
-    resolution: {integrity: sha512-IJXjW13DY5UPsx/eG5DGfXtJ7Ydwrvw/BTZ2Y93lRLHzszVpSmeVmlxjZP5IW2afTSgMLaAAsqNw4NhppRGN8A==}
+  /@nomicfoundation/edr-win32-x64-msvc@0.5.2:
+    resolution: {integrity: sha512-CcvvuA3sAv7liFNPsIR/68YlH6rrybKzYttLlMr80d4GKJjwJ5OKb3YgE6FdZZnOfP19HEHhsLcE0DPLtY3r0w==}
     engines: {node: '>= 18'}
-    cpu: [x64]
-    os: [win32]
-    requiresBuild: true
-    optional: true
 
-  /@nomicfoundation/edr@0.3.5:
-    resolution: {integrity: sha512-dPSM9DuI1sr71gqWUMgLo8MjHQWO4+WNDm3iWaT6P4vUFJReZX5qwA5X+3UwIPBry8GvNY084u7yWUvB3/8rqA==}
+  /@nomicfoundation/edr@0.5.2:
+    resolution: {integrity: sha512-hW/iLvUQZNTVjFyX/I40rtKvvDOqUEyIi96T28YaLfmPL+3LW2lxmYLUXEJ6MI14HzqxDqrLyhf6IbjAa2r3Dw==}
     engines: {node: '>= 18'}
-    optionalDependencies:
-      '@nomicfoundation/edr-darwin-arm64': 0.3.5
-      '@nomicfoundation/edr-darwin-x64': 0.3.5
-      '@nomicfoundation/edr-linux-arm64-gnu': 0.3.5
-      '@nomicfoundation/edr-linux-arm64-musl': 0.3.5
-      '@nomicfoundation/edr-linux-x64-gnu': 0.3.5
-      '@nomicfoundation/edr-linux-x64-musl': 0.3.5
-      '@nomicfoundation/edr-win32-x64-msvc': 0.3.5
+    dependencies:
+      '@nomicfoundation/edr-darwin-arm64': 0.5.2
+      '@nomicfoundation/edr-darwin-x64': 0.5.2
+      '@nomicfoundation/edr-linux-arm64-gnu': 0.5.2
+      '@nomicfoundation/edr-linux-arm64-musl': 0.5.2
+      '@nomicfoundation/edr-linux-x64-gnu': 0.5.2
+      '@nomicfoundation/edr-linux-x64-musl': 0.5.2
+      '@nomicfoundation/edr-win32-x64-msvc': 0.5.2
 
   /@nomicfoundation/ethereumjs-common@4.0.4:
     resolution: {integrity: sha512-9Rgb658lcWsjiicr5GzNCjI1llow/7r0k50dLL95OJ+6iZJcVbi15r3Y0xh2cIO+zgX0WIHcbzIu6FeQf9KPrg==}
@@ -5768,7 +5740,7 @@ packages:
       '@nomicfoundation/ethereumjs-rlp': 5.0.4
       ethereum-cryptography: 0.1.3
 
-  /@nomicfoundation/hardhat-ethers@3.0.5(ethers@5.7.2)(hardhat@2.22.3):
+  /@nomicfoundation/hardhat-ethers@3.0.5(ethers@5.7.2)(hardhat@2.22.10):
     resolution: {integrity: sha512-RNFe8OtbZK6Ila9kIlHp0+S80/0Bu/3p41HUpaRIoHLm6X3WekTd83vob3rE54Duufu1edCiBDxspBzi2rxHHw==}
     peerDependencies:
       ethers: ^5.7.2
@@ -5776,7 +5748,7 @@ packages:
     dependencies:
       debug: 4.3.4(supports-color@8.1.1)
       ethers: 5.7.2
-      hardhat: 2.22.3(ts-node@10.9.2)(typescript@5.5.4)
+      hardhat: 2.22.10(ts-node@10.9.2)(typescript@5.5.4)
       lodash.isequal: 4.5.0
     transitivePeerDependencies:
       - supports-color
@@ -5876,14 +5848,14 @@ packages:
       '@nomicfoundation/solidity-analyzer-win32-ia32-msvc': 0.1.1
       '@nomicfoundation/solidity-analyzer-win32-x64-msvc': 0.1.1
 
-  /@nomiclabs/hardhat-ethers@2.2.3(ethers@5.7.2)(hardhat@2.22.3):
+  /@nomiclabs/hardhat-ethers@2.2.3(ethers@5.7.2)(hardhat@2.22.10):
     resolution: {integrity: sha512-YhzPdzb612X591FOe68q+qXVXGG2ANZRvDo0RRUtimev85rCrAlv/TLMEZw5c+kq9AbzocLTVX/h2jVIFPL9Xg==}
     peerDependencies:
       ethers: ^5.7.2
       hardhat: ^2.0.0
     dependencies:
       ethers: 5.7.2
-      hardhat: 2.22.3(ts-node@10.9.2)(typescript@5.5.4)
+      hardhat: 2.22.10(ts-node@10.9.2)(typescript@5.5.4)
     dev: true
 
   /@openzeppelin/contracts-upgradeable@4.7.3:
@@ -8271,9 +8243,6 @@ packages:
     resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
     dev: true
 
-  /commander@3.0.2:
-    resolution: {integrity: sha512-Gar0ASD4BDyKC4hl4DwHqDrmvjoxWKZigVnAbn5H1owvm4CxCPdb0HQDehwNYMJpla5+M2tPmPARzhtYuwpHow==}
-
   /commander@4.1.1:
     resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
     engines: {node: '>= 6'}
@@ -8283,6 +8252,10 @@ packages:
     resolution: {integrity: sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==}
     engines: {node: '>= 6'}
     dev: true
+
+  /commander@8.3.0:
+    resolution: {integrity: sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==}
+    engines: {node: '>= 12'}
 
   /concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
@@ -8476,7 +8449,7 @@ packages:
     resolution: {integrity: sha512-MOqHvMWF9/9MX6nza0KgvFH4HpMU0EF5uUDXqX/BtxtU8NfB0QzRtJ8Oe/6SuS4kbhyzVJwjd97EA4PKrzJ8bw==}
     engines: {node: '>=0.12'}
     dependencies:
-      es5-ext: github.com/LayerZero-Labs/es5-ext/7e360296a7e27176e240bc063b32f5ada55f9aa6
+      es5-ext: git@github.com+LayerZero-Labs/es5-ext/7e360296a7e27176e240bc063b32f5ada55f9aa6
       type: 2.7.3
 
   /dashdash@1.14.1:
@@ -9720,7 +9693,6 @@ packages:
     dependencies:
       is-hex-prefixed: 1.0.0
       strip-hex-prefix: 1.0.0
-    bundledDependencies: false
 
   /eventemitter3@4.0.4:
     resolution: {integrity: sha512-rlaVLnVxtxvoyLsQQFBx53YmXHDxRIzzTLbdfxqi4yocpSjAxXwkU0cScM5JgSKMqEhrZpnvQ2D9gjylR0AimQ==}
@@ -10120,15 +10092,6 @@ packages:
     engines: {node: '>= 0.6'}
     dev: false
 
-  /fs-extra@0.30.0:
-    resolution: {integrity: sha512-UvSPKyhMn6LEd/WpUaV9C9t3zATuqoqfWc3QdPhPLb58prN9tqYPlPWi8Krxi44loBoUzlobqZ3+8tGpxxSzwA==}
-    dependencies:
-      graceful-fs: 4.2.11
-      jsonfile: 2.4.0
-      klaw: 1.3.1
-      path-is-absolute: 1.0.1
-      rimraf: 2.7.1
-
   /fs-extra@10.1.0:
     resolution: {integrity: sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==}
     engines: {node: '>=12'}
@@ -10356,6 +10319,7 @@ packages:
       minimatch: 3.1.2
       once: 1.4.0
       path-is-absolute: 1.0.1
+    dev: true
 
   /glob@8.1.0:
     resolution: {integrity: sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==}
@@ -10524,14 +10488,14 @@ packages:
     engines: {node: '>=6'}
     dev: true
 
-  /hardhat-contract-sizer@2.10.0(hardhat@2.22.3):
+  /hardhat-contract-sizer@2.10.0(hardhat@2.22.10):
     resolution: {integrity: sha512-QiinUgBD5MqJZJh1hl1jc9dNnpJg7eE/w4/4GEnrcmZJJTDbVFNe3+/3Ep24XqISSkYxRz36czcPHKHd/a0dwA==}
     peerDependencies:
       hardhat: ^2.0.0
     dependencies:
       chalk: 4.1.2
       cli-table3: 0.6.3
-      hardhat: 2.22.3(ts-node@10.9.2)(typescript@5.5.4)
+      hardhat: 2.22.10(ts-node@10.9.2)(typescript@5.5.4)
       strip-ansi: 6.0.1
     dev: true
 
@@ -10634,8 +10598,8 @@ packages:
       - utf-8-validate
     dev: true
 
-  /hardhat@2.22.3(ts-node@10.9.2)(typescript@5.5.4):
-    resolution: {integrity: sha512-k8JV2ECWNchD6ahkg2BR5wKVxY0OiKot7fuxiIpRK0frRqyOljcR2vKwgWSLw6YIeDcNNA4xybj7Og7NSxr2hA==}
+  /hardhat@2.22.10(ts-node@10.9.2)(typescript@5.5.4):
+    resolution: {integrity: sha512-JRUDdiystjniAvBGFmJRsiIZSOP2/6s++8xRDe3TzLeQXlWWHsXBrd9wd3JWFyKXvgMqMeLL5Sz/oNxXKYw9vg==}
     hasBin: true
     peerDependencies:
       ts-node: '*'
@@ -10648,7 +10612,7 @@ packages:
     dependencies:
       '@ethersproject/abi': 5.7.0
       '@metamask/eth-sig-util': 4.0.1
-      '@nomicfoundation/edr': 0.3.5
+      '@nomicfoundation/edr': 0.5.2
       '@nomicfoundation/ethereumjs-common': 4.0.4
       '@nomicfoundation/ethereumjs-tx': 5.0.4
       '@nomicfoundation/ethereumjs-util': 9.0.4
@@ -10682,7 +10646,7 @@ packages:
       raw-body: 2.5.2
       resolve: 1.17.0
       semver: 6.3.1
-      solc: 0.7.3(debug@4.3.5)
+      solc: 0.8.26(debug@4.3.5)
       source-map-support: 0.5.21
       stacktrace-parser: 0.1.10
       ts-node: 10.9.2(@swc/core@1.4.0)(@types/node@18.18.14)(typescript@5.5.4)
@@ -11964,11 +11928,6 @@ packages:
     resolution: {integrity: sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==}
     dev: true
 
-  /jsonfile@2.4.0:
-    resolution: {integrity: sha512-PKllAqbgLgxHaj8TElYymKCAgrASebJrWpTnEkOaTowt23VKXXN0sUeriJ+eh7y6ufb/CC5ap11pz71/cM0hUw==}
-    optionalDependencies:
-      graceful-fs: 4.2.11
-
   /jsonfile@4.0.0:
     resolution: {integrity: sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==}
     optionalDependencies:
@@ -12029,11 +11988,6 @@ packages:
     resolution: {integrity: sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==}
     engines: {node: '>=0.10.0'}
     dev: true
-
-  /klaw@1.3.1:
-    resolution: {integrity: sha512-TED5xi9gGQjGpNnvRWknrwAB1eL5GciPfVFOt3Vk1OJCVDQbzuSfrF3hkUQKlsgKrG1F+0t5W0m+Fje1jIt8rw==}
-    optionalDependencies:
-      graceful-fs: 4.2.11
 
   /kleur@3.0.3:
     resolution: {integrity: sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==}
@@ -13653,13 +13607,6 @@ packages:
     resolution: {integrity: sha512-r5a3l5HzYlIC68TpmYKlxWjmOP6wiPJ1vWv2HeLhNsRZMrCkxeqxiHlQ21oXmQ4F3SiryXBHhAD7JZqvOJjFmg==}
     dev: true
 
-  /rimraf@2.7.1:
-    resolution: {integrity: sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==}
-    deprecated: Rimraf versions prior to v4 are no longer supported
-    hasBin: true
-    dependencies:
-      glob: 7.2.3
-
   /rimraf@3.0.2:
     resolution: {integrity: sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==}
     hasBin: true
@@ -14081,18 +14028,16 @@ packages:
       tslib: 2.6.3
     dev: true
 
-  /solc@0.7.3(debug@4.3.5):
-    resolution: {integrity: sha512-GAsWNAjGzIDg7VxzP6mPjdurby3IkGCjQcM8GFYZT6RyaoUZKmMU6Y7YwG+tFGhv7dwZ8rmR4iwFDrrD99JwqA==}
-    engines: {node: '>=8.0.0'}
+  /solc@0.8.26(debug@4.3.5):
+    resolution: {integrity: sha512-yiPQNVf5rBFHwN6SIf3TUUvVAFKcQqmSUFeq+fb6pNRCo0ZCgpYOZDi3BVoezCPIAcKrVYd/qXlBLUP9wVrZ9g==}
+    engines: {node: '>=10.0.0'}
     hasBin: true
     dependencies:
       command-exists: 1.2.9
-      commander: 3.0.2
+      commander: 8.3.0
       follow-redirects: 1.15.6(debug@4.3.5)
-      fs-extra: 0.30.0
       js-sha3: 0.8.0
       memorystream: 0.3.1
-      require-from-string: 2.0.2
       semver: 5.7.2
       tmp: 0.0.33
     transitivePeerDependencies:
@@ -15907,6 +15852,17 @@ packages:
 
   /zod@3.22.4:
     resolution: {integrity: sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==}
+
+  git@github.com+LayerZero-Labs/es5-ext/7e360296a7e27176e240bc063b32f5ada55f9aa6:
+    resolution: {commit: 7e360296a7e27176e240bc063b32f5ada55f9aa6, repo: git@github.com:LayerZero-Labs/es5-ext.git, type: git}
+    name: es5-ext
+    version: 0.10.62
+    engines: {node: '>=0.10'}
+    requiresBuild: true
+    dependencies:
+      es6-iterator: 2.0.3
+      es6-symbol: 3.1.4
+      next-tick: 1.1.0
 
   github.com/LayerZero-Labs/es5-ext/7e360296a7e27176e240bc063b32f5ada55f9aa6:
     resolution: {tarball: https://codeload.github.com/LayerZero-Labs/es5-ext/tar.gz/7e360296a7e27176e240bc063b32f5ada55f9aa6}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,7 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  es5-ext: https://github.com/LayerZero-Labs/es5-ext
+  es5-ext: git://github.com/LayerZero-Labs/es5-ext
   ethers: ^5.7.2
   hardhat-deploy: ^0.12.1
   rustbn.js: ^0.3.0
@@ -8449,7 +8449,7 @@ packages:
     resolution: {integrity: sha512-MOqHvMWF9/9MX6nza0KgvFH4HpMU0EF5uUDXqX/BtxtU8NfB0QzRtJ8Oe/6SuS4kbhyzVJwjd97EA4PKrzJ8bw==}
     engines: {node: '>=0.12'}
     dependencies:
-      es5-ext: git@github.com+LayerZero-Labs/es5-ext/7e360296a7e27176e240bc063b32f5ada55f9aa6
+      es5-ext: github.com/LayerZero-Labs/es5-ext/7e360296a7e27176e240bc063b32f5ada55f9aa6
       type: 2.7.3
 
   /dashdash@1.14.1:
@@ -9693,6 +9693,7 @@ packages:
     dependencies:
       is-hex-prefixed: 1.0.0
       strip-hex-prefix: 1.0.0
+    bundledDependencies: false
 
   /eventemitter3@4.0.4:
     resolution: {integrity: sha512-rlaVLnVxtxvoyLsQQFBx53YmXHDxRIzzTLbdfxqi4yocpSjAxXwkU0cScM5JgSKMqEhrZpnvQ2D9gjylR0AimQ==}
@@ -15852,17 +15853,6 @@ packages:
 
   /zod@3.22.4:
     resolution: {integrity: sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==}
-
-  git@github.com+LayerZero-Labs/es5-ext/7e360296a7e27176e240bc063b32f5ada55f9aa6:
-    resolution: {commit: 7e360296a7e27176e240bc063b32f5ada55f9aa6, repo: git@github.com:LayerZero-Labs/es5-ext.git, type: git}
-    name: es5-ext
-    version: 0.10.62
-    engines: {node: '>=0.10'}
-    requiresBuild: true
-    dependencies:
-      es6-iterator: 2.0.3
-      es6-symbol: 3.1.4
-      next-tick: 1.1.0
 
   github.com/LayerZero-Labs/es5-ext/7e360296a7e27176e240bc063b32f5ada55f9aa6:
     resolution: {tarball: https://codeload.github.com/LayerZero-Labs/es5-ext/tar.gz/7e360296a7e27176e240bc063b32f5ada55f9aa6}

--- a/tests/devtools-cli-test/package.json
+++ b/tests/devtools-cli-test/package.json
@@ -55,7 +55,7 @@
     "@types/jest": "^29.5.12",
     "ethers": "^5.7.2",
     "fast-check": "^3.15.1",
-    "hardhat": "^2.22.3",
+    "hardhat": "^2.22.10",
     "hardhat-deploy": "^0.12.1",
     "jest": "^29.7.0",
     "jest-extended": "^4.0.2",

--- a/tests/devtools-evm-hardhat-test/package.json
+++ b/tests/devtools-evm-hardhat-test/package.json
@@ -52,7 +52,7 @@
     "@types/jest": "^29.5.12",
     "ethers": "^5.7.2",
     "fast-check": "^3.15.1",
-    "hardhat": "^2.22.3",
+    "hardhat": "^2.22.10",
     "hardhat-deploy": "^0.12.1",
     "jest": "^29.7.0",
     "jest-extended": "^4.0.2",

--- a/tests/devtools-evm-test/package.json
+++ b/tests/devtools-evm-test/package.json
@@ -33,7 +33,7 @@
     "@types/jest": "^29.5.12",
     "ethers": "^5.7.2",
     "fast-check": "^3.15.1",
-    "hardhat": "^2.22.3",
+    "hardhat": "^2.22.10",
     "jest": "^29.7.0",
     "ts-node": "^10.9.2",
     "typescript": "^5.4.4"

--- a/tests/export-deployments-test/package.json
+++ b/tests/export-deployments-test/package.json
@@ -30,7 +30,7 @@
     "@types/jest": "^29.5.12",
     "ethers": "^5.7.2",
     "fast-check": "^3.15.1",
-    "hardhat": "^2.22.3",
+    "hardhat": "^2.22.10",
     "hardhat-deploy": "^0.12.1",
     "jest": "^29.7.0",
     "jest-extended": "^4.0.2",

--- a/tests/test-evm-node/package.json
+++ b/tests/test-evm-node/package.json
@@ -19,7 +19,7 @@
     "start": "$npm_execpath hardhat node --hostname 0.0.0.0"
   },
   "dependencies": {
-    "hardhat": "^2.22.3",
+    "hardhat": "^2.22.10",
     "ts-node": "^10.9.2",
     "tslib": "~2.6.2",
     "typescript": "^5.4.4"

--- a/tests/test-setup-devtools-evm-hardhat/package.json
+++ b/tests/test-setup-devtools-evm-hardhat/package.json
@@ -42,7 +42,7 @@
     "@layerzerolabs/ua-devtools-evm": "~3.0.1",
     "@types/jest": "^29.5.12",
     "ethers": "^5.7.2",
-    "hardhat": "^2.22.3",
+    "hardhat": "^2.22.10",
     "hardhat-deploy": "^0.12.1",
     "ts-node": "^10.9.2",
     "tslib": "~2.6.2",
@@ -60,7 +60,7 @@
     "@layerzerolabs/ua-devtools": "~1.0.5",
     "@layerzerolabs/ua-devtools-evm": "~3.0.1",
     "ethers": "^5.7.2",
-    "hardhat": "^2.22.3",
+    "hardhat": "^2.22.10",
     "hardhat-deploy": "^0.12.1"
   }
 }

--- a/tests/ua-devtools-evm-hardhat-test/package.json
+++ b/tests/ua-devtools-evm-hardhat-test/package.json
@@ -54,7 +54,7 @@
     "@types/jest": "^29.5.12",
     "ethers": "^5.7.2",
     "fast-check": "^3.15.1",
-    "hardhat": "^2.22.3",
+    "hardhat": "^2.22.10",
     "hardhat-deploy": "^0.12.1",
     "jest": "^29.7.0",
     "jest-extended": "^4.0.2",

--- a/tests/ua-devtools-evm-hardhat-v1-test/package.json
+++ b/tests/ua-devtools-evm-hardhat-v1-test/package.json
@@ -56,7 +56,7 @@
     "@types/jest": "^29.5.12",
     "ethers": "^5.7.2",
     "fast-check": "^3.15.1",
-    "hardhat": "^2.22.3",
+    "hardhat": "^2.22.10",
     "hardhat-deploy": "^0.12.1",
     "jest": "^29.7.0",
     "jest-extended": "^4.0.2",


### PR DESCRIPTION
### In this PR

- In `hardhat@2.22.10` the `Environment` constructor has changed signatures so we need to update to match the new constructor
- Updated the top-level resolution for `es5-ext` after CI/CD install started complaining about the `https` dependency. 