### PR TITLE
🪲 Disable solana tests on the CI

### DIFF
--- a/.github/workflows/reusable-test.yaml
+++ b/.github/workflows/reusable-test.yaml
@@ -87,7 +87,10 @@ jobs:
           # And the prebuilt hardhat EVM node image
           DEVTOOLS_EVM_NODE_IMAGE: ghcr.io/layerzero-labs/devtools-dev-node-evm-hardhat:main
           # Provided we have good quality Solana RPCs, we can enable Solana tests
-          LZ_DEVTOOLS_ENABLE_SOLANA_TESTS: 1
+          #
+          # FIXME The Solana tests need to be ported to either use a stable deployment
+          # or a local node. Until then, we disable the tests
+          # LZ_DEVTOOLS_ENABLE_SOLANA_TESTS: 1
           RPC_URL_SOLANA_MAINNET: ${{ secrets.RPC_URL_SOLANA_MAINNET || 'https://rpc.ankr.com/solana' }}
           RPC_URL_SOLANA_TESTNET: ${{ secrets.RPC_URL_SOLANA_TESTNET || 'https://api.devnet.solana.com' }}
 


### PR DESCRIPTION
### In this PR

- The Solana tests which are running against real deployed programs started misbehaving. We'll disable them on the CI until we spin up a local node and deploy a stable program