### PR TITLE
🪲 Fix an issue with outdated hardhat cache

### DIFF
--- a/.changeset/slimy-adults-bow.md
+++ b/.changeset/slimy-adults-bow.md
@@ -1,0 +1,5 @@
+---
+"@layerzerolabs/devtools-evm-hardhat": patch
+---
+
+Fix an issue with outdated hardhat deploy cache

--- a/packages/devtools-evm-hardhat/test/omnigraph/coordinates.test.ts
+++ b/packages/devtools-evm-hardhat/test/omnigraph/coordinates.test.ts
@@ -10,9 +10,11 @@ import { makeZeroAddress } from '@layerzerolabs/devtools-evm'
 import { createGetHreByEid } from '@/runtime'
 import { Artifact } from 'hardhat/types'
 
-jest.spyOn(DeploymentsManager.prototype, 'getChainId').mockResolvedValue('1')
-
 describe('omnigraph/coordinates', () => {
+    beforeEach(() => {
+        jest.spyOn(DeploymentsManager.prototype, 'getChainId').mockResolvedValue('1')
+    })
+
     afterEach(() => {
         jest.restoreAllMocks()
     })


### PR DESCRIPTION
### In this PR

- Reload the whole hardhat deploy store if we get no deployments back. This fixes an issue currently present in Stargate
- Fixed a small issue with the test - a `spy` was initialized on the top of the test suite but was effectively erased in the `afterEach` hook