### PR TITLE
🗞️ Add support for Aptos CLI to the base development images

### DIFF
--- a/.github/workflows/reusable-publish-docker.yaml
+++ b/.github/workflows/reusable-publish-docker.yaml
@@ -73,6 +73,8 @@ jobs:
           annotations: ${{ steps.meta.outputs.annotations }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          build-args: |
+            CARGO_BUILD_JOBS=1
 
   build-node-evm:
     name: Build EVM node image

--- a/.github/workflows/reusable-publish-docker.yaml
+++ b/.github/workflows/reusable-publish-docker.yaml
@@ -65,7 +65,7 @@ jobs:
           #
           # See more about how the build can be distributed here
           # https://docs.docker.com/build/ci/github-actions/multi-platform/
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           push: true
           target: base
           tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/reusable-publish-docker.yaml
+++ b/.github/workflows/reusable-publish-docker.yaml
@@ -74,7 +74,7 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
           build-args: |
-            CARGO_BUILD_JOBS=1
+            CARGO_BUILD_JOBS=2
 
   build-node-evm:
     name: Build EVM node image

--- a/.github/workflows/reusable-publish-docker.yaml
+++ b/.github/workflows/reusable-publish-docker.yaml
@@ -65,7 +65,7 @@ jobs:
           #
           # See more about how the build can be distributed here
           # https://docs.docker.com/build/ci/github-actions/multi-platform/
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
           push: true
           target: base
           tags: ${{ steps.meta.outputs.tags }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -84,15 +84,21 @@ FROM machine AS aptos
 
 WORKDIR /app/aptos
 
-# Grab Aptos source code
-RUN git clone -b devnet --depth 1 https://github.com/aptos-labs/aptos-core.git
+ARG APTOS_VERSION=4.2.3
+RUN \
+    (\
+    # We download the source code and extract the archive
+    curl -s -L https://github.com/aptos-labs/aptos-core/archive/refs/tags/aptos-cli-v${APTOS_VERSION}.tar.gz | tar -xz && \
+    # Then rename the directory just for convenience
+    mv ./aptos-core-aptos-cli-v${APTOS_VERSION} ./src \
+    )
 
-# Switch to the repository
-WORKDIR /app/aptos/aptos-core
+# Switch to the project
+WORKDIR /app/aptos/src
 
 # Configure cargo. We want to provide a way of limiting cargo resources
 # on the github runner since it is not large enough to support multiple cargo builds
-ARG CARGO_BUILD_JOBS=
+ARG CARGO_BUILD_JOBS=default
 ENV CARGO_BUILD_JOBS=$CARGO_BUILD_JOBS
 
 # Install aptos from source
@@ -123,7 +129,7 @@ WORKDIR /app/solana
 
 # Configure cargo. We want to provide a way of limiting cargo resources
 # on the github runner since it is not large enough to support multiple cargo builds
-ARG CARGO_BUILD_JOBS=
+ARG CARGO_BUILD_JOBS=default
 ENV CARGO_BUILD_JOBS=$CARGO_BUILD_JOBS
 
 # Install Solana using a binary with a fallback to installing from source

--- a/Dockerfile
+++ b/Dockerfile
@@ -203,7 +203,7 @@ ENV PATH="/root/.aptos/bin/root/.avm/bin:/root/.foundry/bin:/root/.solana/bin:$P
 COPY --from=aptos /root/.aptos/bin /root/.aptos/bin
 
 # Get solana & avm CLI
-COPY --from=solana /root/.avm/bin /root/.avm/bin
+COPY --from=solana /root/.avm /root/.avm
 COPY --from=solana /root/.solana/bin /root/.solana/bin
 
 # Get EVM tooling

--- a/Dockerfile
+++ b/Dockerfile
@@ -204,6 +204,7 @@ COPY --from=aptos /root/.aptos/bin /root/.aptos/bin
 
 # Get solana tooling
 COPY --from=solana /root/.cargo/bin/anchor /root/.cargo/bin/anchor
+COPY --from=solana /root/.cargo/bin/avm /root/.cargo/bin/avm
 COPY --from=solana /root/.avm /root/.avm
 COPY --from=solana /root/.solana/bin /root/.solana/bin
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -202,7 +202,8 @@ ENV PATH="/root/.aptos/bin/root/.avm/bin:/root/.foundry/bin:/root/.solana/bin:$P
 # Get aptos CLI
 COPY --from=aptos /root/.aptos/bin /root/.aptos/bin
 
-# Get solana & avm CLI
+# Get solana tooling
+COPY --from=evm /root/.cargo/bin/anchor /root/.cargo/bin/anchor
 COPY --from=solana /root/.avm /root/.avm
 COPY --from=solana /root/.solana/bin /root/.solana/bin
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -203,7 +203,7 @@ ENV PATH="/root/.aptos/bin/root/.avm/bin:/root/.foundry/bin:/root/.solana/bin:$P
 COPY --from=aptos /root/.aptos/bin /root/.aptos/bin
 
 # Get solana tooling
-COPY --from=evm /root/.cargo/bin/anchor /root/.cargo/bin/anchor
+COPY --from=solana /root/.cargo/bin/anchor /root/.cargo/bin/anchor
 COPY --from=solana /root/.avm /root/.avm
 COPY --from=solana /root/.solana/bin /root/.solana/bin
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -90,6 +90,11 @@ RUN git clone -b devnet --depth 1 https://github.com/aptos-labs/aptos-core.git
 # Switch to the repository
 WORKDIR /app/aptos/aptos-core
 
+# Configure cargo. We want to provide a way of limiting cargo resources
+# on the github runner since it is not large enough to support multiple cargo builds
+ARG CARGO_BUILD_JOBS=
+ENV CARGO_BUILD_JOBS=$CARGO_BUILD_JOBS
+
 # Install aptos from source
 RUN cargo build --package aptos --profile cli
 
@@ -115,6 +120,11 @@ RUN aptos --version
 FROM machine AS solana
 
 WORKDIR /app/solana
+
+# Configure cargo. We want to provide a way of limiting cargo resources
+# on the github runner since it is not large enough to support multiple cargo builds
+ARG CARGO_BUILD_JOBS=
+ENV CARGO_BUILD_JOBS=$CARGO_BUILD_JOBS
 
 # Install Solana using a binary with a fallback to installing from source
 ARG SOLANA_VERSION=1.18.17

--- a/Dockerfile
+++ b/Dockerfile
@@ -209,7 +209,7 @@ COPY --from=solana /root/.solana/bin /root/.solana/bin
 # Get EVM tooling
 COPY --from=evm /root/.cargo/bin/solc /root/.cargo/bin/solc
 COPY --from=evm /root/.cargo/bin/svm /root/.cargo/bin/svm
-COPY --from=evm /root/.foundry/bin /root/.foundry/bin
+COPY --from=evm /root/.foundry /root/.foundry
 COPY --from=evm /root/.svm /root/.svm
 
 # Enable corepack, new node package manager manager

--- a/Dockerfile
+++ b/Dockerfile
@@ -62,8 +62,7 @@ RUN apt-get install --yes \
     # Utilities required to build solana
     pkg-config libudev-dev llvm libclang-dev protobuf-compiler \
     # Utilities required to build aptos CLI
-    # grcov lcov libssl-dev lld cmake clang
-    libssl-dev libdw-dev
+    libssl-dev libdw-dev lld
 
 # Install rust
 ARG RUST_TOOLCHAIN_VERSION=1.75.0


### PR DESCRIPTION
### In this PR

- We'll need Aptos CLI In order to support the legacy Aptos programs
- The `Dockerfile` has been restructured and the VM dependencies have been separated into individual stages as opposed to building everything in the `base` image
  - `aptos` stage builds the Aptos CLI from specified release
  - `solana` stage downloads/builds the Solana CLI from specified release, then adds `avm` and `anchor`
  - `evm` stage adds `foundry`, `svm-rs` and `solc`