### PR TITLE
🪲 Wrong default enabled value for declaration map plugin

### DIFF
--- a/.changeset/clean-stingrays-drop.md
+++ b/.changeset/clean-stingrays-drop.md
@@ -1,0 +1,5 @@
+---
+"@layerzerolabs/build-devtools": patch
+---
+
+Fix the default enabled value for declaration map plugin

--- a/packages/build-devtools/src/tsup/declarations.ts
+++ b/packages/build-devtools/src/tsup/declarations.ts
@@ -31,7 +31,7 @@ type Plugin = Exclude<Options['plugins'], undefined>[number]
 const LOG_LABEL = 'DMAP'
 
 export const createDeclarationBuild = ({
-    enabled = process.env.NODE_ENV === 'production',
+    enabled = process.env.NODE_ENV !== 'production',
     tsc = 'tsc',
     tsConfig = 'tsconfig.build.json',
     outDir: outDirOption,

--- a/packages/build-devtools/test/tsup/declarations.test.ts
+++ b/packages/build-devtools/test/tsup/declarations.test.ts
@@ -34,32 +34,6 @@ describe('tsup/declarations', () => {
         })
     })
 
-    describe('if not enabled in production environment', () => {
-        let NODE_ENV: string | undefined
-
-        beforeAll(() => {
-            NODE_ENV = process.env.NODE_ENV
-        })
-
-        afterAll(() => {
-            process.env.NODE_ENV = NODE_ENV
-        })
-
-        it('should not run tsc', async () => {
-            await fc.assert(
-                fc.asyncProperty(fc.oneof(fc.string(), fc.constantFrom(undefined)), async (env) => {
-                    fc.pre(env !== 'production')
-
-                    const plugin = createDeclarationBuild({ enabled: false })
-
-                    await plugin.buildEnd.call(pluginContext)
-
-                    expect(spawnSyncMock).not.toHaveBeenCalled()
-                })
-            )
-        })
-    })
-
     describe('if enabled explicitly', () => {
         it('should run tsc', async () => {
             const plugin = createDeclarationBuild({ enabled: true })
@@ -72,13 +46,11 @@ describe('tsup/declarations', () => {
         })
     })
 
-    describe('if enabled in production environment', () => {
+    describe('if not in production environment', () => {
         let NODE_ENV: string | undefined
 
         beforeAll(() => {
             NODE_ENV = process.env.NODE_ENV
-
-            process.env.NODE_ENV = 'production'
         })
 
         afterAll(() => {
@@ -105,6 +77,34 @@ describe('tsup/declarations', () => {
             )
 
             expect(spawnSyncMock).toHaveBeenCalledTimes(1)
+        })
+    })
+
+    describe('if in production environment', () => {
+        let NODE_ENV: string | undefined
+
+        beforeAll(() => {
+            NODE_ENV = process.env.NODE_ENV
+
+            process.env.NODE_ENV = 'production'
+        })
+
+        afterAll(() => {
+            process.env.NODE_ENV = NODE_ENV
+        })
+
+        it('should not run tsc', async () => {
+            await fc.assert(
+                fc.asyncProperty(fc.oneof(fc.string(), fc.constantFrom(undefined)), async (env) => {
+                    fc.pre(env !== 'production')
+
+                    const plugin = createDeclarationBuild({ enabled: undefined })
+
+                    await plugin.buildEnd.call(pluginContext)
+
+                    expect(spawnSyncMock).not.toHaveBeenCalled()
+                })
+            )
         })
     })
 })


### PR DESCRIPTION
### In this PR

- The `build-devtools` package's `enabled` option was being defaulted wrongly - it should be disabled in production environment by default