### PR TITLE
🧹 Downgrade anchor in the base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -144,7 +144,7 @@ ENV CARGO_BUILD_JOBS=$CARGO_BUILD_JOBS
 RUN cargo install --git https://github.com/coral-xyz/anchor avm
 
 # Install anchor
-ARG ANCHOR_VERSION=0.30.1
+ARG ANCHOR_VERSION=0.29.0
 RUN avm install ${ANCHOR_VERSION}
 RUN avm use ${ANCHOR_VERSION}
 


### PR DESCRIPTION
### In this PR

- Our Solana stack is using `anchor@0.29.0` so we match that version with the version in the `Dockerfile`