### PR TITLE
🧹 Stay on the safe side and docker ignore all .env & .netrc files

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -11,6 +11,9 @@ docker-*.yaml
 .github
 .husky
 .turbo
+.netrc
+.env
+.env*
 
 # Misc
 *ignore


### PR DESCRIPTION
### In this PR

- Add `.netrc` and `.env*` to `.dockerignore` as a precaution - the images are built on isolated machines without these files but one never knows