### PR TITLE
🗞️ Move sleep() helper to io-devtools

### DIFF
--- a/.changeset/serious-lizards-thank.md
+++ b/.changeset/serious-lizards-thank.md
@@ -1,0 +1,6 @@
+---
+"@layerzerolabs/verify-contract": patch
+"@layerzerolabs/io-devtools": patch
+---
+
+Add sleep helper to io-devtools

--- a/packages/io-devtools/src/async/index.ts
+++ b/packages/io-devtools/src/async/index.ts
@@ -1,0 +1,1 @@
+export * from './time'

--- a/packages/io-devtools/src/async/time.ts
+++ b/packages/io-devtools/src/async/time.ts
@@ -1,0 +1,7 @@
+/**
+ * Returns a promise that resolves after the specified number of milliseconds
+ *
+ * @param {number} timeout Nap time in milliseconds
+ * @returns {Promise<void>}
+ */
+export const sleep = (timeout: number): Promise<void> => new Promise<void>((resolve) => setTimeout(resolve, timeout))

--- a/packages/io-devtools/src/index.ts
+++ b/packages/io-devtools/src/index.ts
@@ -1,3 +1,4 @@
+export * from './async'
 export * from './config'
 export * from './filesystem'
 export * from './language'

--- a/packages/verify-contract/src/common/etherscan.ts
+++ b/packages/verify-contract/src/common/etherscan.ts
@@ -1,7 +1,7 @@
-import { type Logger } from '@layerzerolabs/io-devtools'
+import { type Logger, sleep } from '@layerzerolabs/io-devtools'
 import { LicenseType } from './licenses'
 import { z } from 'zod'
-import { retry, sleep } from './promises'
+import { retry } from './promises'
 import EventEmitter from 'events'
 import got from 'got'
 

--- a/packages/verify-contract/src/common/promises.ts
+++ b/packages/verify-contract/src/common/promises.ts
@@ -1,10 +1,5 @@
 import assert from 'assert'
 
-export const sleep = (timeout: number) =>
-    new Promise((resolve) => {
-        setTimeout(resolve, timeout)
-    })
-
 /**
  * Simple async retry functionality
  *


### PR DESCRIPTION
### In this PR

- Moving the `sleep()` helper to `io-devtools` so we can reuse