### PR TITLE
Updated foundry imports to meet foundry versions >1.8.0

### DIFF
--- a/packages/test-devtools-evm-foundry/contracts/TestHelperOz5.sol
+++ b/packages/test-devtools-evm-foundry/contracts/TestHelperOz5.sol
@@ -3,8 +3,8 @@
 pragma solidity ^0.8.18;
 
 // Forge
-import { Test } from "forge-std/Test.sol";
-import "forge-std/console.sol";
+import { Test } from "forge-std/src/Test.sol";
+import "forge-std/src/console.sol";
 
 // Oz
 import { DoubleEndedQueue } from "@openzeppelin/contracts/utils/structs/DoubleEndedQueue.sol";


### PR DESCRIPTION
Test.sol and console.sol have been moved inside the src folder in foundry 1.8.0 and higher.