### PR TITLE
🪲 Avoid concurrent solana cache access in user tests

### DIFF
--- a/tests-user/tests/create-lz-oapp.bats
+++ b/tests-user/tests/create-lz-oapp.bats
@@ -177,7 +177,16 @@ teardown() {
 
     LZ_ENABLE_EXPERIMENTAL_SOLANA_OFT_EXAMPLE=1 npx --yes create-lz-oapp --ci --example oft-solana --destination $DESTINATION --package-manager pnpm
     cd "$DESTINATION"
-    pnpm compile
+    # 
+    # Solana is not great when it comes to single machine parallelism
+    # and provides no way of overriding the cache directory.
+    # 
+    # See https://github.com/solana-labs/solana/blob/27eff8408b7223bb3c4ab70523f8a8dca3ca6645/sdk/cargo-build-sbf/src/main.rs#L225
+    # 
+    # In order to avoid flaky tests with multiple solana builds running in parallel,
+    # we need to flock the cache for the duration of the build
+    # 
+    flock ~/.cache/solana pnpm compile
     pnpm test
 }
 
@@ -241,7 +250,16 @@ teardown() {
 
     YARN_CACHE_FOLDER="/tmp/.yarn-cache-oft-solana" LZ_ENABLE_EXPERIMENTAL_SOLANA_OFT_EXAMPLE=1 npx --yes create-lz-oapp --ci --example oft-solana --destination $DESTINATION --package-manager yarn
     cd "$DESTINATION"
-    yarn compile
+    # 
+    # Solana is not great when it comes to single machine parallelism
+    # and provides no way of overriding the cache directory.
+    # 
+    # See https://github.com/solana-labs/solana/blob/27eff8408b7223bb3c4ab70523f8a8dca3ca6645/sdk/cargo-build-sbf/src/main.rs#L225
+    # 
+    # In order to avoid flaky tests with multiple solana builds running in parallel,
+    # we need to flock the cache for the duration of the build
+    # 
+    flock ~/.cache/solana yarn compile
     yarn test
 }
 
@@ -305,6 +323,15 @@ teardown() {
 
     LZ_ENABLE_EXPERIMENTAL_SOLANA_OFT_EXAMPLE=1 npx --yes create-lz-oapp --ci --example oft-solana --destination $DESTINATION --package-manager npm
     cd "$DESTINATION"
-    npm run compile
+    # 
+    # Solana is not great when it comes to single machine parallelism
+    # and provides no way of overriding the cache directory.
+    # 
+    # See https://github.com/solana-labs/solana/blob/27eff8408b7223bb3c4ab70523f8a8dca3ca6645/sdk/cargo-build-sbf/src/main.rs#L225
+    # 
+    # In order to avoid flaky tests with multiple solana builds running in parallel,
+    # we need to flock the cache for the duration of the build
+    # 
+    flock ~/.cache/solana npm run compile
     npm run test
 }


### PR DESCRIPTION
### In this PR

- As of lately the concurrent nature of the user tests has been causing flaky user tests runs. This PR wraps the compilation step in an `flock` to avoid concurrent access of Solana's cache
- Another issue had to do with discrepancy between `anchor` versions available in the image and set in the Solana example. @St0rmBr3w is there a reason why I should stick to anchor `0.29.0` in the example? If there is I will downgrade the version we install in our base docker container