### PR TITLE
🧹 Prebuilt devcontainer images

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -1,0 +1,23 @@
+<p align="center">
+  <a href="https://layerzero.network">
+    <img alt="LayerZero" style="width: 50%" src="https://layerzero.network/static/logo.svg"/>
+  </a>
+</p>
+
+<p align="center">
+  <a href="https://layerzero.network" style="color: #a77dff">Homepage</a> | <a href="https://docs.layerzero.network/" style="color: #a77dff">Docs</a> | <a href="https://layerzero.network/developers" style="color: #a77dff">Developers</a>
+</p>
+
+<h1 align="center">Devcontainer setup</h1>
+
+## Usage
+
+### Prebuilt images (default)
+
+By default, the devcontainer will use the prebuilt base images from (https://github.com/LayerZero-Labs/devtools/pkgs/container/devtools-dev-base).
+
+### Local images
+
+If the prebuilt images are not available or not accessible, or if work on the base images needs to be tested in a devcontainer, they can be built locally.
+
+To do this, use the provided `devcontainer.local.json` instead of the `devcontainer.json`

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -14,7 +14,7 @@
 
 ### Prebuilt images (default)
 
-By default, the devcontainer will use the prebuilt base images from (https://github.com/LayerZero-Labs/devtools/pkgs/container/devtools-dev-base).
+By default, the devcontainer will use the prebuilt base images from [GHCR](https://github.com/LayerZero-Labs/devtools/pkgs/container/devtools-dev-base).
 
 ### Local images
 

--- a/.devcontainer/devcontainer.local.json
+++ b/.devcontainer/devcontainer.local.json
@@ -1,6 +1,10 @@
 {
   "name": "LayerZero Devtools",
-  "image": "ghcr.io/layerzero-labs/devtools-dev-base:latest",
+  "build": {
+    "context": "..",
+    "dockerfile": "../Dockerfile",
+    "target": "base"
+  },
   "mounts": ["type=volume,target=${containerWorkspaceFolder}/node_modules"],
   "runArgs": ["--env-file", ".env"],
   "features": {


### PR DESCRIPTION
### In this PR

- Use the prebuilt base images in the devcontainer by default