### PR TITLE
🧹 bump "major" version (really minor) for Solana OFT

### DIFF
--- a/.changeset/curvy-vans-worry.md
+++ b/.changeset/curvy-vans-worry.md
@@ -1,0 +1,5 @@
+---
+"@layerzerolabs/oft-solana-example": patch
+---
+
+Bump for new Solana Implementation Version


### PR DESCRIPTION
Missed in the initial merge.  We don't publish this package anyway, so it shouldn't cause issues.