### PR TITLE
🧹 Turn existing flows into flow factories

### DIFF
--- a/.changeset/slow-rats-itch.md
+++ b/.changeset/slow-rats-itch.md
@@ -1,0 +1,7 @@
+---
+"@layerzerolabs/ua-devtools-evm-hardhat": patch
+"@layerzerolabs/devtools-evm-hardhat": patch
+"@layerzerolabs/devtools": patch
+---
+
+Turn existing flows into flow factories

--- a/packages/devtools-evm-hardhat/src/tasks/transactions/subtask.sign-and-send.ts
+++ b/packages/devtools-evm-hardhat/src/tasks/transactions/subtask.sign-and-send.ts
@@ -1,14 +1,23 @@
 import { types } from '@/cli'
 import { SUBTASK_LZ_SIGN_AND_SEND } from '@/constants'
-import { signAndSendFlow, type SignAndSendFlowArgs } from '@layerzerolabs/devtools'
+import { createSignAndSendFlow, type OmniSignerFactory, type OmniTransaction } from '@layerzerolabs/devtools'
+import type { Logger } from '@layerzerolabs/io-devtools'
 import { subtask } from 'hardhat/config'
 
-/**
- * @deprecated Use `SignAndSendFlowArgs` from `@layerzerolabs/devtools` instead.
- */
-export type SignAndSendTaskArgs = SignAndSendFlowArgs
+export interface SignAndSendTaskArgs {
+    ci?: boolean
+    logger?: Logger
+    transactions: OmniTransaction[]
+    createSigner: OmniSignerFactory
+}
 
-subtask(SUBTASK_LZ_SIGN_AND_SEND, 'Sign and send a list of transactions using a local signer', signAndSendFlow)
+subtask(
+    SUBTASK_LZ_SIGN_AND_SEND,
+    'Sign and send a list of transactions using a local signer',
+    ({ transactions, ...args }: SignAndSendTaskArgs) => createSignAndSendFlow(args)({ transactions })
+)
     .addFlag('ci', 'Continuous integration (non-interactive) mode. Will not ask for any input from the user')
     .addParam('transactions', 'List of OmniTransaction objects', undefined, types.any)
     .addParam('createSigner', 'Function that creates a signer for a particular network', undefined, types.fn)
+    .addParam('logger', 'Logger object (see @layerzerolabs/io-devtools', undefined, types.any, true)
+    .addParam('onFailure', 'Function that handles sign & send failures', undefined, types.fn, true)

--- a/packages/devtools/src/flows/config.execute.ts
+++ b/packages/devtools/src/flows/config.execute.ts
@@ -2,48 +2,52 @@ import { createLogger, type Logger, printJson } from '@layerzerolabs/io-devtools
 import { OmniGraphBuilder, type Configurator, type IOmniSDK, type OmniGraph, type OmniSDKFactory } from '@/omnigraph'
 import type { OmniTransaction } from '@/transactions'
 
