### PR TITLE
🧹 Turn configLoadFlow into a factory

### DIFF
--- a/.changeset/slimy-pears-approve.md
+++ b/.changeset/slimy-pears-approve.md
@@ -1,0 +1,7 @@
+---
+"@layerzerolabs/ua-devtools-evm-hardhat": patch
+"@layerzerolabs/io-devtools": patch
+"@layerzerolabs/devtools": patch
+---
+
+Turn configLoadFlow into createConfigLoadFLow factory

--- a/packages/devtools/src/flows/config.load.ts
+++ b/packages/devtools/src/flows/config.load.ts
@@ -3,13 +3,16 @@ import type { SafeParseReturnType, ZodType, ZodTypeDef } from 'zod'
 import type { OmniGraph } from '@/omnigraph'
 import { resolve } from 'path'
 
-export interface ConfigLoadFlowArgs<TOmniGraph = OmniGraph> {
-    configPath: string
+export interface CreateConfigLoadFlowArgs<TOmniGraph = OmniGraph> {
     configSchema: ZodType<TOmniGraph, ZodTypeDef, unknown>
     logger?: Logger
 }
 
-export type ConfigLoadFlow<TOmniGraph = OmniGraph> = (args: ConfigLoadFlowArgs<TOmniGraph>) => Promise<TOmniGraph>
+export interface ConfigLoadFlowArgs {
+    configPath: string
+}
+
+export type ConfigLoadFlow<TOmniGraph = OmniGraph> = (args: ConfigLoadFlowArgs) => Promise<TOmniGraph>
 
 /**
  * A flow that loads a configuration file from `configPath` and validates it against a `configSchema`.
@@ -30,82 +33,83 @@ export type ConfigLoadFlow<TOmniGraph = OmniGraph> = (args: ConfigLoadFlowArgs<T
  * @param ConfigLoadFlowArgs
  * @returns {Promise<TOmniGraph>}
  */
-export const configLoadFlow = async <TOmniGraph = OmniGraph>({
-    configPath,
-    configSchema,
-    logger = createLogger(),
-}: ConfigLoadFlowArgs<TOmniGraph>): Promise<TOmniGraph> => {
-    logger.verbose(`Loading config from ${configPath}`)
+export const createConfigLoadFlow =
+    <TOmniGraph = OmniGraph>({
+        configSchema,
+        logger = createLogger(),
+    }: CreateConfigLoadFlowArgs<TOmniGraph>): ConfigLoadFlow<TOmniGraph> =>
+    async ({ configPath }): Promise<TOmniGraph> => {
+        logger.verbose(`Loading config from ${configPath}`)
 
-    const absolutePath = resolve(configPath)
-    logger.verbose(`Resolved config file location for '${configPath}': '${absolutePath}'`)
+        const absolutePath = resolve(configPath)
+        logger.verbose(`Resolved config file location for '${configPath}': '${absolutePath}'`)
 
-    // First we check that the config file is indeed there and we can read it
-    logger.verbose(`Checking config file '${absolutePath}' for existence & readability`)
-    const isConfigReadable = isFile(absolutePath) && isReadable(absolutePath)
-    if (!isConfigReadable) {
-        throw new Error(
-            `Unable to read config file '${configPath}'. Check that the file exists and is readable to your terminal user`
-        )
-    }
-
-    // Keep talking to the user
-    logger.verbose(`Config file '${absolutePath}' exists & is readable`)
-
-    // Now let's see if we can load the config file
-    let rawConfig: unknown
-    try {
-        logger.verbose(`Loading config file '${absolutePath}'`)
-
-        rawConfig = await importDefault(absolutePath)
-    } catch (error) {
-        throw new Error(`Unable to read config file '${configPath}': ${error}`)
-    }
-
-    logger.verbose(`Loaded config file '${absolutePath}'`)
-
-    // Now let's check whether the config file contains a function
-    //
-    // If so, we'll execute this function and will expect a config as a result
-    let rawConfigMaterialized: unknown
-    if (typeof rawConfig === 'function') {
-        logger.verbose(`Executing configuration function from config file '${absolutePath}'`)
-
-        try {
-            rawConfigMaterialized = await rawConfig()
-        } catch (error) {
-            throw new Error(`Got an exception while executing config funtion from file '${configPath}': ${error}`)
+        // First we check that the config file is indeed there and we can read it
+        logger.verbose(`Checking config file '${absolutePath}' for existence & readability`)
+        const isConfigReadable = isFile(absolutePath) && isReadable(absolutePath)
+        if (!isConfigReadable) {
+            throw new Error(
+                `Unable to read config file '${configPath}'. Check that the file exists and is readable to your terminal user`
+            )
         }
-    } else {
-        logger.verbose(`Using exported value from config file '${absolutePath}'`)
-        rawConfigMaterialized = rawConfig
+
+        // Keep talking to the user
+        logger.verbose(`Config file '${absolutePath}' exists & is readable`)
+
+        // Now let's see if we can load the config file
+        let rawConfig: unknown
+        try {
+            logger.verbose(`Loading config file '${absolutePath}'`)
+
+            rawConfig = await importDefault(absolutePath)
+        } catch (error) {
+            throw new Error(`Unable to read config file '${configPath}': ${error}`)
+        }
+
+        logger.verbose(`Loaded config file '${absolutePath}'`)
+
+        // Now let's check whether the config file contains a function
+        //
+        // If so, we'll execute this function and will expect a config as a result
+        let rawConfigMaterialized: unknown
+        if (typeof rawConfig === 'function') {
+            logger.verbose(`Executing configuration function from config file '${absolutePath}'`)
+
+            try {
+                rawConfigMaterialized = await rawConfig()
+            } catch (error) {
+                throw new Error(`Got an exception while executing config funtion from file '${configPath}': ${error}`)
+            }
+        } else {
+            logger.verbose(`Using exported value from config file '${absolutePath}'`)
+            rawConfigMaterialized = rawConfig
+        }
+
+        // It's time to make sure that the config is not malformed
+        //
+        // At this stage we are only interested in the shape of the data,
+        // we are not checking whether the information makes sense (e.g.
+        // whether there are no missing nodes etc)
+        logger.verbose(`Validating the structure of config file '${absolutePath}'`)
+
+        // We'll try/catch the schema validation (even though we are using the "safe" version,
+        // zod will just throw if any of the schema transformations throw)
+        //
+        // We do this so that we can prepend the error message with a more meaningful one
+        let configParseResult: SafeParseReturnType<unknown, TOmniGraph>
+        try {
+            configParseResult = await configSchema.safeParseAsync(rawConfigMaterialized)
+        } catch (error) {
+            throw new Error(`Config from file '${configPath}' is invalid: ${error}`)
+        }
+
+        if (configParseResult.success === false) {
+            const userFriendlyErrors = printZodErrors(configParseResult.error)
+
+            throw new Error(
+                `Config from file '${configPath}' is malformed. Please fix the following errors:\n\n${userFriendlyErrors}`
+            )
+        }
+
+        return configParseResult.data
     }
-
-    // It's time to make sure that the config is not malformed
-    //
-    // At this stage we are only interested in the shape of the data,
-    // we are not checking whether the information makes sense (e.g.
-    // whether there are no missing nodes etc)
-    logger.verbose(`Validating the structure of config file '${absolutePath}'`)
-
-    // We'll try/catch the schema validation (even though we are using the "safe" version,
-    // zod will just throw if any of the schema transformations throw)
-    //
-    // We do this so that we can prepend the error message with a more meaningful one
-    let configParseResult: SafeParseReturnType<unknown, TOmniGraph>
-    try {
-        configParseResult = await configSchema.safeParseAsync(rawConfigMaterialized)
-    } catch (error) {
-        throw new Error(`Config from file '${configPath}' is invalid: ${error}`)
-    }
-
-    if (configParseResult.success === false) {
-        const userFriendlyErrors = printZodErrors(configParseResult.error)
-
-        throw new Error(
-            `Config from file '${configPath}' is malformed. Please fix the following errors:\n\n${userFriendlyErrors}`
-        )
-    }
-
-    return configParseResult.data
-}

--- a/packages/devtools/test/flows/__snapshots__/config.load.test.ts.snap
+++ b/packages/devtools/test/flows/__snapshots__/config.load.test.ts.snap
@@ -1,34 +1,34 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`flows/config.load configLoadFlow should reject if the file cannot be imported 1`] = `[Error: Unable to read config file './myconfig.ts': No way]`;
+exports[`flows/config.load createConfigLoadFlow should reject if the file cannot be imported 1`] = `[Error: Unable to read config file './myconfig.ts': No way]`;
 
-exports[`flows/config.load configLoadFlow should reject if the path is not a file 1`] = `[Error: Unable to read config file './myconfig.ts'. Check that the file exists and is readable to your terminal user]`;
+exports[`flows/config.load createConfigLoadFlow should reject if the path is not a file 1`] = `[Error: Unable to read config file './myconfig.ts'. Check that the file exists and is readable to your terminal user]`;
 
-exports[`flows/config.load configLoadFlow should reject if the path is not readable 1`] = `[Error: Unable to read config file './myconfig.ts'. Check that the file exists and is readable to your terminal user]`;
+exports[`flows/config.load createConfigLoadFlow should reject if the path is not readable 1`] = `[Error: Unable to read config file './myconfig.ts'. Check that the file exists and is readable to your terminal user]`;
 
-exports[`flows/config.load configLoadFlow when config file exports a config should reject if the file contents do not match the schema 1`] = `
+exports[`flows/config.load createConfigLoadFlow when config file exports a config should reject if the file contents do not match the schema 1`] = `
 [Error: Config from file './myconfig.ts' is malformed. Please fix the following errors:
 
 Property 'good': Required]
 `;
 
-exports[`flows/config.load configLoadFlow when config file exports a config should resolve if the file contents match the schema 1`] = `
+exports[`flows/config.load createConfigLoadFlow when config file exports a config should resolve if the file contents match the schema 1`] = `
 {
   "good": "config",
 }
 `;
 
-exports[`flows/config.load configLoadFlow when config file exports a function when it is a synchronous function should reject if the function returns an invalid config 1`] = `
+exports[`flows/config.load createConfigLoadFlow when config file exports a function when it is a synchronous function should reject if the function returns an invalid config 1`] = `
 [Error: Config from file './myconfig.ts' is malformed. Please fix the following errors:
 
 Property 'good': Required]
 `;
 
-exports[`flows/config.load configLoadFlow when config file exports a function when it is a synchronous function should reject if the function throws an error 1`] = `[Error: Got an exception while executing config funtion from file './myconfig.ts': Error: Oh not again]`;
+exports[`flows/config.load createConfigLoadFlow when config file exports a function when it is a synchronous function should reject if the function throws an error 1`] = `[Error: Got an exception while executing config funtion from file './myconfig.ts': Error: Oh not again]`;
 
-exports[`flows/config.load configLoadFlow when config file exports a function when it is an asynchronous function should reject if the function rejects 1`] = `[Error: Got an exception while executing config funtion from file './myconfig.ts': Error: Y u do dis]`;
+exports[`flows/config.load createConfigLoadFlow when config file exports a function when it is an asynchronous function should reject if the function rejects 1`] = `[Error: Got an exception while executing config funtion from file './myconfig.ts': Error: Y u do dis]`;
 
-exports[`flows/config.load configLoadFlow when config file exports a function when it is an asynchronous function should reject if the function resolves with an invalid config 1`] = `
+exports[`flows/config.load createConfigLoadFlow when config file exports a function when it is an asynchronous function should reject if the function resolves with an invalid config 1`] = `
 [Error: Config from file './myconfig.ts' is malformed. Please fix the following errors:
 
 Property 'good': Required]

--- a/packages/devtools/test/flows/config.load.test.ts
+++ b/packages/devtools/test/flows/config.load.test.ts
@@ -1,4 +1,4 @@
-import { configLoadFlow } from '@/flows/config.load'
+import { createConfigLoadFlow } from '@/flows/config.load'
 import { importDefault, isFile, isReadable } from '@layerzerolabs/io-devtools'
 import { z } from 'zod'
 
@@ -20,12 +20,12 @@ describe('flows/config.load', () => {
         isReadableMock.mockReset()
     })
 
-    describe('configLoadFlow', () => {
+    describe('createConfigLoadFlow', () => {
         it('should reject if the path is not a file', async () => {
             isFileMock.mockReturnValue(false)
 
             await expect(
-                configLoadFlow({ configPath: './myconfig.ts', configSchema: z.unknown() })
+                createConfigLoadFlow({ configSchema: z.unknown() })({ configPath: './myconfig.ts' })
             ).rejects.toMatchSnapshot()
         })
 
@@ -34,7 +34,7 @@ describe('flows/config.load', () => {
             isReadableMock.mockReturnValue(false)
 
             await expect(
-                configLoadFlow({ configPath: './myconfig.ts', configSchema: z.unknown() })
+                createConfigLoadFlow({ configSchema: z.unknown() })({ configPath: './myconfig.ts' })
             ).rejects.toMatchSnapshot()
         })
 
@@ -44,7 +44,9 @@ describe('flows/config.load', () => {
             importDefaultMock.mockRejectedValue('No way')
 
             await expect(
-                configLoadFlow({ configPath: './myconfig.ts', configSchema: z.unknown() })
+                createConfigLoadFlow({ configSchema: z.unknown() })({
+                    configPath: './myconfig.ts',
+                })
             ).rejects.toMatchSnapshot()
         })
 
@@ -55,7 +57,9 @@ describe('flows/config.load', () => {
                 importDefaultMock.mockResolvedValue({ bad: 'config' })
 
                 await expect(
-                    configLoadFlow({ configPath: './myconfig.ts', configSchema: z.object({ good: z.string() }) })
+                    createConfigLoadFlow({ configSchema: z.object({ good: z.string() }) })({
+                        configPath: './myconfig.ts',
+                    })
                 ).rejects.toMatchSnapshot()
             })
 
@@ -65,7 +69,9 @@ describe('flows/config.load', () => {
                 importDefaultMock.mockResolvedValue({ good: 'config' })
 
                 await expect(
-                    configLoadFlow({ configPath: './myconfig.ts', configSchema: z.object({ good: z.string() }) })
+                    createConfigLoadFlow({ configSchema: z.object({ good: z.string() }) })({
+                        configPath: './myconfig.ts',
+                    })
                 ).resolves.toMatchSnapshot()
             })
         })
@@ -82,7 +88,9 @@ describe('flows/config.load', () => {
                     importDefaultMock.mockResolvedValue(configFunctionMock)
 
                     await expect(
-                        configLoadFlow({ configPath: './myconfig.ts', configSchema: z.object({ good: z.string() }) })
+                        createConfigLoadFlow({ configSchema: z.object({ good: z.string() }) })({
+                            configPath: './myconfig.ts',
+                        })
                     ).rejects.toMatchSnapshot()
 
                     expect(configFunctionMock).toHaveBeenCalledTimes(1)
@@ -97,7 +105,9 @@ describe('flows/config.load', () => {
                     importDefaultMock.mockResolvedValue(configFunctionMock)
 
                     await expect(
-                        configLoadFlow({ configPath: './myconfig.ts', configSchema: z.object({ good: z.string() }) })
+                        createConfigLoadFlow({ configSchema: z.object({ good: z.string() }) })({
+                            configPath: './myconfig.ts',
+                        })
                     ).rejects.toMatchSnapshot()
 
                     expect(configFunctionMock).toHaveBeenCalledTimes(1)
@@ -112,7 +122,9 @@ describe('flows/config.load', () => {
                     importDefaultMock.mockResolvedValue(configFunctionMock)
 
                     await expect(
-                        configLoadFlow({ configPath: './myconfig.ts', configSchema: z.object({ good: z.string() }) })
+                        createConfigLoadFlow({ configSchema: z.object({ good: z.string() }) })({
+                            configPath: './myconfig.ts',
+                        })
                     ).resolves.toEqual({ good: 'config' })
 
                     expect(configFunctionMock).toHaveBeenCalledTimes(1)
@@ -129,7 +141,9 @@ describe('flows/config.load', () => {
                     importDefaultMock.mockResolvedValue(configFunctionMock)
 
                     await expect(
-                        configLoadFlow({ configPath: './myconfig.ts', configSchema: z.object({ good: z.string() }) })
+                        createConfigLoadFlow({ configSchema: z.object({ good: z.string() }) })({
+                            configPath: './myconfig.ts',
+                        })
                     ).rejects.toMatchSnapshot()
 
                     expect(configFunctionMock).toHaveBeenCalledTimes(1)
@@ -144,7 +158,9 @@ describe('flows/config.load', () => {
                     importDefaultMock.mockResolvedValue(configFunctionMock)
 
                     await expect(
-                        configLoadFlow({ configPath: './myconfig.ts', configSchema: z.object({ good: z.string() }) })
+                        createConfigLoadFlow({ configSchema: z.object({ good: z.string() }) })({
+                            configPath: './myconfig.ts',
+                        })
                     ).rejects.toMatchSnapshot()
 
                     expect(configFunctionMock).toHaveBeenCalledTimes(1)
@@ -159,7 +175,9 @@ describe('flows/config.load', () => {
                     importDefaultMock.mockResolvedValue(configFunctionMock)
 
                     await expect(
-                        configLoadFlow({ configPath: './myconfig.ts', configSchema: z.object({ good: z.string() }) })
+                        createConfigLoadFlow({ configSchema: z.object({ good: z.string() }) })({
+                            configPath: './myconfig.ts',
+                        })
                     ).resolves.toEqual({ good: 'config' })
 
                     expect(configFunctionMock).toHaveBeenCalledTimes(1)

--- a/packages/io-devtools/src/config/loading.ts
+++ b/packages/io-devtools/src/config/loading.ts
@@ -5,7 +5,7 @@ import { resolve } from 'path'
 import { z } from 'zod'
 
 /**
- * @deprecated Please use `configLoadFlow` from `@layerzerolabs/devtools`
+ * @deprecated Please use `createConfigLoadFlow` from `@layerzerolabs/devtools`
  */
 export const createConfigLoader =
     <TConfig>(schema: z.ZodSchema<TConfig, z.ZodTypeDef, unknown>, logger = createModuleLogger('config loader')) =>

--- a/packages/ua-devtools-evm-hardhat/src/tasks/oapp/subtask.config.load.ts
+++ b/packages/ua-devtools-evm-hardhat/src/tasks/oapp/subtask.config.load.ts
@@ -1,5 +1,5 @@
 import { SUBTASK_LZ_OAPP_CONFIG_LOAD } from '@/constants/tasks'
-import { configLoadFlow, type OmniGraph } from '@layerzerolabs/devtools'
+import { createConfigLoadFlow, type OmniGraph } from '@layerzerolabs/devtools'
 import { createOmniGraphHardhatTransformer, types } from '@layerzerolabs/devtools-evm-hardhat'
 import { createModuleLogger } from '@layerzerolabs/io-devtools'
 import { subtask } from 'hardhat/config'
@@ -11,11 +11,10 @@ const action: ActionType<SubtaskLoadConfigTaskArgs> = async ({
     schema,
     task,
 }): Promise<OmniGraph<unknown, unknown>> =>
-    configLoadFlow({
-        configPath,
+    createConfigLoadFlow({
         configSchema: schema.transform(createOmniGraphHardhatTransformer()),
         logger: createModuleLogger(`${task}${SUBTASK_LZ_OAPP_CONFIG_LOAD}`),
-    })
+    })({ configPath })
 
 subtask(SUBTASK_LZ_OAPP_CONFIG_LOAD, 'Loads and transforms OmniGraphHardhat into an OmniGraph', action)
     .addParam('configPath', 'Path to the config file', undefined, types.string)


### PR DESCRIPTION
### In this PR

- Turn `configLoadFlow` into `createConfigLoadFlow` so that some of the parameters are encapsulated in a closure. This is the last PR before the versioning PR can be unblocked and merged