### PR TITLE
🗞️ Restore docker image build for linux/arm64

### DIFF
--- a/.github/workflows/actions/docker-build-image/action.yaml
+++ b/.github/workflows/actions/docker-build-image/action.yaml
@@ -65,7 +65,6 @@ runs:
         platforms: ${{ inputs.platform }}
         target: ${{ inputs.target }}
         outputs: type=image,name=${{ inputs.image }},push-by-digest=true,name-canonical=true,push=true
-        tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
         annotations: ${{ steps.meta.outputs.annotations }}
         cache-from: type=gha,scope=build-${{ env.PLATFORM_PAIR }}

--- a/.github/workflows/actions/docker-build-image/action.yaml
+++ b/.github/workflows/actions/docker-build-image/action.yaml
@@ -70,6 +70,8 @@ runs:
         annotations: ${{ steps.meta.outputs.annotations }}
         cache-from: type=gha,scope=build-${{ env.PLATFORM_PAIR }}
         cache-to: type=gha,mode=max,scope=build-${{ env.PLATFORM_PAIR }}
+        build-args: |
+          CARGO_BUILD_JOBS=8
 
     - name: Export digest
       shell: bash

--- a/.github/workflows/actions/docker-build-image/action.yaml
+++ b/.github/workflows/actions/docker-build-image/action.yaml
@@ -17,7 +17,7 @@ inputs:
   namespace:
     description: "Docker image namespace"
     required: true
-    default: ${{ github.repository_owner }}
+    default: layerzero-labs
   username:
     description: "Docker registry username"
     required: true
@@ -62,10 +62,8 @@ runs:
       id: build
       uses: docker/build-push-action@v6
       with:
-        context: .
         target: ${{ inputs.target }}
         platforms: ${{ inputs.platform }}
-        provenance: false
         outputs: type=image,name=${{ inputs.registry }}/${{ inputs.namespace }}/${{ inputs.image }},push-by-digest=true,name-canonical=true,push=true
         labels: ${{ steps.meta.outputs.labels }}
         annotations: ${{ steps.meta.outputs.annotations }}

--- a/.github/workflows/actions/docker-build-image/action.yaml
+++ b/.github/workflows/actions/docker-build-image/action.yaml
@@ -71,7 +71,7 @@ runs:
         cache-from: type=gha,scope=build-${{ env.PLATFORM_PAIR }}
         cache-to: type=gha,mode=max,scope=build-${{ env.PLATFORM_PAIR }}
         build-args: |
-          CARGO_BUILD_JOBS=8
+          CARGO_BUILD_JOBS=4
 
     - name: Export digest
       shell: bash

--- a/.github/workflows/actions/docker-build-image/action.yaml
+++ b/.github/workflows/actions/docker-build-image/action.yaml
@@ -24,6 +24,10 @@ inputs:
   password:
     description: "Docker registry password"
     required: true
+  digest-name:
+    description: "Unique name for the produced digests. Must be unique for a workflow run"
+    required: true
+    default: digest
   digest-path:
     description: "Output digests directory path, without a trailing slash"
     required: true
@@ -83,7 +87,7 @@ runs:
     - name: Upload digest
       uses: actions/upload-artifact@v4
       with:
