### PR TITLE
🪲createOFT should allow mint=0

### DIFF
--- a/.changeset/sharp-knives-jam.md
+++ b/.changeset/sharp-knives-jam.md
@@ -1,0 +1,5 @@
+---
+"@layerzerolabs/oft-solana-example": patch
+---
+
+Fix createOFT should allow 0 amount


### PR DESCRIPTION
metaplex's `mpl-token-metadata` has a very _strange_ implementation which converts `undefined` to `1` for `mintV1` instruction.  This is really non-intuitive.  As such, if you want to mint 0, you need to elide the mintV1 instruction altogether.

See: https://github.com/metaplex-foundation/mpl-token-metadata/blob/main/clients/js/src/generated/instructions/mintV1.ts#L115

This change fixes #926 