### PR TITLE
🪲 Test assumptions

### DIFF
--- a/packages/devtools-evm-hardhat/test/cli.test.ts
+++ b/packages/devtools-evm-hardhat/test/cli.test.ts
@@ -54,7 +54,9 @@ describe('cli', () => {
         it('should not parse invalid strings', () => {
             fc.assert(
                 fc.property(fc.string(), (eid) => {
+                    // We filter out the values that by any slim chance could be valid endpoint IDs
                     fc.pre(EndpointId[eid] == null)
+                    fc.pre(EndpointId[parseInt(eid)] == null)
 
                     expect(() => types.eid.parse('eid', eid)).toThrow()
                 })


### PR DESCRIPTION
### In this PR

- There was a failing test in [this CI run](https://github.com/LayerZero-Labs/devtools/actions/runs/11511605645/job/32045294959) that had to do with test preconditions not being strong enough. In this case a string (`"106 "`) that does not represent a valid key on `EndpointId` enum is passed through `parseInt` and becomes `106`, a valid `EndpointId`