### PR TITLE
🪲 Fix a typo with CLI option name for export-deployments

### DIFF
--- a/.changeset/modern-melons-ring.md
+++ b/.changeset/modern-melons-ring.md
@@ -1,0 +1,6 @@
+---
+"@layerzerolabs/export-deployments-test": patch
+"@layerzerolabs/export-deployments": patch
+---
+
+Fix a CLI option that has not been typed correctly

--- a/packages/export-deployments/src/cli.ts
+++ b/packages/export-deployments/src/cli.ts
@@ -6,7 +6,7 @@ import {
     logLevelOption,
     networksOption,
     outputPathOption,
-    skipDeploymentFilesOption,
+    excludeDeploymentFilesOption,
 } from '@/cli/options'
 import { COLORS, SUCCESS_SYMBOL } from '@/common/logger'
 import { createIncludeDirent, generateSafe } from '@/index'
@@ -30,13 +30,13 @@ new Command('export-deployments')
     .addOption(logLevelOption)
     .addOption(networksOption)
     .addOption(deploymentFilesOption)
-    .addOption(skipDeploymentFilesOption)
+    .addOption(excludeDeploymentFilesOption)
     .addOption(generatorOption)
     .action(
         async (args: {
             deployments: string
             files?: string[]
-            exclude?: string[]
+            excludeFiles?: string[]
             networks?: string[]
             logLevel: LogLevel
             outDir: string

--- a/packages/export-deployments/src/cli.ts
+++ b/packages/export-deployments/src/cli.ts
@@ -50,7 +50,7 @@ new Command('export-deployments')
                 generateSafe({
                     deploymentsDir: args.deployments,
                     outDir: args.outDir,
-                    includeDeploymentFile: createIncludeDirent(args.files, args.exclude),
+                    includeDeploymentFile: createIncludeDirent(args.files, args.excludeFiles),
                     includeNetworkDir: createIncludeDirent(args.networks),
                     generator: args.generator,
                 }),

--- a/packages/export-deployments/src/cli/options.ts
+++ b/packages/export-deployments/src/cli/options.ts
@@ -26,7 +26,7 @@ export const deploymentFilesOption = new Option(
     'Comma-separated list of case-sensitive deployment file names to include in the export'
 ).argParser((value: string) => value.trim().split(/\s*,\s*/))
 
-export const skipDeploymentFilesOption = new Option(
+export const excludeDeploymentFilesOption = new Option(
     '--exclude-files <deployment file name>',
     'Comma-separated list of case-sensitive deployment file names to exclude from the export'
 ).argParser((value: string) => value.trim().split(/\s*,\s*/))

--- a/tests/export-deployments-test/test/export.test.expectations/export-exclude.exp
+++ b/tests/export-deployments-test/test/export.test.expectations/export-exclude.exp
@@ -35,5 +35,6 @@ expect eof
 
 # And export the deployments, excluding the Test deployment
 spawn npx --yes @layerzerolabs/export-deployments --exclude-files Test
-expect "No files generated, exiting"
+# The CLI now generates an index & contracts file even if there were no contractes passed in
+expect "Generated 2 files:"
 expect eof

--- a/tests/export-deployments-test/test/export.test.ts
+++ b/tests/export-deployments-test/test/export.test.ts
@@ -28,6 +28,12 @@ describe(`export`, () => {
             expect(isDirectory('../generated')).toBeFalse()
         })
 
+        it('should not export excluded contracts', async () => {
+            const result = runExpect('export-exclude')
+
+            expect(result.status).toBe(0)
+        })
+
         it('should export all contracts', async () => {
             const result = runExpect('export-all')
 


### PR DESCRIPTION
### In this PR

- The `--exclude-files` CLI options has not been typed correctly in the CLI action handler and the provided test case has not been plugged into the test runner 🤦🏻