-export interface ConfigExecuteFlowArgs<TOmniGraph extends OmniGraph = OmniGraph, TSDK = IOmniSDK> {
-    graph: TOmniGraph
+export interface CreateConfigExecuteFlowArgs<TOmniGraph extends OmniGraph = OmniGraph, TSDK = IOmniSDK> {
     configurator: Configurator<TOmniGraph, TSDK>
     sdkFactory: OmniSDKFactory<TSDK>
     logger?: Logger
 }
 
-export type ConfigExecuteFlow<TOmniGraph extends OmniGraph = OmniGraph, TSDK = IOmniSDK> = (
-    args: ConfigExecuteFlowArgs<TOmniGraph, TSDK>
+export interface ConfigExecuteFlowArgs<TOmniGraph extends OmniGraph = OmniGraph> {
+    graph: TOmniGraph
+}
+
+export type ConfigExecuteFlow<TOmniGraph extends OmniGraph = OmniGraph> = (
+    args: ConfigExecuteFlowArgs<TOmniGraph>
 ) => Promise<OmniTransaction[]>
 
-export const configExecuteFlow = async <TOmniGraph extends OmniGraph = OmniGraph, TSDK = IOmniSDK>({
-    graph,
-    logger = createLogger(),
-    configurator,
-    sdkFactory,
-}: ConfigExecuteFlowArgs<TOmniGraph, TSDK>): Promise<OmniTransaction[]> => {
-    logger.verbose(`Executing graph:\n\n${printJson(graph)}`)
+export const createConfigExecuteFlow =
+    <TOmniGraph extends OmniGraph = OmniGraph, TSDK = IOmniSDK>({
+        logger = createLogger(),
+        configurator,
+        sdkFactory,
+    }: CreateConfigExecuteFlowArgs<TOmniGraph, TSDK>): ConfigExecuteFlow<TOmniGraph> =>
+    async ({ graph }: ConfigExecuteFlowArgs<TOmniGraph>): Promise<OmniTransaction[]> => {
+        logger.verbose(`Executing graph:\n\n${printJson(graph)}`)
 
-    // As an additional step, even though this task is getting called
-    // from controlled and type-safe environments (for now),
-    // we pass the graph through a builder
-    //
-    // We can discard the output, this step is only here to ensure that the graph is valid
-    // (this) call would throw if the graph was not valid
-    try {
-        logger.verbose(`Validating graph`)
+        // As an additional step, even though this task is getting called
+        // from controlled and type-safe environments (for now),
+        // we pass the graph through a builder
+        //
+        // We can discard the output, this step is only here to ensure that the graph is valid
+        // (this) call would throw if the graph was not valid
+        try {
+            logger.verbose(`Validating graph`)
 
-        OmniGraphBuilder.fromGraph(graph)
-    } catch (error) {
-        logger.verbose(`Provided graph does not look valid: ${error}`)
+            OmniGraphBuilder.fromGraph(graph)
+        } catch (error) {
+            logger.verbose(`Provided graph does not look valid: ${error}`)
 
-        throw new Error(`An error occurred while validating OmniGraph configuration: ${error}`)
+            throw new Error(`An error occurred while validating OmniGraph configuration: ${error}`)
+        }
+
+        // The only thing this task does is it uses the provided arguments
+        // to compile a list of OmniTransactions
+        try {
+            return await configurator(graph, sdkFactory)
+        } catch (error) {
+            logger.verbose(`Encountered an error: ${error}`)
+
+            throw new Error(`An error occurred while getting the OApp configuration: ${error}`)
+        }
     }
-
-    // The only thing this task does is it uses the provided arguments
-    // to compile a list of OmniTransactions
-    try {
-        return await configurator(graph, sdkFactory)
-    } catch (error) {
-        logger.verbose(`Encountered an error: ${error}`)
-
-        throw new Error(`An error occurred while getting the OApp configuration: ${error}`)
-    }
-}

--- a/packages/devtools/src/flows/sign.and.send.ts
+++ b/packages/devtools/src/flows/sign.and.send.ts
@@ -18,13 +18,16 @@ import {
 import { createProgressBar, printRecords, render } from '@layerzerolabs/io-devtools/swag'
 
 export interface SignAndSendFlowArgs {
-    ci?: boolean
-    logger?: Logger
     transactions: OmniTransaction[]
-    createSigner: OmniSignerFactory
 }
 
 export type SignAndSendFlow = (args: SignAndSendFlowArgs) => Promise<SignAndSendResult>
+
+export interface CreateSignAndSendFlowArgs {
+    ci?: boolean
+    logger?: Logger
+    createSigner: OmniSignerFactory
+}
 
 /**
  * Sign and send flow is responsible for submitting (i.e. signing and sending)
@@ -34,142 +37,143 @@ export type SignAndSendFlow = (args: SignAndSendFlowArgs) => Promise<SignAndSend
  * be it hardhat or a standalone script.
  *
  * @param {SignAndSendFlowArgs}
- * @returns {Promise<SignAndSendResult>}
+ * @returns {SignAndSendFlow}
  */
-export const signAndSendFlow: SignAndSendFlow = async ({
-    ci,
-    logger = createLogger(),
-    transactions,
-    createSigner,
-}: SignAndSendFlowArgs): Promise<SignAndSendResult> => {
-    // We only want to be asking users for input if we are not in interactive mode
-    const isInteractive = !ci
+export const createSignAndSendFlow =
+    ({ ci = false, createSigner, logger = createLogger() }: CreateSignAndSendFlowArgs): SignAndSendFlow =>
+    async ({ transactions }: SignAndSendFlowArgs): Promise<SignAndSendResult> => {
+        // We only want to be asking users for input if we are not in interactive mode
+        const isInteractive = !ci
 
-    // We create a separate logger for flow-specific debug logs
-    const subtaskLogger = createModuleLogger(`signAndSendFlow`)
+        // We create a separate logger for flow-specific debug logs
+        const subtaskLogger = createModuleLogger(`signAndSendFlow`)
 
-    // Ask them whether they want to see them
-    const previewTransactions = isInteractive
-        ? await promptToContinue(`Would you like to preview the transactions before continuing?`)
-        : true
-    if (previewTransactions) {
-        printRecords(transactions.map(formatOmniTransaction))
-    }
+        // Ask them whether they want to see them
+        const previewTransactions = isInteractive
+            ? await promptToContinue(`Would you like to preview the transactions before continuing?`)
+            : true
+        if (previewTransactions) {
+            printRecords(transactions.map(formatOmniTransaction))
+        }
 
-    // Now ask the user whether they want to go ahead with signing them
-    //
-    // If they don't, we'll just return the list of pending transactions
-    const shouldSubmit = isInteractive
-        ? await promptToContinue(`Would you like to submit the required transactions?`)
-        : true
-    if (!shouldSubmit) {
-        return subtaskLogger.verbose(`User cancelled the operation, exiting`), [[], [], transactions]
-    }
+        // Now ask the user whether they want to go ahead with signing them
+        //
+        // If they don't, we'll just return the list of pending transactions
+        const shouldSubmit = isInteractive
+            ? await promptToContinue(`Would you like to submit the required transactions?`)
+            : true
+        if (!shouldSubmit) {
+            return subtaskLogger.verbose(`User cancelled the operation, exiting`), [[], [], transactions]
+        }
 
-    subtaskLogger.verbose(`Signing and sending transactions:\n\n${printJson(transactions)}`)
+        subtaskLogger.verbose(`Signing and sending transactions:\n\n${printJson(transactions)}`)
 
-    // The last step is to execute those transactions
-    //
-    // For now we are only allowing sign & send using the accounts confgiured in hardhat config
-    const signAndSend = createSignAndSend(createSigner)
+        // The last step is to execute those transactions
+        //
+        // For now we are only allowing sign & send using the accounts confgiured in hardhat config
+        const signAndSend = createSignAndSend(createSigner)
 
-    // We'll use these variables to store the state of signing
-    let transactionsToSign: OmniTransaction[] = transactions
-    let successfulTransactions: OmniTransactionWithReceipt[] = []
-    let errors: OmniTransactionWithError[] = []
+        // We'll use these variables to store the state of signing
+        let transactionsToSign: OmniTransaction[] = transactions
+        let successfulTransactions: OmniTransactionWithReceipt[] = []
+        let errors: OmniTransactionWithError[] = []
 
-    // We will run an infinite retry loop when signing the transactions
-    //
-    // This loop will be broken in these scenarios:
-    // - if all the transactions succeed
-    // - if some of the transactions fail
-    //      - in the interactive mode, if the user decides not to retry the failed transactions
-    //      - in the non-interactive mode
-    //
-    // eslint-disable-next-line no-constant-condition
-    while (true) {
-        // Now we render a progressbar to monitor the task progress
-        const progressBar = render(
-            createProgressBar({ before: 'Signing... ', after: ` 0/${transactionsToSign.length}` })
-        )
+        // We will run an infinite retry loop when signing the transactions
+        //
+        // This loop will be broken in these scenarios:
+        // - if all the transactions succeed
+        // - if some of the transactions fail
+        //      - in the interactive mode, if the user decides not to retry the failed transactions
+        //      - in the non-interactive mode
+        //
+        // eslint-disable-next-line no-constant-condition
+        while (true) {
+            // Now we render a progressbar to monitor the task progress
+            const progressBar = render(
+                createProgressBar({ before: 'Signing... ', after: ` 0/${transactionsToSign.length}` })
+            )
 
-        subtaskLogger.verbose(`Sending the transactions`)
-        const [successfulBatch, errorsBatch, pendingBatch] = await signAndSend(
-            transactionsToSign,
-            (result, results) => {
-                // We'll keep updating the progressbar as we sign the transactions
-                progressBar.rerender(
-                    createProgressBar({
-                        progress: results.length / transactionsToSign.length,
-                        before: 'Signing... ',
-                        after: ` ${results.length}/${transactionsToSign.length}`,
-                    })
+            subtaskLogger.verbose(`Sending the transactions`)
+            const [successfulBatch, errorsBatch, pendingBatch] = await signAndSend(
+                transactionsToSign,
+                (result, results) => {
+                    // We'll keep updating the progressbar as we sign the transactions
+                    progressBar.rerender(
+                        createProgressBar({
+                            progress: results.length / transactionsToSign.length,
+                            before: 'Signing... ',
+                            after: ` ${results.length}/${transactionsToSign.length}`,
+                        })
+                    )
+                }
+            )
+
+            // And finally we drop the progressbar and continue
+            progressBar.clear()
+
+            // Now let's update the accumulators
+            //
+            // We'll append the successful transactions
+            successfulTransactions = [...successfulTransactions, ...successfulBatch]
+            // Overwrite the errrors
+            //
+            // We might in future return the error history but for now the last errors are okay
+            errors = errorsBatch
+            // And we update the array of transactions with the ones that did not make it through
+            transactionsToSign = pendingBatch
+
+            subtaskLogger.verbose(`Sent the transactions`)
+            subtaskLogger.debug(`Successfully sent the following transactions:\n\n${printJson(successfulBatch)}`)
+            subtaskLogger.debug(`Failed to send the following transactions:\n\n${printJson(errorsBatch)}`)
+            subtaskLogger.debug(`Did not send the following transactions:\n\n${printJson(pendingBatch)}`)
+
+            // Let the user know about the results of the batch
+            logger.info(
+                pluralizeNoun(
+                    successfulBatch.length,
+                    `Successfully sent 1 transaction`,
+                    `Successfully sent ${successfulBatch.length} transactions`
+                )
+            )
+
+            // If there are no errors, we break out of the loop immediatelly
+            if (errors.length === 0) {
+                logger.info(`${printBoolean(true)} Your OApp is now configured`)
+
+                break
+            }
+
+            // Now we bring the bad news to the user
+            logger.error(
+                pluralizeNoun(
+                    errors.length,
+                    `Failed to send 1 transaction`,
+                    `Failed to send ${errors.length} transactions`
+                )
+            )
+
+            const previewErrors = isInteractive
+                ? await promptToContinue(`Would you like to preview the failed transactions?`)
+                : true
+            if (previewErrors) {
+                printRecords(
+                    errors.map(({ error, transaction }) => ({
+                        error: String(error),
+                        ...formatOmniTransaction(transaction),
+                    }))
                 )
             }
-        )
 
-        // And finally we drop the progressbar and continue
-        progressBar.clear()
+            // We'll ask the user if they want to retry if we're in interactive mode
+            //
+            // If they decide not to, we exit, if they want to retry we start the loop again
+            const retry = isInteractive ? await promptToContinue(`Would you like to retry?`, true) : false
+            if (!retry) {
+                logger.error(`${printBoolean(false)} Failed to configure the OApp`)
 
-        // Now let's update the accumulators
-        //
-        // We'll append the successful transactions
-        successfulTransactions = [...successfulTransactions, ...successfulBatch]
-        // Overwrite the errrors
-        //
-        // We might in future return the error history but for now the last errors are okay
-        errors = errorsBatch
-        // And we update the array of transactions with the ones that did not make it through
-        transactionsToSign = pendingBatch
-
-        subtaskLogger.verbose(`Sent the transactions`)
-        subtaskLogger.debug(`Successfully sent the following transactions:\n\n${printJson(successfulBatch)}`)
-        subtaskLogger.debug(`Failed to send the following transactions:\n\n${printJson(errorsBatch)}`)
-        subtaskLogger.debug(`Did not send the following transactions:\n\n${printJson(pendingBatch)}`)
-
-        // Let the user know about the results of the batch
-        logger.info(
-            pluralizeNoun(
-                successfulBatch.length,
-                `Successfully sent 1 transaction`,
-                `Successfully sent ${successfulBatch.length} transactions`
-            )
-        )
-
-        // If there are no errors, we break out of the loop immediatelly
-        if (errors.length === 0) {
-            logger.info(`${printBoolean(true)} Your OApp is now configured`)
-
-            break
+                break
+            }
         }
 
-        // Now we bring the bad news to the user
-        logger.error(
-            pluralizeNoun(errors.length, `Failed to send 1 transaction`, `Failed to send ${errors.length} transactions`)
-        )
-
-        const previewErrors = isInteractive
-            ? await promptToContinue(`Would you like to preview the failed transactions?`)
-            : true
-        if (previewErrors) {
-            printRecords(
-                errors.map(({ error, transaction }) => ({
-                    error: String(error),
-                    ...formatOmniTransaction(transaction),
-                }))
-            )
-        }
-
-        // We'll ask the user if they want to retry if we're in interactive mode
-        //
-        // If they decide not to, we exit, if they want to retry we start the loop again
-        const retry = isInteractive ? await promptToContinue(`Would you like to retry?`, true) : false
-        if (!retry) {
-            logger.error(`${printBoolean(false)} Failed to configure the OApp`)
-
-            break
-        }
+        return [successfulTransactions, errors, transactionsToSign]
     }
-
-    return [successfulTransactions, errors, transactionsToSign]
-}

--- a/packages/devtools/src/transactions/utils.ts
+++ b/packages/devtools/src/transactions/utils.ts
@@ -1,5 +1,6 @@
 import type { EndpointId } from '@layerzerolabs/lz-definitions'
 import type { OmniTransaction } from './types'
+import { SignAndSendResult } from './signer'
 
 const isNonNullable = <T>(value: T | null | undefined): value is T => value != null
 
@@ -22,3 +23,5 @@ export const groupTransactionsByEid = (transactions: OmniTransaction[]): Map<End
             ]),
         new Map<EndpointId, OmniTransaction[]>()
     )
+
+export const isFailedSignAndSendResult = ([, failed]: SignAndSendResult): boolean => failed.length > 0

--- a/packages/ua-devtools-evm-hardhat/src/tasks/oapp/wire/subtask.configure.ts
+++ b/packages/ua-devtools-evm-hardhat/src/tasks/oapp/wire/subtask.configure.ts
@@ -1,5 +1,5 @@
 import { SUBTASK_LZ_OAPP_WIRE_CONFIGURE } from '@/constants'
-import { configExecuteFlow, OmniTransaction } from '@layerzerolabs/devtools'
+import { createConfigExecuteFlow, OmniTransaction } from '@layerzerolabs/devtools'
 import { createConnectedContractFactory, types } from '@layerzerolabs/devtools-evm-hardhat'
 import { createModuleLogger } from '@layerzerolabs/io-devtools'
 import { IOApp, OAppOmniGraph, configureOApp } from '@layerzerolabs/ua-devtools'
@@ -13,7 +13,9 @@ const action: ActionType<SubtaskConfigureTaskArgs<OAppOmniGraph, IOApp>> = async
     configurator = configureOApp,
     sdkFactory = createOAppFactory(createConnectedContractFactory()),
 }): Promise<OmniTransaction[]> =>
-    configExecuteFlow({ graph, configurator, sdkFactory, logger: createModuleLogger(SUBTASK_LZ_OAPP_WIRE_CONFIGURE) })
+    createConfigExecuteFlow({ configurator, sdkFactory, logger: createModuleLogger(SUBTASK_LZ_OAPP_WIRE_CONFIGURE) })({
+        graph,
+    })
 
 subtask(SUBTASK_LZ_OAPP_WIRE_CONFIGURE, 'Create a list of OmniTransactions that configure your OApp', action)
     .addParam('graph', 'Configuration graph', undefined, types.any)


### PR DESCRIPTION
### In this PR

After arriving at the point of being able to create the wire flow, I realized that in the current setup, the wire flow would need to pass a lot of arguments through to these flows, e.g.

  - Configuration execution flow needs a configurator and an SDK factory
  - Sign an send flow needs a signer factory

This would be an anti-pattern and could grow into a massive headache down the line. Instead, since the flows have not been released yet, I turned them into flow factories. This means that the internal information they need is encapsulated in a closure and the overarching flows don't need to care about the internals.

The only place that suffered is the hardhat setup where the subtasks (e.g. `SUBTASK_LZ_SIGN_AND_SEND`) now need to create and immediately execute these flows - nothing horrible, just a side effect of moving to the standalone CLI structure.

This PR consists mostly of indentation changes, sorry for the diff.
