### PR TITLE
🧹 Move configuration execution into a flow

### DIFF
--- a/.changeset/calm-spies-deny.md
+++ b/.changeset/calm-spies-deny.md
@@ -1,0 +1,5 @@
+---
+"@layerzerolabs/ua-devtools-evm-hardhat": patch
+---
+
+Move configuration execution into a flow

--- a/.changeset/calm-spies-deny.md
+++ b/.changeset/calm-spies-deny.md
@@ -1,4 +1,5 @@
 ---
+"@layerzerolabs/devtools": patch
 "@layerzerolabs/ua-devtools-evm-hardhat": patch
 ---
 

--- a/packages/devtools/src/flows/config.execute.ts
+++ b/packages/devtools/src/flows/config.execute.ts
@@ -1,0 +1,49 @@
+import { createLogger, type Logger, printJson } from '@layerzerolabs/io-devtools'
+import { OmniGraphBuilder, type Configurator, type IOmniSDK, type OmniGraph, type OmniSDKFactory } from '@/omnigraph'
+import type { OmniTransaction } from '@/transactions'
+
+export interface ConfigExecuteFlowArgs<TOmniGraph extends OmniGraph = OmniGraph, TSDK = IOmniSDK> {
+    graph: TOmniGraph
+    configurator: Configurator<TOmniGraph, TSDK>
+    sdkFactory: OmniSDKFactory<TSDK>
+    logger?: Logger
+}
+
+export type ConfigExecuteFlow<TOmniGraph extends OmniGraph = OmniGraph, TSDK = IOmniSDK> = (
+    args: ConfigExecuteFlowArgs<TOmniGraph, TSDK>
+) => Promise<OmniTransaction[]>
+
+export const configExecuteFlow = async <TOmniGraph extends OmniGraph = OmniGraph, TSDK = IOmniSDK>({
+    graph,
+    logger = createLogger(),
+    configurator,
+    sdkFactory,
+}: ConfigExecuteFlowArgs<TOmniGraph, TSDK>): Promise<OmniTransaction[]> => {
+    logger.verbose(`Executing graph:\n\n${printJson(graph)}`)
+
+    // As an additional step, even though this task is getting called
+    // from controlled and type-safe environments (for now),
+    // we pass the graph through a builder
+    //
+    // We can discard the output, this step is only here to ensure that the graph is valid
+    // (this) call would throw if the graph was not valid
+    try {
+        logger.verbose(`Validating graph`)
+
+        OmniGraphBuilder.fromGraph(graph)
+    } catch (error) {
+        logger.verbose(`Provided graph does not look valid: ${error}`)
+
+        throw new Error(`An error occurred while validating OmniGraph configuration: ${error}`)
+    }
+
+    // The only thing this task does is it uses the provided arguments
+    // to compile a list of OmniTransactions
+    try {
+        return await configurator(graph, sdkFactory)
+    } catch (error) {
+        logger.verbose(`Encountered an error: ${error}`)
+
+        throw new Error(`An error occurred while getting the OApp configuration: ${error}`)
+    }
+}

--- a/packages/devtools/src/flows/index.ts
+++ b/packages/devtools/src/flows/index.ts
@@ -1,2 +1,3 @@
+export * from './config.execute'
 export * from './config.load'
 export * from './sign.and.send'

--- a/packages/ua-devtools-evm-hardhat/src/tasks/oapp/wire/subtask.configure.ts
+++ b/packages/ua-devtools-evm-hardhat/src/tasks/oapp/wire/subtask.configure.ts
@@ -1,7 +1,7 @@
 import { SUBTASK_LZ_OAPP_WIRE_CONFIGURE } from '@/constants'
-import { OmniGraphBuilder, OmniTransaction } from '@layerzerolabs/devtools'
+import { configExecuteFlow, OmniTransaction } from '@layerzerolabs/devtools'
 import { createConnectedContractFactory, types } from '@layerzerolabs/devtools-evm-hardhat'
-import { createModuleLogger, printJson } from '@layerzerolabs/io-devtools'
+import { createModuleLogger } from '@layerzerolabs/io-devtools'
 import { IOApp, OAppOmniGraph, configureOApp } from '@layerzerolabs/ua-devtools'
 import { createOAppFactory } from '@layerzerolabs/ua-devtools-evm'
 import { subtask } from 'hardhat/config'
@@ -12,37 +12,8 @@ const action: ActionType<SubtaskConfigureTaskArgs<OAppOmniGraph, IOApp>> = async
     graph,
     configurator = configureOApp,
     sdkFactory = createOAppFactory(createConnectedContractFactory()),
-}): Promise<OmniTransaction[]> => {
-    const logger = createModuleLogger(SUBTASK_LZ_OAPP_WIRE_CONFIGURE)
-
-    logger.verbose(`Running with graph:\n\n${printJson(graph)}`)
-
-    // As an additional step, even though this task is getting called
-    // from controlled and type-safe environments (for now),
-    // we pass the graph through a builder
-    //
-    // We can discard the output, this step is only here to ensure that the graph is valid
-    // (this) call would throw if the graph was not valid
-    try {
-        logger.verbose(`Validating graph`)
-
-        OmniGraphBuilder.fromGraph(graph)
-    } catch (error) {
-        logger.verbose(`Provided graph does not look valid: ${error}`)
-
-        throw new Error(`An error occurred while verifying OApp OmniGraph: ${error}`)
-    }
-
-    // The only thing this task does is it uses the provided arguments
-    // to compile a list of OmniTransactions
-    try {
-        return await configurator(graph, sdkFactory)
-    } catch (error) {
-        logger.verbose(`Encountered an error: ${error}`)
-
-        throw new Error(`An error occurred while getting the OApp configuration: ${error}`)
-    }
-}
+}): Promise<OmniTransaction[]> =>
+    configExecuteFlow({ graph, configurator, sdkFactory, logger: createModuleLogger(SUBTASK_LZ_OAPP_WIRE_CONFIGURE) })
 
 subtask(SUBTASK_LZ_OAPP_WIRE_CONFIGURE, 'Create a list of OmniTransactions that configure your OApp', action)
     .addParam('graph', 'Configuration graph', undefined, types.any)


### PR DESCRIPTION
### In this PR

- Move configuration execution subtask into a flow. This was the last subtask to be moved into a flow which means the wire task can now be moved to a flow and subsequently used by both the hardhat and the CLI implementations