### PR TITLE
🧹 Add createDefaultApplicative utility

### DIFF
--- a/.changeset/clean-turtles-hide.md
+++ b/.changeset/clean-turtles-hide.md
@@ -1,0 +1,5 @@
+---
+"@layerzerolabs/devtools": patch
+---
+
+Add createDefaultApplicative utility

--- a/packages/devtools/src/common/promise.ts
+++ b/packages/devtools/src/common/promise.ts
@@ -1,4 +1,5 @@
 import { Factory } from '@/types'
+import { Logger } from '@layerzerolabs/io-devtools'
 import assert from 'assert'
 import { backOff } from 'exponential-backoff'
 
@@ -34,6 +35,22 @@ export const sequence = async <T>(tasks: Task<T>[]): Promise<T[]> => {
  * @returns {Promise<T[]>}
  */
 export const parallel = async <T>(tasks: Task<T>[]): Promise<T[]> => await Promise.all(tasks.map((task) => task()))
+
+/**
+ * Creates a default applicative based on an environment feature flag.
+ *
+ * For now we keep the parallel execution as an opt-in feature flag
+ * before we have a retry logic fully in place for the SDKs
+ *
+ * This is to avoid 429 too many requests errors from the RPCs
+ *
+ * @param logger
+ * @returns
+ */
+export const createDefaultApplicative = (logger?: Logger) =>
+    process.env.LZ_ENABLE_EXPERIMENTAL_PARALLEL_EXECUTION
+        ? (logger?.warn(`You are using experimental parallel configuration`), parallel)
+        : sequence
 
 /**
  * Maps the errors coming from a task. Errors thrown from the `toError`

--- a/packages/devtools/src/omnigraph/config.ts
+++ b/packages/devtools/src/omnigraph/config.ts
@@ -3,7 +3,7 @@ import type { Configurator, IOmniSDK, InferOmniEdge, InferOmniNode, OmniGraph, O
 import type { OmniTransaction } from '@/transactions/types'
 import { flattenTransactions } from '@/transactions/utils'
 import { createModuleLogger } from '@layerzerolabs/io-devtools'
-import { parallel, sequence } from '@/common/promise'
+import { createDefaultApplicative } from '@/common/promise'
 
 export type CreateTransactionsFromOmniNodes<TOmniGraph extends OmniGraph = OmniGraph, TOmniSDK = IOmniSDK> = Factory<
     [InferOmniNode<TOmniGraph>, TOmniSDK, TOmniGraph, OmniSDKFactory<TOmniSDK>],
@@ -119,9 +119,7 @@ export const createConfigureMultiple =
         // before we have a retry logic fully in place for the SDKs
         //
         // This is to avoid 429 too many requests errors from the RPCs
-        const applicative = process.env.LZ_ENABLE_EXPERIMENTAL_PARALLEL_EXECUTION
-            ? (logger.warn(`You are using experimental parallel configuration`), parallel)
-            : sequence
+        const applicative = createDefaultApplicative(logger)
 
         return flattenTransactions(await applicative(tasks))
     }


### PR DESCRIPTION
### In this PR

- The `serial`/`parallel` applicative is chosen based on an feature flag coming from an environment variable. This isolates this small piece of functionality to be reused outside of `createConfigureMultiple`