### PR TITLE
🪲 Preinstall binaries when running user tests

### DIFF
--- a/tests-user/tests/build-lz-options.bats
+++ b/tests-user/tests/build-lz-options.bats
@@ -1,5 +1,14 @@
+# This will be run at the start of this testing suite,
+# similar to beforeAll() in jest
+setup() {
+    # Load bats-assert and bats-support
+    load "../lib/bats-support/load.bash"
+    load "../lib/bats-assert/load.bash"
 
+    # Install the binary so that we avoid race conditions
+    npm install -g build-lz-options
+}
 
 @test "should output version" {
-    npx --yes build-lz-options --version
+    npx --no build-lz-options --version
 }

--- a/tests-user/tests/create-lz-oapp.bats
+++ b/tests-user/tests/create-lz-oapp.bats
@@ -17,6 +17,9 @@ setup() {
 
     # Setup a directory for all the projects created by this test
     PROJECTS_DIRECTORY=$(mktemp -d)
+
+    # Install the binary so that we avoid race conditions
+    npm install -g create-lz-oapp
 }
 
 teardown() {
@@ -24,11 +27,11 @@ teardown() {
 }
 
 @test "should output version" {
-    npx --yes create-lz-oapp --version
+    npx --no create-lz-oapp --version
 }
 
 @test "should fail if --destination is missing in CI mode" {
-    run npx --yes create-lz-oapp --ci --example oft
+    run npx --no create-lz-oapp --ci --example oft
 
     assert_failure
     assert_output --partial "Missing argument: --destination must be specified in CI mode"
@@ -38,7 +41,7 @@ teardown() {
     local DESTINATION="$PROJECTS_DIRECTORY/existing"
     mkdir -p "$DESTINATION"
 
-    run npx --yes create-lz-oapp --ci --example oft --destination $DESTINATION
+    run npx --no create-lz-oapp --ci --example oft --destination $DESTINATION
 
     assert_failure
     assert_output --regexp "Directory '.*?' already exists"
@@ -48,7 +51,7 @@ teardown() {
     local DESTINATION="$PROJECTS_DIRECTORY/file.json"
     touch $DESTINATION
 
-    run npx --yes create-lz-oapp --ci --example oft --destination $DESTINATION
+    run npx --no create-lz-oapp --ci --example oft --destination $DESTINATION
     assert_failure
     assert_output --regexp "File '.*?' already exists"
 }
@@ -56,7 +59,7 @@ teardown() {
 @test "should fail if --example is missing in CI mode" {
     local DESTINATION="$PROJECTS_DIRECTORY/unused"
 
-    run npx --yes create-lz-oapp --ci --destination $DESTINATION
+    run npx --no create-lz-oapp --ci --destination $DESTINATION
 
     assert_failure
     assert_output --partial "Missing argument: --example must be specified in CI mode"
@@ -66,7 +69,7 @@ teardown() {
 @test "should fail if --example is not valid in CI mode" {
     local DESTINATION="$PROJECTS_DIRECTORY/unused"
 
-    run npx --yes create-lz-oapp --ci --destination $DESTINATION --example wat
+    run npx --no create-lz-oapp --ci --destination $DESTINATION --example wat
 
     assert_failure
     assert [ ! -d $DESTINATION ]
@@ -75,7 +78,7 @@ teardown() {
 @test "should fail if --package-manager is not valid in CI mode" {
     local DESTINATION="$PROJECTS_DIRECTORY/unused"
 
-    run npx --yes create-lz-oapp --ci --destination $DESTINATION --example oft --package-manager wroom
+    run npx --no create-lz-oapp --ci --destination $DESTINATION --example oft --package-manager wroom
 
     assert_failure
     assert_output --partial "manager wroom not found"
@@ -88,7 +91,7 @@ teardown() {
     local DESTINATION="$PROJECTS_DIRECTORY/pnpm-oapp"
     local MNEMONIC="test test test test test test test test test test test junk"
 
-    npx --yes create-lz-oapp --ci --example oapp --destination $DESTINATION --package-manager pnpm
+    npx --no create-lz-oapp --ci --example oapp --destination $DESTINATION --package-manager pnpm
     cd "$DESTINATION"
 
     MNEMONIC=$MNEMONIC run pnpm hardhat lz:deploy --ci
@@ -104,7 +107,7 @@ teardown() {
     local DESTINATION="$PROJECTS_DIRECTORY/pnpm-oft"
     local MNEMONIC="test test test test test test test test test test test junk"
 
-    npx --yes create-lz-oapp --ci --example oft --destination $DESTINATION --package-manager pnpm
+    npx --no create-lz-oapp --ci --example oft --destination $DESTINATION --package-manager pnpm
     cd "$DESTINATION"
 
     MNEMONIC=$MNEMONIC run pnpm hardhat lz:deploy --ci
@@ -117,7 +120,7 @@ teardown() {
 @test "should work with pnpm & oapp example in CI mode" {
     local DESTINATION="$PROJECTS_DIRECTORY/pnpm-oapp"
 
-    npx --yes create-lz-oapp --ci --example oapp --destination $DESTINATION --package-manager pnpm
+    npx --no create-lz-oapp --ci --example oapp --destination $DESTINATION --package-manager pnpm
     cd "$DESTINATION"
     pnpm compile
     pnpm test
@@ -128,7 +131,7 @@ teardown() {
 @test "should work with pnpm & oft example in CI mode" {
     local DESTINATION="$PROJECTS_DIRECTORY/pnpm-oft"
 
-    npx --yes create-lz-oapp --ci --example oft --destination $DESTINATION --package-manager pnpm
+    npx --no create-lz-oapp --ci --example oft --destination $DESTINATION --package-manager pnpm
     cd "$DESTINATION"
     pnpm compile
     pnpm test
@@ -139,7 +142,7 @@ teardown() {
 @test "should work with pnpm & onft721 example in CI mode" {
     local DESTINATION="$PROJECTS_DIRECTORY/pnpm-onft721"
 
-    npx --yes create-lz-oapp --ci --example onft721 --destination $DESTINATION --package-manager pnpm
+    npx --no create-lz-oapp --ci --example onft721 --destination $DESTINATION --package-manager pnpm
     cd "$DESTINATION"
     pnpm compile
     pnpm test
@@ -150,7 +153,7 @@ teardown() {
 @test "should work with pnpm & oft-adapter example in CI mode" {
     local DESTINATION="$PROJECTS_DIRECTORY/pnpm-oft-adapter"
 
-    npx --yes create-lz-oapp --ci --example oft-adapter --destination $DESTINATION --package-manager pnpm
+    npx --no create-lz-oapp --ci --example oft-adapter --destination $DESTINATION --package-manager pnpm
     cd "$DESTINATION"
     pnpm compile
     pnpm test
@@ -161,7 +164,7 @@ teardown() {
 @test "should work with pnpm & oft solana example in CI mode" {
     local DESTINATION="$PROJECTS_DIRECTORY/pnpm-oft-solana"
 
-    LZ_ENABLE_EXPERIMENTAL_SOLANA_OFT_EXAMPLE=1 npx --yes create-lz-oapp --ci --example oft-solana --destination $DESTINATION --package-manager pnpm
+    LZ_ENABLE_EXPERIMENTAL_SOLANA_OFT_EXAMPLE=1 npx --no create-lz-oapp --ci --example oft-solana --destination $DESTINATION --package-manager pnpm
     cd "$DESTINATION"
     pnpm compile
     pnpm test
@@ -170,7 +173,7 @@ teardown() {
 @test "should work with yarn & oapp example in CI mode" {
     local DESTINATION="$PROJECTS_DIRECTORY/yarn-oapp"
 
-    YARN_CACHE_FOLDER="/tmp/.yarn-cache" npx --yes create-lz-oapp --ci --example oapp --destination $DESTINATION --package-manager yarn
+    YARN_CACHE_FOLDER="/tmp/.yarn-cache" npx --no create-lz-oapp --ci --example oapp --destination $DESTINATION --package-manager yarn
     cd "$DESTINATION"
     yarn compile
     yarn test
@@ -181,7 +184,7 @@ teardown() {
 @test "should work with yarn & oft example in CI mode" {
     local DESTINATION="$PROJECTS_DIRECTORY/yarn-oft"
 
-    YARN_CACHE_FOLDER="/tmp/.yarn-cache-oft-evm" npx --yes create-lz-oapp --ci --example oft --destination $DESTINATION --package-manager yarn
+    YARN_CACHE_FOLDER="/tmp/.yarn-cache-oft-evm" npx --no create-lz-oapp --ci --example oft --destination $DESTINATION --package-manager yarn
     cd "$DESTINATION"
     yarn compile
     yarn test
@@ -192,7 +195,7 @@ teardown() {
 @test "should work with yarn & onft721 example in CI mode" {
     local DESTINATION="$PROJECTS_DIRECTORY/yarn-oapp"
 
-    YARN_CACHE_FOLDER="/tmp/.yarn-cache-onft-evm" npx --yes create-lz-oapp --ci --example onft721 --destination $DESTINATION --package-manager yarn
+    YARN_CACHE_FOLDER="/tmp/.yarn-cache-onft-evm" npx --no create-lz-oapp --ci --example onft721 --destination $DESTINATION --package-manager yarn
     cd "$DESTINATION"
     yarn compile
     yarn test
@@ -203,7 +206,7 @@ teardown() {
 @test "should work with yarn & oft-adapter example in CI mode" {
     local DESTINATION="$PROJECTS_DIRECTORY/yarn-oapp"
 
-    YARN_CACHE_FOLDER="/tmp/.yarn-cache-oft-adapter-evm" npx --yes create-lz-oapp --ci --example oft-adapter --destination $DESTINATION --package-manager yarn
+    YARN_CACHE_FOLDER="/tmp/.yarn-cache-oft-adapter-evm" npx --no create-lz-oapp --ci --example oft-adapter --destination $DESTINATION --package-manager yarn
     cd "$DESTINATION"
     yarn compile
     yarn test
@@ -214,7 +217,7 @@ teardown() {
 @test "should work with yarn & oft solana example in CI mode" {
     local DESTINATION="$PROJECTS_DIRECTORY/yarn-oft-solana"
 
-    YARN_CACHE_FOLDER="/tmp/.yarn-cache-oft-solana" LZ_ENABLE_EXPERIMENTAL_SOLANA_OFT_EXAMPLE=1 npx --yes create-lz-oapp --ci --example oft-solana --destination $DESTINATION --package-manager yarn
+    YARN_CACHE_FOLDER="/tmp/.yarn-cache-oft-solana" LZ_ENABLE_EXPERIMENTAL_SOLANA_OFT_EXAMPLE=1 npx --no create-lz-oapp --ci --example oft-solana --destination $DESTINATION --package-manager yarn
     cd "$DESTINATION"
     yarn compile
     yarn test
@@ -223,7 +226,7 @@ teardown() {
 @test "should work with npm & oapp example in CI mode" {
     local DESTINATION="$PROJECTS_DIRECTORY/npm-oapp"
 
-    npx --yes create-lz-oapp --ci --example oapp --destination $DESTINATION --package-manager npm
+    npx --no create-lz-oapp --ci --example oapp --destination $DESTINATION --package-manager npm
     cd "$DESTINATION"
     npm run compile
     npm run test
@@ -234,7 +237,7 @@ teardown() {
 @test "should work with npm & oft example in CI mode" {
     local DESTINATION="$PROJECTS_DIRECTORY/npm-oft"
 
-    npx --yes create-lz-oapp --ci --example oft --destination $DESTINATION --package-manager npm
+    npx --no create-lz-oapp --ci --example oft --destination $DESTINATION --package-manager npm
     cd "$DESTINATION"
     npm run compile
     npm run test
@@ -245,7 +248,7 @@ teardown() {
 @test "should work with npm & onft721 example in CI mode" {
     local DESTINATION="$PROJECTS_DIRECTORY/npm-oft"
 
-    npx --yes create-lz-oapp --ci --example onft721 --destination $DESTINATION --package-manager npm
+    npx --no create-lz-oapp --ci --example onft721 --destination $DESTINATION --package-manager npm
     cd "$DESTINATION"
     npm run compile
     npm run test
@@ -256,7 +259,7 @@ teardown() {
 @test "should work with npm & oft-adapter example in CI mode" {
     local DESTINATION="$PROJECTS_DIRECTORY/npm-oft"
 
-    npx --yes create-lz-oapp --ci --example oft-adapter --destination $DESTINATION --package-manager npm
+    npx --no create-lz-oapp --ci --example oft-adapter --destination $DESTINATION --package-manager npm
     cd "$DESTINATION"
     npm run compile
     npm run test
@@ -267,7 +270,7 @@ teardown() {
 @test "should work with npm & oft solana example in CI mode" {
     local DESTINATION="$PROJECTS_DIRECTORY/npm-oft-solana"
 
-    LZ_ENABLE_EXPERIMENTAL_SOLANA_OFT_EXAMPLE=1 npx --yes create-lz-oapp --ci --example oft-solana --destination $DESTINATION --package-manager npm
+    LZ_ENABLE_EXPERIMENTAL_SOLANA_OFT_EXAMPLE=1 npx --no create-lz-oapp --ci --example oft-solana --destination $DESTINATION --package-manager npm
     cd "$DESTINATION"
     npm run compile
     npm run test

--- a/tests-user/tests/decode-lz-options.bats
+++ b/tests-user/tests/decode-lz-options.bats
@@ -1,5 +1,14 @@
+# This will be run at the start of this testing suite,
+# similar to beforeAll() in jest
+setup() {
+    # Load bats-assert and bats-support
+    load "../lib/bats-support/load.bash"
+    load "../lib/bats-assert/load.bash"
 
+    # Install the binary so that we avoid race conditions
+    npm install -g decode-lz-options
+}
 
 @test "should output version" {
-    npx --yes decode-lz-options --version
+    npx --no decode-lz-options --version
 }

--- a/tests-user/tests/devtools-cli.bats
+++ b/tests-user/tests/devtools-cli.bats
@@ -17,6 +17,9 @@ setup() {
 
     # Setup a directory for all the projects created by this test
     PROJECTS_DIRECTORY=$(mktemp -d)
+
+    # Install the binary so that we avoid race conditions
+    npm install -g @layerzerolabs/devtools-cli
 }
 
 teardown() {
@@ -24,19 +27,19 @@ teardown() {
 }
 
 @test "should output version" {
-    npx --yes @layerzerolabs/devtools-cli --version
+    npx --no @layerzerolabs/devtools-cli --version
 }
 
 @test "should output help" {
-    npx --yes @layerzerolabs/devtools-cli --help
+    npx --no @layerzerolabs/devtools-cli --help
 }
 
 @test "should work with pnpm & oapp example in CI mode" {
     local DESTINATION="$PROJECTS_DIRECTORY/pnpm-oapp"
 
-    npx --yes create-lz-oapp --ci --example oapp --destination $DESTINATION --package-manager pnpm
+    npx --no create-lz-oapp --ci --example oapp --destination $DESTINATION --package-manager pnpm
     cd "$DESTINATION"
 
-    run npx --yes @layerzerolabs/devtools-cli oapp wire --setup ./imaginary.layerzero.setup.ts --oapp-config ./layerzero.config.ts --dry-run
+    run npx --no @layerzerolabs/devtools-cli oapp wire --setup ./imaginary.layerzero.setup.ts --oapp-config ./layerzero.config.ts --dry-run
     assert_output --partial "This command is just a placeholder. Please use @layerzerolabs/toolbox-hardhat package for the time being."
 }

--- a/tests-user/tests/devtools-evm-hardhat-export-deployments.bats
+++ b/tests-user/tests/devtools-evm-hardhat-export-deployments.bats
@@ -4,12 +4,15 @@ setup() {
     # Load bats-assert and bats-support
     load "../lib/bats-support/load.bash"
     load "../lib/bats-assert/load.bash"
+
+    # Install the binary so that we avoid race conditions
+    npm install -g @layerzerolabs/export-deployments
 }
 
 @test "should output version" {
-    npx --yes @layerzerolabs/export-deployments --version
+    npx --no @layerzerolabs/export-deployments --version
 }
 
 @test "should output help" {
-    npx --yes @layerzerolabs/export-deployments --help
+    npx --no @layerzerolabs/export-deployments --help
 }

--- a/tests-user/tests/verify-contract.bats
+++ b/tests-user/tests/verify-contract.bats
@@ -4,12 +4,15 @@ setup() {
     # Load bats-assert and bats-support
     load "../lib/bats-support/load.bash"
     load "../lib/bats-assert/load.bash"
+
+    # Install the binary so that we avoid race conditions
+    npm install -g @layerzerolabs/verify-contract
 }
 
 @test "should output version" {
-    npx --yes @layerzerolabs/verify-contract --version
+    npx --no @layerzerolabs/verify-contract --version
 }
 
 @test "should output help" {
-    npx --yes @layerzerolabs/verify-contract --help
+    npx --no @layerzerolabs/verify-contract --help
 }


### PR DESCRIPTION
### In this PR

- Preinstall tested packages when running user tests. Since these are ran in parallel, race conditions can occur if two tests are trying to install the same dependency (e.g. `typescript`, see [here](https://github.com/LayerZero-Labs/devtools/actions/runs/11262125975))