### PR TITLE
🪲 Use defaults for Solana RPC URLs

### DIFF
--- a/.github/workflows/reusable-test.yaml
+++ b/.github/workflows/reusable-test.yaml
@@ -88,8 +88,8 @@ jobs:
           DEVTOOLS_EVM_NODE_IMAGE: ghcr.io/layerzero-labs/devtools-dev-node-evm-hardhat:main
           # Provided we have good quality Solana RPCs, we can enable Solana tests
           LZ_DEVTOOLS_ENABLE_SOLANA_TESTS: 1
-          RPC_URL_SOLANA_MAINNET: ${{ secrets.RPC_URL_SOLANA_MAINNET }}
-          RPC_URL_SOLANA_TESTNET: ${{ secrets.RPC_URL_SOLANA_TESTNET }}
+          RPC_URL_SOLANA_MAINNET: ${{ secrets.RPC_URL_SOLANA_MAINNET || 'https://rpc.ankr.com/solana' }}
+          RPC_URL_SOLANA_TESTNET: ${{ secrets.RPC_URL_SOLANA_TESTNET || 'https://api.devnet.solana.com' }}
 
       # We'll collect the docker compose logs from all containers on failure
       - name: Collect docker logs on failure

--- a/packages/devtools-solana/test/common/accounts.test.ts
+++ b/packages/devtools-solana/test/common/accounts.test.ts
@@ -19,8 +19,8 @@ describe('common/accounts', () => {
     beforeAll(() => {
         connectionFactory = createConnectionFactory(
             createRpcUrlFactory({
-                [EndpointId.SOLANA_V2_MAINNET]: process.env.RPC_URL_SOLANA_MAINNET,
-                [EndpointId.SOLANA_V2_TESTNET]: process.env.RPC_URL_SOLANA_TESTNET,
+                [EndpointId.SOLANA_V2_MAINNET]: process.env.RPC_URL_SOLANA_MAINNET || 'https://rpc.ankr.com/solana',
+                [EndpointId.SOLANA_V2_TESTNET]: process.env.RPC_URL_SOLANA_TESTNET || 'https://api.testnet.solana.com',
             })
         )
     })

--- a/packages/devtools-solana/test/common/accounts.test.ts
+++ b/packages/devtools-solana/test/common/accounts.test.ts
@@ -19,8 +19,8 @@ describe('common/accounts', () => {
     beforeAll(() => {
         connectionFactory = createConnectionFactory(
             createRpcUrlFactory({
-                [EndpointId.SOLANA_V2_MAINNET]: process.env.RPC_URL_SOLANA_MAINNET || 'https://rpc.ankr.com/solana',
-                [EndpointId.SOLANA_V2_TESTNET]: process.env.RPC_URL_SOLANA_TESTNET || 'https://api.testnet.solana.com',
+                [EndpointId.SOLANA_V2_MAINNET]: process.env.RPC_URL_SOLANA_MAINNET,
+                [EndpointId.SOLANA_V2_TESTNET]: process.env.RPC_URL_SOLANA_TESTNET,
             })
         )
     })


### PR DESCRIPTION
### In this PR

- Use default Solana RPC URLs for tests for PRs coming from forks