### PR TITLE
🧹 Docker cache

### DIFF
--- a/.github/workflows/actions/docker-build-image/action.yaml
+++ b/.github/workflows/actions/docker-build-image/action.yaml
@@ -40,7 +40,10 @@ runs:
       shell: bash
       run: |
         platform=${{ inputs.platform }}
+        ref=${{ github.ref_name }}
+
         echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
+        echo "REF_NAME=${ref//[^a-zA-Z0-9_-]/-}" >> $GITHUB_ENV
 
     - name: Log in to the Container registry
       uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d
@@ -72,8 +75,11 @@ runs:
         outputs: type=image,name=${{ inputs.registry }}/${{ inputs.namespace }}/${{ inputs.image }},push-by-digest=true,name-canonical=true,push=true
         labels: ${{ steps.meta.outputs.labels }}
         annotations: ${{ steps.meta.outputs.annotations }}
-        cache-from: type=gha,scope=build-${{ env.PLATFORM_PAIR }}
-        cache-to: type=gha,mode=max,scope=build-${{ env.PLATFORM_PAIR }}
+        cache-from: |
+          type=registry,ref=${{ inputs.registry }}/${{ inputs.namespace }}/${{ inputs.image }}:cache-${{ env.REF_NAME }}-${{ env.PLATFORM_PAIR }}
+          type=registry,ref=${{ inputs.registry }}/${{ inputs.namespace }}/${{ inputs.image }}:cache-main-${{ env.PLATFORM_PAIR }}
+        cache-to: |
+          type=registry,ref=${{ inputs.registry }}/${{ inputs.namespace }}/${{ inputs.image }}:cache-${{ env.REF_NAME }}-${{ env.PLATFORM_PAIR }}
         build-args: |
           CARGO_BUILD_JOBS=4
 


### PR DESCRIPTION
### In this PR

- Create cache artifacts in GHCR instead of the GHA cache. This means that the layers of all, including the intermediate, images will be uploaded to GHCR
- The cache will try to use the layers built for its branch will fallback to the `main` branch cache