### PR TITLE
🧹 Disable parallel user tests

### DIFF
--- a/docker-compose.registry.yaml
+++ b/docker-compose.registry.yaml
@@ -96,7 +96,7 @@ services:
         echo "create-lz-oapp:repository   ${LAYERZERO_EXAMPLES_REPOSITORY_URL}"
         echo "create-lz-oapp:ref          ${LAYERZERO_EXAMPLES_REPOSITORY_REF}"
 
-        /app/tests-user/lib/bats-core/bin/bats --verbose-run --recursive ./tests-user/tests --jobs 3
+        /app/tests-user/lib/bats-core/bin/bats --verbose-run --recursive ./tests-user/tests
     volumes:
       # If we want to clone from github.com, we'll need its public keys added to our SSH config
       # otherwise git clone would trigger an interactive prompt asking us to add a server fingerprint

--- a/tests-user/tests/build-lz-options.bats
+++ b/tests-user/tests/build-lz-options.bats
@@ -4,9 +4,6 @@ setup() {
     # Load bats-assert and bats-support
     load "../lib/bats-support/load.bash"
     load "../lib/bats-assert/load.bash"
-
-    # Install the binary so that we avoid race conditions
-    flock --verbose bats.lock npm install -g build-lz-options
 }
 
 @test "should output version" {

--- a/tests-user/tests/create-lz-oapp.bats
+++ b/tests-user/tests/create-lz-oapp.bats
@@ -17,9 +17,6 @@ setup() {
 
     # Setup a directory for all the projects created by this test
     PROJECTS_DIRECTORY=$(mktemp -d)
-
-    # Install the binary so that we avoid race conditions
-    flock --verbose bats.lock npm install -g create-lz-oapp
 }
 
 teardown() {

--- a/tests-user/tests/decode-lz-options.bats
+++ b/tests-user/tests/decode-lz-options.bats
@@ -4,9 +4,6 @@ setup() {
     # Load bats-assert and bats-support
     load "../lib/bats-support/load.bash"
     load "../lib/bats-assert/load.bash"
-
-    # Install the binary so that we avoid race conditions
-    flock --verbose bats.lock npm install -g decode-lz-options
 }
 
 @test "should output version" {

--- a/tests-user/tests/devtools-cli.bats
+++ b/tests-user/tests/devtools-cli.bats
@@ -17,9 +17,6 @@ setup() {
 
     # Setup a directory for all the projects created by this test
     PROJECTS_DIRECTORY=$(mktemp -d)
-
-    # Install the binary so that we avoid race conditions
-    flock --verbose bats.lock npm install -g @layerzerolabs/devtools-cli
 }
 
 teardown() {

--- a/tests-user/tests/devtools-evm-hardhat-export-deployments.bats
+++ b/tests-user/tests/devtools-evm-hardhat-export-deployments.bats
@@ -4,9 +4,6 @@ setup() {
     # Load bats-assert and bats-support
     load "../lib/bats-support/load.bash"
     load "../lib/bats-assert/load.bash"
-
-    # Install the binary so that we avoid race conditions
-    flock --verbose bats.lock npm install -g @layerzerolabs/export-deployments
 }
 
 @test "should output version" {

--- a/tests-user/tests/verify-contract.bats
+++ b/tests-user/tests/verify-contract.bats
@@ -4,9 +4,6 @@ setup() {
     # Load bats-assert and bats-support
     load "../lib/bats-support/load.bash"
     load "../lib/bats-assert/load.bash"
-
-    # Install the binary so that we avoid race conditions
-    flock --verbose bats.lock npm install -g @layerzerolabs/verify-contract
 }
 
 @test "should output version" {


### PR DESCRIPTION
### In this PR

- Unfortunately `cargo` and `npx` are not yet ready to be fully parallelized on one machine due to the cache behavior. Even though the user tests parallelization brought down the pipeline runtime for the happy case, the fact that it became flaky makes it actually run longer on average (due to required reruns)