### PR TITLE
🪲 Fix issues with type literal size limits when exporting deployments

### DIFF
--- a/.changeset/wise-onions-try.md
+++ b/.changeset/wise-onions-try.md
@@ -1,0 +1,5 @@
+---
+"@layerzerolabs/export-deployments": patch
+---
+
+Work around the compiler type literal limits

--- a/.dockerignore
+++ b/.dockerignore
@@ -11,6 +11,9 @@ docker-*.yaml
 .github
 .husky
 .turbo
+.netrc
+.env
+.env*
 
 # Misc
 *ignore


### PR DESCRIPTION
### In this PR

- This PR fixes an issue with compiler limits for type literals. This is a follow-up for #943 that introduces a fix rather than a workaround

### The problem

The issue comes from the shape of the generated file:

```typescript
const abi0 = [{ /** Contract ABI **/ }] as const;

export const abis = {
  'ethereum-mainnet': abi0,
  'ethereum-testnet': abi0,
  'optimism-mainnet': abi0,
  /** ... ** /
}
```

The exported `abis` constant is not type annotated and is expanded to a type literal whose size grows not only with the size of the ABI, but also with the amount of networks we export.

### The solution

The solution is to create a type alias for the individual `abiN` constants, then create a type for the `abis` constant:

```typescript
const abi0 = [{ /** Contract ABI **/ }] as const;

// The new stuff
type Abi0 = typeof abi0;
type Abis = {
  'ethereum-mainnet':  Abi0,
  'ethereum-testnet': Abi0,
  'optimism-mainnet': Abi0,
  /** ... ** /
}

// And here we use the type
export const abis: Abis = {
  'ethereum-mainnet': abi0,
  'ethereum-testnet': abi0,
  'optimism-mainnet': abi0,
  /** ... ** /
}
```

This way the types of keys of `abis` are not expanded but all reference the `AbiN` types.