### PR TITLE
🧹 Bump timeout on TON node tests

### DIFF
--- a/packages/test-devtools-ton/jest.config.js
+++ b/packages/test-devtools-ton/jest.config.js
@@ -9,4 +9,5 @@ module.exports = {
     transform: {
         '^.+\\.(t|j)sx?$': '@swc/jest',
     },
+    testTimeout: 15_000,
 };


### PR DESCRIPTION
### In this PR

- The TON local node tests depend on the quality of the machine that runs the node so we bump the timeout to remove any flakiness