-        name: digests-${{ env.PLATFORM_PAIR }}
+        name: ${{ inputs.digest-name }}-${{ env.PLATFORM_PAIR }}
         path: ${{ inputs.digest-path }}/*
         if-no-files-found: error
         retention-days: 1

--- a/.github/workflows/actions/docker-build-image/action.yaml
+++ b/.github/workflows/actions/docker-build-image/action.yaml
@@ -44,10 +44,6 @@ runs:
       with:
         images: |
           ${{ inputs.registry }}/${{ inputs.namespace }}/${{ inputs.image }}
-        tags: |
-          type=ref,event=branch
-          type=raw,value=FIXME,enable={{is_default_branch}}
-          type=raw,value=${{ github.sha }}
 
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v3

--- a/.github/workflows/actions/docker-build-image/action.yaml
+++ b/.github/workflows/actions/docker-build-image/action.yaml
@@ -1,0 +1,93 @@
+name: Build docker image
+description: Build dockker image and store the artifacts locally
+inputs:
+  image:
+    description: "Docker image name"
+    required: true
+  platform:
+    description: "Docker platform"
+    required: true
+  target:
+    description: "Docker target stage"
+    required: true
+  registry:
+    description: "Docker registry"
+    required: true
+    default: ghcr.io
+  namespace:
+    description: "Docker image namespace"
+    required: true
+    default: ${{ github.repository_owner }}
+  username:
+    description: "Docker registry username"
+    required: true
+  password:
+    description: "Docker registry password"
+    required: true
+  digest-path:
+    description: "Output digests directory path, without a trailing slash"
+    required: true
+    default: /tmp/digests
+
+runs:
+  using: "composite"
+  steps:
+    - name: Prepare
+      shell: bash
+      run: |
+        platform=${{ inputs.platform }}
+        echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
+
+    - name: Extract metadata (tags, labels) for Docker
+      id: meta
+      uses: docker/metadata-action@8e5442c4ef9f78752691e2d8f8d19755c6f78e81
+      with:
+        images: |
+          ${{ inputs.registry }}/${{ inputs.namespace }}/${{ inputs.image }}
+        tags: |
+          type=ref,event=branch
+          type=raw,value=FIXME,enable={{is_default_branch}}
+          type=raw,value=${{ github.sha }}
+
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v3
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: Log in to the Container registry
+      uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d
+      with:
+        registry: ${{ inputs.registry }}
+        username: ${{ inputs.username }}
+        password: ${{ inputs.password }}
+
+    - name: Build and push by digest
+      id: build
+      uses: docker/build-push-action@v6
+      with:
+        platforms: ${{ inputs.platform }}
+        target: ${{ inputs.target }}
+        outputs: type=image,name=${{ inputs.image }},push-by-digest=true,name-canonical=true,push=true
+        tags: ${{ steps.meta.outputs.tags }}
+        labels: ${{ steps.meta.outputs.labels }}
+        annotations: ${{ steps.meta.outputs.annotations }}
+        cache-from: type=gha,scope=build-${{ env.PLATFORM_PAIR }}
+        cache-to: type=gha,mode=max,scope=build-${{ env.PLATFORM_PAIR }}
+        build-args: |
+          CARGO_BUILD_JOBS=2
+
+    - name: Export digest
+      shell: bash
+      run: |
+        mkdir -p ${{ inputs.digest-path }}
+        digest="${{ steps.build.outputs.digest }}"
+        touch "${{ inputs.digest-path }}/${digest#sha256:}"
+
+    - name: Upload digest
+      uses: actions/upload-artifact@v4
+      with:
+        name: digests-${{ env.PLATFORM_PAIR }}
+        path: ${{ inputs.digest-path }}/*
+        if-no-files-found: error
+        retention-days: 1

--- a/.github/workflows/actions/docker-build-image/action.yaml
+++ b/.github/workflows/actions/docker-build-image/action.yaml
@@ -70,8 +70,6 @@ runs:
         annotations: ${{ steps.meta.outputs.annotations }}
         cache-from: type=gha,scope=build-${{ env.PLATFORM_PAIR }}
         cache-to: type=gha,mode=max,scope=build-${{ env.PLATFORM_PAIR }}
-        build-args: |
-          CARGO_BUILD_JOBS=2
 
     - name: Export digest
       shell: bash

--- a/.github/workflows/actions/docker-build-image/action.yaml
+++ b/.github/workflows/actions/docker-build-image/action.yaml
@@ -62,9 +62,11 @@ runs:
       id: build
       uses: docker/build-push-action@v6
       with:
-        platforms: ${{ inputs.platform }}
+        context: .
         target: ${{ inputs.target }}
-        outputs: type=image,name=${{ inputs.image }},push-by-digest=true,name-canonical=true,push=true
+        platforms: ${{ inputs.platform }}
+        provenance: false
+        outputs: type=image,name=${{ inputs.registry }}/${{ inputs.namespace }}/${{ inputs.image }},push-by-digest=true,name-canonical=true,push=true
         labels: ${{ steps.meta.outputs.labels }}
         annotations: ${{ steps.meta.outputs.annotations }}
         cache-from: type=gha,scope=build-${{ env.PLATFORM_PAIR }}

--- a/.github/workflows/actions/docker-build-image/action.yaml
+++ b/.github/workflows/actions/docker-build-image/action.yaml
@@ -64,6 +64,7 @@ runs:
       with:
         target: ${{ inputs.target }}
         platforms: ${{ inputs.platform }}
+        provenance: false
         outputs: type=image,name=${{ inputs.registry }}/${{ inputs.namespace }}/${{ inputs.image }},push-by-digest=true,name-canonical=true,push=true
         labels: ${{ steps.meta.outputs.labels }}
         annotations: ${{ steps.meta.outputs.annotations }}

--- a/.github/workflows/actions/docker-build-image/action.yaml
+++ b/.github/workflows/actions/docker-build-image/action.yaml
@@ -38,6 +38,13 @@ runs:
         platform=${{ inputs.platform }}
         echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
 
+    - name: Log in to the Container registry
+      uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d
+      with:
+        registry: ${{ inputs.registry }}
+        username: ${{ inputs.username }}
+        password: ${{ inputs.password }}
+
     - name: Extract metadata (tags, labels) for Docker
       id: meta
       uses: docker/metadata-action@8e5442c4ef9f78752691e2d8f8d19755c6f78e81
@@ -50,13 +57,6 @@ runs:
 
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
-
-    - name: Log in to the Container registry
-      uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d
-      with:
-        registry: ${{ inputs.registry }}
-        username: ${{ inputs.username }}
-        password: ${{ inputs.password }}
 
     - name: Build and push by digest
       id: build

--- a/.github/workflows/actions/docker-push-image/action.yaml
+++ b/.github/workflows/actions/docker-push-image/action.yaml
@@ -65,8 +65,8 @@ runs:
     - name: FIXME Debug docker
       shell: bash
       run: |
-        echo $(jq -cr '.tags | map("-t \"" + . + "\"") | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
-        echo $(jq -cr '.annotations | map("--annotation \"" + . + "\"") | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+        echo $(jq -cr '.tags | map("-t \"" + . + "\"") | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON")
+        echo $(jq -cr '.annotations | map("--annotation \"" + . + "\"") | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON")
         echo $(printf '${{ inputs.registry }}/${{ inputs.namespace }}/${{ inputs.image }}@sha256:%s ' *)
 
     - name: Create manifest list and push

--- a/.github/workflows/actions/docker-push-image/action.yaml
+++ b/.github/workflows/actions/docker-push-image/action.yaml
@@ -58,8 +58,10 @@ runs:
       shell: bash
       working-directory: ${{ inputs.digest-path }}
       run: |
-        docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
-          $(printf '${{ inputs.registry }}/${{ inputs.namespace }}/${{ inputs.image }}@sha256:%s ' *)
+        docker buildx imagetools create \
+        $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+        $(jq -cr '.annotations | map("--annotation " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+        $(printf '${{ inputs.registry }}/${{ inputs.namespace }}/${{ inputs.image }}@sha256:%s ' *)
 
     - name: Inspect image
       shell: bash

--- a/.github/workflows/actions/docker-push-image/action.yaml
+++ b/.github/workflows/actions/docker-push-image/action.yaml
@@ -76,7 +76,7 @@ runs:
         docker buildx imagetools create \
         $(jq -cr '.tags | map("-t \"" + . + "\"") | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
         $(jq -cr '.annotations | map("--annotation \"" + . + "\"") | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
-        $(printf '${{ inputs.registry }}/${{ inputs.namespace }}/${{ inputs.image }}@sha256:%s ' *)
+        $(printf '"${{ inputs.registry }}/${{ inputs.namespace }}/${{ inputs.image }}@sha256:%s" ' *)
 
     - name: Inspect image
       shell: bash

--- a/.github/workflows/actions/docker-push-image/action.yaml
+++ b/.github/workflows/actions/docker-push-image/action.yaml
@@ -18,6 +18,10 @@ inputs:
   password:
     description: "Docker registry password"
     required: true
+  digest-name:
+    description: "Unique name for the produced digests. Must be unique for a workflow run"
+    required: true
+    default: digest
   digest-path:
     description: "Digests directory path, without a trailing slash"
     required: true
@@ -30,8 +34,12 @@ runs:
       uses: actions/download-artifact@v4
       with:
         path: ${{ inputs.digest-path }}
-        pattern: digests-*
+        pattern: ${{ inputs.digest-name }}-*
         merge-multiple: true
+
+    - name: FIXME Debug artifacts
+      shell: bash
+      run: ls -al ${{ inputs.digest-path }}/${{ inputs.digest-name }}
 
     - name: Log in to the Container registry
       uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d
@@ -53,6 +61,13 @@ runs:
           type=ref,event=branch
           type=raw,value=latest,enable={{is_default_branch}}
           type=raw,value=${{ github.sha }}
+
+    - name: FIXME Debug docker
+      shell: bash
+      run: |
+        echo $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+        echo $(jq -cr '.annotations | map("--annotation " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+        echo $(printf '${{ inputs.registry }}/${{ inputs.namespace }}/${{ inputs.image }}@sha256:%s ' *)
 
     - name: Create manifest list and push
       shell: bash

--- a/.github/workflows/actions/docker-push-image/action.yaml
+++ b/.github/workflows/actions/docker-push-image/action.yaml
@@ -39,7 +39,7 @@ runs:
 
     - name: FIXME Debug artifacts
       shell: bash
-      run: ls -al ${{ inputs.digest-path }}/${{ inputs.digest-name }}
+      run: ls -al ${{ inputs.digest-path }}
 
     - name: Log in to the Container registry
       uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d

--- a/.github/workflows/actions/docker-push-image/action.yaml
+++ b/.github/workflows/actions/docker-push-image/action.yaml
@@ -75,8 +75,7 @@ runs:
       run: |
         docker buildx imagetools create \
         $(jq -cr '.tags | map("-t \"" + . + "\"") | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
-        $(jq -cr '.annotations | map("--annotation \"" + . + "\"") | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
-        $(printf '"${{ inputs.registry }}/${{ inputs.namespace }}/${{ inputs.image }}@sha256:%s" ' *)
+        $(printf '${{ inputs.registry }}/${{ inputs.namespace }}/${{ inputs.image }}@sha256:%s ' *)
 
     - name: Inspect image
       shell: bash

--- a/.github/workflows/actions/docker-push-image/action.yaml
+++ b/.github/workflows/actions/docker-push-image/action.yaml
@@ -65,8 +65,7 @@ runs:
     - name: FIXME Debug docker
       shell: bash
       run: |
-        echo $(jq -cr '.tags | map("-t \"" + . + "\"") | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON")
-        echo $(jq -cr '.annotations | map("--annotation \"" + . + "\"") | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON")
+        echo $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON")
         echo $(printf '${{ inputs.registry }}/${{ inputs.namespace }}/${{ inputs.image }}@sha256:%s ' *)
 
     - name: Create manifest list and push
@@ -74,7 +73,7 @@ runs:
       working-directory: ${{ inputs.digest-path }}
       run: |
         docker buildx imagetools create \
-        $(jq -cr '.tags | map("-t \"" + . + "\"") | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+        $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
         $(printf '${{ inputs.registry }}/${{ inputs.namespace }}/${{ inputs.image }}@sha256:%s ' *)
 
     - name: Inspect image

--- a/.github/workflows/actions/docker-push-image/action.yaml
+++ b/.github/workflows/actions/docker-push-image/action.yaml
@@ -64,7 +64,6 @@ runs:
       run: |
         docker buildx imagetools create \
         $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
-        $(jq -cr '.annotations | map("--annotation \"" + . + "\"") | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
         $(printf '${{ inputs.registry }}/${{ inputs.namespace }}/${{ inputs.image }}@sha256:%s ' *)
 
     - name: Inspect image

--- a/.github/workflows/actions/docker-push-image/action.yaml
+++ b/.github/workflows/actions/docker-push-image/action.yaml
@@ -65,8 +65,8 @@ runs:
     - name: FIXME Debug docker
       shell: bash
       run: |
-        echo $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
-        echo $(jq -cr '.annotations | map("--annotation " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+        echo $(jq -cr '.tags | map("-t '" + . + "'") | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+        echo $(jq -cr '.annotations | map("--annotation '" + . + "'") | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
         echo $(printf '${{ inputs.registry }}/${{ inputs.namespace }}/${{ inputs.image }}@sha256:%s ' *)
 
     - name: Create manifest list and push
@@ -74,8 +74,8 @@ runs:
       working-directory: ${{ inputs.digest-path }}
       run: |
         docker buildx imagetools create \
-        $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
-        $(jq -cr '.annotations | map("--annotation " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+        $(jq -cr '.tags | map("-t '" + . + "'") | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+        $(jq -cr '.annotations | map("--annotation '" + . + "'") | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
         $(printf '${{ inputs.registry }}/${{ inputs.namespace }}/${{ inputs.image }}@sha256:%s ' *)
 
     - name: Inspect image

--- a/.github/workflows/actions/docker-push-image/action.yaml
+++ b/.github/workflows/actions/docker-push-image/action.yaml
@@ -65,8 +65,8 @@ runs:
     - name: FIXME Debug docker
       shell: bash
       run: |
-        echo $(jq -cr '.tags | map("-t '" + . + "'") | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
-        echo $(jq -cr '.annotations | map("--annotation '" + . + "'") | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+        echo $(jq -cr '.tags | map("-t \"" + . + "\"") | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+        echo $(jq -cr '.annotations | map("--annotation \"" + . + "\"") | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
         echo $(printf '${{ inputs.registry }}/${{ inputs.namespace }}/${{ inputs.image }}@sha256:%s ' *)
 
     - name: Create manifest list and push
@@ -74,8 +74,8 @@ runs:
       working-directory: ${{ inputs.digest-path }}
       run: |
         docker buildx imagetools create \
-        $(jq -cr '.tags | map("-t '" + . + "'") | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
-        $(jq -cr '.annotations | map("--annotation '" + . + "'") | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+        $(jq -cr '.tags | map("-t \"" + . + "\"") | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+        $(jq -cr '.annotations | map("--annotation \"" + . + "\"") | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
         $(printf '${{ inputs.registry }}/${{ inputs.namespace }}/${{ inputs.image }}@sha256:%s ' *)
 
     - name: Inspect image

--- a/.github/workflows/actions/docker-push-image/action.yaml
+++ b/.github/workflows/actions/docker-push-image/action.yaml
@@ -51,7 +51,7 @@ runs:
           ${{ inputs.registry }}/${{ inputs.namespace }}/${{ inputs.image }}
         tags: |
           type=ref,event=branch
-          type=raw,value=FIXME,enable={{is_default_branch}}
+          type=raw,value=latest,enable={{is_default_branch}}
           type=raw,value=${{ github.sha }}
 
     - name: Create manifest list and push

--- a/.github/workflows/actions/docker-push-image/action.yaml
+++ b/.github/workflows/actions/docker-push-image/action.yaml
@@ -37,10 +37,6 @@ runs:
         pattern: ${{ inputs.digest-name }}-*
         merge-multiple: true
 
-    - name: FIXME Debug artifacts
-      shell: bash
-      run: ls -al ${{ inputs.digest-path }}
-
     - name: Log in to the Container registry
       uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d
       with:
@@ -62,18 +58,13 @@ runs:
           type=raw,value=latest,enable={{is_default_branch}}
           type=raw,value=${{ github.sha }}
 
-    - name: FIXME Debug docker
-      shell: bash
-      run: |
-        echo $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON")
-        echo $(printf '${{ inputs.registry }}/${{ inputs.namespace }}/${{ inputs.image }}@sha256:%s ' *)
-
     - name: Create manifest list and push
       shell: bash
       working-directory: ${{ inputs.digest-path }}
       run: |
         docker buildx imagetools create \
         $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+        $(jq -cr '.annotations | map("--annotation \"" + . + "\"") | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
         $(printf '${{ inputs.registry }}/${{ inputs.namespace }}/${{ inputs.image }}@sha256:%s ' *)
 
     - name: Inspect image

--- a/.github/workflows/actions/merge-docker-image/action.yaml
+++ b/.github/workflows/actions/merge-docker-image/action.yaml
@@ -33,6 +33,13 @@ runs:
         pattern: digests-*
         merge-multiple: true
 
+    - name: Log in to the Container registry
+      uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d
+      with:
+        registry: ${{ inputs.registry }}
+        username: ${{ inputs.username }}
+        password: ${{ inputs.password }}
+
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
 
@@ -46,13 +53,6 @@ runs:
           type=ref,event=branch
           type=raw,value=FIXME,enable={{is_default_branch}}
           type=raw,value=${{ github.sha }}
-
-    - name: Log in to the Container registry
-      uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d
-      with:
-        registry: ${{ inputs.registry }}
-        username: ${{ inputs.username }}
-        password: ${{ inputs.password }}
 
     - name: Create manifest list and push
       shell: bash

--- a/.github/workflows/actions/merge-docker-image/action.yaml
+++ b/.github/workflows/actions/merge-docker-image/action.yaml
@@ -1,0 +1,67 @@
+name: Merge multiplatform docker image digests
+description: Merge multiplatform docker image digests to form a single image
+inputs:
+  image:
+    description: "Docker image name"
+    required: true
+  registry:
+    description: "Docker registry"
+    required: true
+    default: ghcr.io
+  namespace:
+    description: "Docker image namespace"
+    required: true
+    default: ${{ github.repository_owner }}
+  username:
+    description: "Docker registry username"
+    required: true
+  password:
+    description: "Docker registry password"
+    required: true
+  digest-path:
+    description: "Digests directory path, without a trailing slash"
+    required: true
+    default: /tmp/digests
+
+runs:
+  using: "composite"
+  steps:
+    - name: Download digests
+      uses: actions/download-artifact@v4
+      with:
+        path: ${{ inputs.digest-path }}
+        pattern: digests-*
+        merge-multiple: true
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: Extract metadata (tags, labels) for Docker
+      id: meta
+      uses: docker/metadata-action@8e5442c4ef9f78752691e2d8f8d19755c6f78e81
+      with:
+        images: |
+          ${{ inputs.registry }}/${{ inputs.namespace }}/${{ inputs.image }}
+        tags: |
+          type=ref,event=branch
+          type=raw,value=FIXME,enable={{is_default_branch}}
+          type=raw,value=${{ github.sha }}
+
+    - name: Log in to the Container registry
+      uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d
+      with:
+        registry: ${{ inputs.registry }}
+        username: ${{ inputs.username }}
+        password: ${{ inputs.password }}
+
+    - name: Create manifest list and push
+      shell: bash
+      working-directory: ${{ inputs.digest-path }}
+      run: |
+        docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+          $(printf '${{ inputs.image }}@sha256:%s ' *)
+
+    - name: Inspect image
+      shell: bash
+      run: |
+        docker buildx imagetools inspect ${{ inputs.image }}:${{ steps.meta.outputs.version }}

--- a/.github/workflows/actions/merge-docker-image/action.yaml
+++ b/.github/workflows/actions/merge-docker-image/action.yaml
@@ -11,7 +11,7 @@ inputs:
   namespace:
     description: "Docker image namespace"
     required: true
-    default: ${{ github.repository_owner }}
+    default: layerzero-labs
   username:
     description: "Docker registry username"
     required: true

--- a/.github/workflows/actions/merge-docker-image/action.yaml
+++ b/.github/workflows/actions/merge-docker-image/action.yaml
@@ -59,9 +59,9 @@ runs:
       working-directory: ${{ inputs.digest-path }}
       run: |
         docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
-          $(printf '${{ inputs.image }}@sha256:%s ' *)
+          $(printf '${{ inputs.registry }}/${{ inputs.namespace }}/${{ inputs.image }}@sha256:%s ' *)
 
     - name: Inspect image
       shell: bash
       run: |
-        docker buildx imagetools inspect ${{ inputs.image }}:${{ steps.meta.outputs.version }}
+        docker buildx imagetools inspect ${{ inputs.registry }}/${{ inputs.namespace }}/${{ inputs.image }}:${{ steps.meta.outputs.version }}

--- a/.github/workflows/reusable-publish-docker.yaml
+++ b/.github/workflows/reusable-publish-docker.yaml
@@ -50,6 +50,10 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+        with:
+          config-inline: |
+            [worker.oci]
+              max-parallelism = 2
 
       - name: Build and push base image
         uses: docker/build-push-action@4a13e500e55cf31b7a5d59a38ab2040ab0f42f56

--- a/.github/workflows/reusable-publish-docker.yaml
+++ b/.github/workflows/reusable-publish-docker.yaml
@@ -33,7 +33,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Build image
+      - name: Push image digest
         uses: ./.github/workflows/actions/docker-build-image
         with:
           image: devtools-dev-base
@@ -63,7 +63,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Build image
+      - name: Push image digest
         uses: ./.github/workflows/actions/docker-build-image
         with:
           image: devtools-dev-node-evm-hardhat

--- a/.github/workflows/reusable-publish-docker.yaml
+++ b/.github/workflows/reusable-publish-docker.yaml
@@ -12,9 +12,6 @@ name: Build base development images
 on:
   workflow_call:
   workflow_dispatch:
-  push:
-    branches:
-      - platforms
 
 jobs:
   build-base:
@@ -40,7 +37,7 @@ jobs:
         uses: ./.github/workflows/actions/docker-build-image
         with:
           image: devtools-dev-base
-          target: machine
+          target: base
           platform: ${{ matrix.platform }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/reusable-publish-docker.yaml
+++ b/.github/workflows/reusable-publish-docker.yaml
@@ -53,6 +53,9 @@ jobs:
   #
   # Build the EVM node image and push it as digests
   #
+  # We build the node images after we're done with the base so that we can use the docker layer cache
+  # instead of rebuilding the whole thing from scratch
+  #
   build-node-evm:
     name: Build EVM node image
     runs-on: ubuntu-latest-16xlarge

--- a/.github/workflows/reusable-publish-docker.yaml
+++ b/.github/workflows/reusable-publish-docker.yaml
@@ -42,6 +42,36 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+  build-node-evm:
+    name: Build EVM node image
+    runs-on: ubuntu-latest-16xlarge
+    needs:
+      - build-base
+
+    permissions:
+      contents: read
+      packages: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - linux/amd64
+          - linux/arm64
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Build image
+        uses: ./.github/workflows/actions/docker-build-image
+        with:
+          image: devtools-dev-node-evm-hardhat
+          target: node-evm-hardhat
+          platform: ${{ matrix.platform }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
   push-base:
     name: Push base image
     runs-on: ubuntu-latest-4xlarge
@@ -56,7 +86,24 @@ jobs:
         uses: ./.github/workflows/actions/merge-docker-image
         with:
           image: devtools-dev-base
-          target: base
+          platform: ${{ matrix.platform }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+  push-node-evm:
+    name: Push EVM node image
+    runs-on: ubuntu-latest-4xlarge
+    needs:
+      - build-node-evm
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Push image
+        uses: ./.github/workflows/actions/merge-docker-image
+        with:
+          image: devtools-dev-node-evm-hardhat
           platform: ${{ matrix.platform }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/reusable-publish-docker.yaml
+++ b/.github/workflows/reusable-publish-docker.yaml
@@ -12,6 +12,9 @@ name: Build base development images
 on:
   workflow_call:
   workflow_dispatch:
+  push:
+    branches:
+      - platforms
 
 jobs:
   build-base:

--- a/.github/workflows/reusable-publish-docker.yaml
+++ b/.github/workflows/reusable-publish-docker.yaml
@@ -13,10 +13,6 @@ on:
   workflow_call:
   workflow_dispatch:
 
-env:
-  REGISTRY: ghcr.io
-  IMAGE_NAMESPACE: ${{ github.repository_owner }}
-
 jobs:
   build-base:
     name: Build base image
@@ -26,105 +22,41 @@ jobs:
       contents: read
       packages: write
 
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - linux/amd64
+          - linux/arm64
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Log in to the Container registry
-        uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d
+      - name: Build image
+        uses: ./.github/workflows/actions/docker-build-image
         with:
-          registry: ${{ env.REGISTRY }}
+          image: devtools-dev-base
+          target: base
+          platform: ${{ matrix.platform }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Extract metadata (tags, labels) for Docker
-        id: meta
-        uses: docker/metadata-action@8e5442c4ef9f78752691e2d8f8d19755c6f78e81
-        with:
-          images: |
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAMESPACE }}/devtools-dev-base
-          tags: |
-            type=ref,event=branch
-            type=raw,value=latest,enable={{is_default_branch}}
-            type=raw,value=${{ github.sha }}
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-        with:
-          config-inline: |
-            [worker.oci]
-              max-parallelism = 2
-
-      - name: Build and push base image
-        uses: docker/build-push-action@4a13e500e55cf31b7a5d59a38ab2040ab0f42f56
-        with:
-          provenance: false
-          context: .
-          # linux/arm64 platform build is timing out on github runners
-          # most probably due to memory limitations of the runner
-          #
-          # Since this platform is only used on local M1/2/3 machines
-          # and can be built locally, we'll disable the CI/CD build
-          # instead of going for much more complex distributed matrix build
-          #
-          # See more about how the build can be distributed here
-          # https://docs.docker.com/build/ci/github-actions/multi-platform/
-          platforms: linux/amd64,linux/arm64
-          push: true
-          target: base
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          annotations: ${{ steps.meta.outputs.annotations }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-          build-args: |
-            CARGO_BUILD_JOBS=2
-
-  build-node-evm:
-    name: Build EVM node image
+  push-base:
+    name: Push base image
     runs-on: ubuntu-latest-4xlarge
     needs:
       - build-base
 
-    permissions:
-      contents: read
-      packages: write
-
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Log in to the Container registry
-        uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d
+      - name: Push image
+        uses: ./.github/workflows/actions/merge-docker-image
         with:
-          registry: ${{ env.REGISTRY }}
+          image: devtools-dev-base
+          target: base
+          platform: ${{ matrix.platform }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Extract metadata (tags, labels) for Docker
-        id: meta
-        uses: docker/metadata-action@8e5442c4ef9f78752691e2d8f8d19755c6f78e81
-        with:
-          images: |
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAMESPACE }}/devtools-dev-node-evm-hardhat
-          tags: |
-            type=ref,event=branch
-            type=raw,value=latest,enable={{is_default_branch}}
-            type=raw,value=${{ github.sha }}
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Build and push EVM node image
-        uses: docker/build-push-action@4a13e500e55cf31b7a5d59a38ab2040ab0f42f56
-        with:
-          provenance: false
-          context: .
-          platforms: linux/amd64,linux/arm64
-          push: true
-          target: node-evm-hardhat
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          annotations: ${{ steps.meta.outputs.annotations }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max

--- a/.github/workflows/reusable-publish-docker.yaml
+++ b/.github/workflows/reusable-publish-docker.yaml
@@ -14,6 +14,9 @@ on:
   workflow_dispatch:
 
 jobs:
+  #
+  # Build the base image and push it as digests
+  #
   build-base:
     name: Build base image
     runs-on: ubuntu-latest-16xlarge
@@ -33,15 +36,23 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Push image digest
+      - name: Build image & push the digest
         uses: ./.github/workflows/actions/docker-build-image
         with:
+          # The name of the image
           image: devtools-dev-base
+          # The target stage of the Dockerfile
           target: base
+          # Since the digests will be shared across jobs as artifacts,
+          # we need a unique name (per workflow) for these artifacts
+          digest-name: base
           platform: ${{ matrix.platform }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+  #
+  # Build the EVM node image and push it as digests
+  #
   build-node-evm:
     name: Build EVM node image
     runs-on: ubuntu-latest-16xlarge
@@ -63,15 +74,23 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Push image digest
+      - name: Build image & push the digest
         uses: ./.github/workflows/actions/docker-build-image
         with:
+          # The name of the image
           image: devtools-dev-node-evm-hardhat
+          # The target stage of the Dockerfile
           target: node-evm-hardhat
+          # Since the digests will be shared across jobs as artifacts,
+          # we need a unique name (per workflow) for these artifacts
+          digest-name: node-evm-hardhat
           platform: ${{ matrix.platform }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+  #
+  # Collect the base image digests and push them to GHCR
+  #
   push-base:
     name: Push base image
     runs-on: ubuntu-latest-4xlarge
@@ -83,12 +102,21 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Push image
-        uses: ./.github/workflows/actions/merge-docker-image
+        uses: ./.github/workflows/actions/docker-push-image
         with:
+          # The name of the image
           image: devtools-dev-base
+          # Since the digests will be shared across jobs as artifacts,
+          # we need a unique name (per workflow) for these artifacts
+          #
+          # This needs to match the digest name of the build stage
+          digest-name: base
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+  #
+  # Collect the EVM node image digests and push them to GHCR
+  #
   push-node-evm:
     name: Push EVM node image
     runs-on: ubuntu-latest-4xlarge
@@ -100,8 +128,14 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Push image
-        uses: ./.github/workflows/actions/merge-docker-image
+        uses: ./.github/workflows/actions/docker-push-image
         with:
+          # The name of the image
           image: devtools-dev-node-evm-hardhat
+          # Since the digests will be shared across jobs as artifacts,
+          # we need a unique name (per workflow) for these artifacts
+          #
+          # This needs to match the digest name of the build stage
+          digest-name: node-evm-hardhat
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/reusable-publish-docker.yaml
+++ b/.github/workflows/reusable-publish-docker.yaml
@@ -65,7 +65,7 @@ jobs:
           #
           # See more about how the build can be distributed here
           # https://docs.docker.com/build/ci/github-actions/multi-platform/
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           push: true
           target: base
           tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/reusable-publish-docker.yaml
+++ b/.github/workflows/reusable-publish-docker.yaml
@@ -37,7 +37,7 @@ jobs:
         uses: ./.github/workflows/actions/docker-build-image
         with:
           image: devtools-dev-base
-          target: base
+          target: machine
           platform: ${{ matrix.platform }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/reusable-publish-docker.yaml
+++ b/.github/workflows/reusable-publish-docker.yaml
@@ -86,7 +86,6 @@ jobs:
         uses: ./.github/workflows/actions/merge-docker-image
         with:
           image: devtools-dev-base
-          platform: ${{ matrix.platform }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
@@ -104,6 +103,5 @@ jobs:
         uses: ./.github/workflows/actions/merge-docker-image
         with:
           image: devtools-dev-node-evm-hardhat
-          platform: ${{ matrix.platform }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -195,6 +195,9 @@ RUN solana --version
 # `-'   `-`-'   `-`-'   `-`-'   `-`-'   `-`-'   `-`-'   `-`-'
 FROM machine AS evm
 
+ARG CARGO_BUILD_JOBS=default
+ENV CARGO_BUILD_JOBS=$CARGO_BUILD_JOBS
+
 # Install foundry
 ENV PATH="/root/.foundry/bin:$PATH"
 RUN curl -L https://foundry.paradigm.xyz | bash

--- a/Dockerfile
+++ b/Dockerfile
@@ -153,18 +153,13 @@ RUN \
 # Delete the source files (only left behind if solana was built from source)
 RUN rm -rf ./solana-*
 
-# Install AVM - Anchor version manager for Solana
-RUN cargo install --git https://github.com/coral-xyz/anchor avm
-
 # Install anchor
 ARG ANCHOR_VERSION=0.30.1
-RUN avm install ${ANCHOR_VERSION}
-RUN avm use ${ANCHOR_VERSION}
+RUN cargo install --git https://github.com/coral-xyz/anchor --tag v${ANCHOR_VERSION} anchor-cli
 
 # Make sure we can execute the binaries
 ENV PATH="/root/.avm/bin:/root/.solana/bin:$PATH"
 RUN anchor --version
-RUN avm --version
 RUN solana --version
 
 #   .-.-.   .-.-.   .-.-.   .-.-.   .-.-.   .-.-.   .-.-.   .-.-
@@ -220,8 +215,6 @@ COPY --from=aptos /root/.aptos/bin /root/.aptos/bin
 
 # Get solana tooling
 COPY --from=solana /root/.cargo/bin/anchor /root/.cargo/bin/anchor
-COPY --from=solana /root/.cargo/bin/avm /root/.cargo/bin/avm
-COPY --from=solana /root/.avm /root/.avm
 COPY --from=solana /root/.solana/bin /root/.solana/bin
 
 # Get EVM tooling
@@ -240,7 +233,6 @@ RUN node -v
 RUN pnpm --version
 RUN git --version
 RUN anchor --version
-RUN avm --version
 RUN forge --version
 RUN anvil --version
 RUN chisel --version

--- a/Dockerfile
+++ b/Dockerfile
@@ -153,13 +153,18 @@ RUN \
 # Delete the source files (only left behind if solana was built from source)
 RUN rm -rf ./solana-*
 
+# Install AVM - Anchor version manager for Solana
+RUN cargo install --git https://github.com/coral-xyz/anchor avm
+
 # Install anchor
 ARG ANCHOR_VERSION=0.30.1
-RUN cargo install --git https://github.com/coral-xyz/anchor --tag v${ANCHOR_VERSION} anchor-cli
+RUN avm install ${ANCHOR_VERSION}
+RUN avm use ${ANCHOR_VERSION}
 
 # Make sure we can execute the binaries
-ENV PATH="/root/.solana/bin:$PATH"
+ENV PATH="/root/.avm/bin:/root/.solana/bin:$PATH"
 RUN anchor --version
+RUN avm --version
 RUN solana --version
 
 #   .-.-.   .-.-.   .-.-.   .-.-.   .-.-.   .-.-.   .-.-.   .-.-
@@ -208,13 +213,15 @@ WORKDIR /app
 # We'll add an empty NPM_TOKEN to suppress any warnings
 ENV NPM_TOKEN=
 ENV NPM_CONFIG_STORE_DIR=/pnpm
-ENV PATH="/root/.aptos/bin:/root/.foundry/bin:/root/.solana/bin:$PATH"
+ENV PATH="/root/.aptos/bin:/root/.avm/bin:/root/.foundry/bin:/root/.solana/bin:$PATH"
 
 # Get aptos CLI
 COPY --from=aptos /root/.aptos/bin /root/.aptos/bin
 
 # Get solana tooling
 COPY --from=solana /root/.cargo/bin/anchor /root/.cargo/bin/anchor
+COPY --from=solana /root/.cargo/bin/avm /root/.cargo/bin/avm
+COPY --from=solana /root/.avm /root/.avm
 COPY --from=solana /root/.solana/bin /root/.solana/bin
 
 # Get EVM tooling
@@ -233,6 +240,7 @@ RUN node -v
 RUN pnpm --version
 RUN git --version
 RUN anchor --version
+RUN avm --version
 RUN aptos --version
 RUN forge --version
 RUN anvil --version

--- a/Dockerfile
+++ b/Dockerfile
@@ -158,7 +158,7 @@ ARG ANCHOR_VERSION=0.30.1
 RUN cargo install --git https://github.com/coral-xyz/anchor --tag v${ANCHOR_VERSION} anchor-cli
 
 # Make sure we can execute the binaries
-ENV PATH="/root/.avm/bin:/root/.solana/bin:$PATH"
+ENV PATH="/root/.solana/bin:$PATH"
 RUN anchor --version
 RUN solana --version
 
@@ -208,7 +208,7 @@ WORKDIR /app
 # We'll add an empty NPM_TOKEN to suppress any warnings
 ENV NPM_TOKEN=
 ENV NPM_CONFIG_STORE_DIR=/pnpm
-ENV PATH="/root/.aptos/bin/root/.avm/bin:/root/.foundry/bin:/root/.solana/bin:$PATH"
+ENV PATH="/root/.aptos/bin:/root/.foundry/bin:/root/.solana/bin:$PATH"
 
 # Get aptos CLI
 COPY --from=aptos /root/.aptos/bin /root/.aptos/bin
@@ -233,6 +233,7 @@ RUN node -v
 RUN pnpm --version
 RUN git --version
 RUN anchor --version
+RUN aptos --version
 RUN forge --version
 RUN anvil --version
 RUN chisel --version

--- a/Dockerfile
+++ b/Dockerfile
@@ -118,7 +118,37 @@ RUN aptos --version
 #  / / \ \ / / \ \ / / \ \ / / \ \ / / \ \ / / \ \ / / \ \ / / \
 # `-'   `-`-'   `-`-'   `-`-'   `-`-'   `-`-'   `-`-'   `-`-'
 #
-#          Image that builds Solana developer tooling
+#               Image that builds AVM & Anchor
+#
+#   .-.-.   .-.-.   .-.-.   .-.-.   .-.-.   .-.-.   .-.-.   .-.-
+#  / / \ \ / / \ \ / / \ \ / / \ \ / / \ \ / / \ \ / / \ \ / / \
+# `-'   `-`-'   `-`-'   `-`-'   `-`-'   `-`-'   `-`-'   `-`-'
+FROM machine AS avm
+
+WORKDIR /app/avm
+
+# Configure cargo. We want to provide a way of limiting cargo resources
+# on the github runner since it is not large enough to support multiple cargo builds
+ARG CARGO_BUILD_JOBS=default
+ENV CARGO_BUILD_JOBS=$CARGO_BUILD_JOBS
+
+# Install AVM - Anchor version manager for Solana
+RUN cargo install --git https://github.com/coral-xyz/anchor avm
+
+# Install anchor
+ARG ANCHOR_VERSION=0.30.1
+RUN avm install ${ANCHOR_VERSION}
+RUN avm use ${ANCHOR_VERSION}
+
+ENV PATH="/root/.avm/bin:$PATH"
+RUN anchor --version
+RUN avm --version
+
+#   .-.-.   .-.-.   .-.-.   .-.-.   .-.-.   .-.-.   .-.-.   .-.-
+#  / / \ \ / / \ \ / / \ \ / / \ \ / / \ \ / / \ \ / / \ \ / / \
+# `-'   `-`-'   `-`-'   `-`-'   `-`-'   `-`-'   `-`-'   `-`-'
+#
+#                 Image that builds Solana CLI
 #
 #   .-.-.   .-.-.   .-.-.   .-.-.   .-.-.   .-.-.   .-.-.   .-.-
 #  / / \ \ / / \ \ / / \ \ / / \ \ / / \ \ / / \ \ / / \ \ / / \
@@ -150,21 +180,8 @@ RUN \
     ./solana-${SOLANA_VERSION}/scripts/cargo-install-all.sh --validator-only /root/.solana \
     )
 
-# Delete the source files (only left behind if solana was built from source)
-RUN rm -rf ./solana-*
-
-# Install AVM - Anchor version manager for Solana
-RUN cargo install --git https://github.com/coral-xyz/anchor avm
-
-# Install anchor
-ARG ANCHOR_VERSION=0.30.1
-RUN avm install ${ANCHOR_VERSION}
-RUN avm use ${ANCHOR_VERSION}
-
 # Make sure we can execute the binaries
-ENV PATH="/root/.avm/bin:/root/.solana/bin:$PATH"
-RUN anchor --version
-RUN avm --version
+ENV PATH="/root/.solana/bin:$PATH"
 RUN solana --version
 
 #   .-.-.   .-.-.   .-.-.   .-.-.   .-.-.   .-.-.   .-.-.   .-.-
@@ -219,9 +236,9 @@ ENV PATH="/root/.aptos/bin:/root/.avm/bin:/root/.foundry/bin:/root/.solana/bin:$
 COPY --from=aptos /root/.aptos/bin /root/.aptos/bin
 
 # Get solana tooling
-COPY --from=solana /root/.cargo/bin/anchor /root/.cargo/bin/anchor
-COPY --from=solana /root/.cargo/bin/avm /root/.cargo/bin/avm
-COPY --from=solana /root/.avm /root/.avm
+COPY --from=avm /root/.cargo/bin/anchor /root/.cargo/bin/anchor
+COPY --from=avm /root/.cargo/bin/avm /root/.cargo/bin/avm
+COPY --from=avm /root/.avm /root/.avm
 COPY --from=solana /root/.solana/bin /root/.solana/bin
 
 # Get EVM tooling


### PR DESCRIPTION
### In this PR

- To better support downstream projects and provide base images that can be used with all sorts of VM tooling on both unix and macOS, we distribute the docker build on separate runners, push the digests, then merge the digests into a final image
- The docker publishing action now follows the official guidelines for distributing builds across workers [here](https://docs.docker.com/build/ci/github-actions/multi-platform/#distribute-build-across-multiple-runners)

The action run for this PR is [here](https://github.com/LayerZero-Labs/devtools/actions/runs/11449791078). I want to make sure that it passes before I merge this.