### PR TITLE
🗞️ Standalone CLI: Moving wiring logic into a flow

### DIFF
--- a/.changeset/brown-kings-grin.md
+++ b/.changeset/brown-kings-grin.md
@@ -1,0 +1,6 @@
+---
+"@layerzerolabs/ua-devtools-evm-hardhat": patch
+"@layerzerolabs/devtools": patch
+---
+
+Move the wiring logic into a flow

--- a/packages/devtools/src/flows/index.ts
+++ b/packages/devtools/src/flows/index.ts
@@ -1,3 +1,4 @@
 export * from './config.execute'
 export * from './config.load'
 export * from './sign.and.send'
+export * from './wire'

--- a/packages/devtools/src/flows/wire.ts
+++ b/packages/devtools/src/flows/wire.ts
@@ -5,7 +5,6 @@ import type { SignAndSendFlow } from './sign.and.send'
 import type { OmniGraph } from '@/omnigraph'
 import { formatOmniTransaction, type OmniTransaction, type SignAndSendResult } from '@/transactions'
 import { printRecords } from '@layerzerolabs/io-devtools/swag'
-import { AssertionError } from 'assert'
 
 export interface CreateWireFlowArgs<TOmniGraph extends OmniGraph> {
     logger?: Logger
@@ -64,12 +63,14 @@ export const createWireFlow =
             // Print the outstanding transactions
             printRecords(transactions.map(formatOmniTransaction))
 
-            // And scream
-            throw new AssertionError({
-                message: `The OApp is not fully wired`,
-                expected: [],
-                actual: transactions,
-            })
+            // Mark the process as failed (if not already marked)
+            //
+            // TODO This is a bit ugly since we might not be running this in a standalone process
+            // so we might want to move the assert functionality outside of this flow
+            process.exitCode = process.exitCode || 1
+
+            // Return the list of pending transactions
+            return [[], [], transactions]
         }
 
         // Tell the user about the transactions

--- a/packages/devtools/src/flows/wire.ts
+++ b/packages/devtools/src/flows/wire.ts
@@ -1,0 +1,90 @@
+import { createLogger, printJson, pluralizeNoun, type Logger } from '@layerzerolabs/io-devtools'
+
+import type { ConfigExecuteFlow } from './config.execute'
+import type { SignAndSendFlow } from './sign.and.send'
+import type { OmniGraph } from '@/omnigraph'
+import { formatOmniTransaction, type OmniTransaction, type SignAndSendResult } from '@/transactions'
+import { printRecords } from '@layerzerolabs/io-devtools/swag'
+import { AssertionError } from 'assert'
+
+export interface CreateWireFlowArgs<TOmniGraph extends OmniGraph> {
+    logger?: Logger
+    executeConfig: ConfigExecuteFlow<TOmniGraph>
+    signAndSend: SignAndSendFlow
+}
+
+export interface WireFlowArgs<TOmniGraph extends OmniGraph> {
+    graph: TOmniGraph
+    assert?: boolean
+    dryRun?: boolean
+}
+
+export const createWireFlow =
+    <TOmniGraph extends OmniGraph>({
+        logger = createLogger(),
+        executeConfig,
+        signAndSend,
+    }: CreateWireFlowArgs<TOmniGraph>) =>
+    async ({ graph, assert = false, dryRun = false }: WireFlowArgs<TOmniGraph>): Promise<SignAndSendResult> => {
+        if (assert) {
+            logger.info(`Running in assertion mode`)
+        } else if (dryRun) {
+            logger.info(`Running in dry run mode`)
+        }
+
+        // At this point we are ready to create the list of transactions
+        logger.verbose(`Creating a list of wiring transactions`)
+
+        // We'll get the list of OmniTransactions using the config execution flow
+        const transactions: OmniTransaction[] = await executeConfig({ graph })
+
+        // Flood users with debug output
+        logger.verbose(`Created a list of wiring transactions`)
+        logger.debug(`Following transactions are necessary:\n\n${printJson(transactions)}`)
+
+        // If there are no transactions that need to be executed, we'll just exit
+        if (transactions.length === 0) {
+            logger.info(`The OApp is wired, no action is necessary`)
+
+            return [[], [], []]
+        }
+
+        // If we are in a dry run mode, we print our the results and exit
+        if (dryRun) {
+            printRecords(transactions.map(formatOmniTransaction))
+
+            return [[], [], transactions]
+        }
+
+        // If we are in an assertion mode, we make sure there are no pending transactions
+        if (assert) {
+            // Let the user know something's about to go down
+            logger.error(`The OApp is not fully wired, following transactions are necessary:`)
+
+            // Print the outstanding transactions
+            printRecords(transactions.map(formatOmniTransaction))
+
+            // And scream
+            throw new AssertionError({
+                message: `The OApp is not fully wired`,
+                expected: [],
+                actual: transactions,
+            })
+        }
+
+        // Tell the user about the transactions
+        logger.info(
+            pluralizeNoun(
+                transactions.length,
+                `There is 1 transaction required to configure the OApp`,
+                `There are ${transactions.length} transactions required to configure the OApp`
+            )
+        )
+
+        // Now sign & send the transactions
+        const signAndSendResult: SignAndSendResult = await signAndSend({
+            transactions,
+        })
+
+        return signAndSendResult
+    }

--- a/packages/ua-devtools-evm-hardhat/src/tasks/oapp/wire/index.ts
+++ b/packages/ua-devtools-evm-hardhat/src/tasks/oapp/wire/index.ts
@@ -94,13 +94,15 @@ const action: ActionType<TaskArgs> = async (
     const wireFlow = createWireFlow({
         logger,
         executeConfig: ({ graph }) => hre.run(configureSubtask, { graph } satisfies SubtaskConfigureTaskArgs),
-        signAndSend: ({ transactions }) =>
+        signAndSend: ({ transactions }) => (
+            console.warn('HERERE', transactions),
             hre.run(signAndSendSubtask, {
                 ci,
                 logger,
                 createSigner,
                 transactions,
-            } satisfies SignAndSendTaskArgs),
+            } satisfies SignAndSendTaskArgs)
+        ),
     })
 
     // And run the wire flow

--- a/packages/ua-devtools-evm-hardhat/src/tasks/oapp/wire/index.ts
+++ b/packages/ua-devtools-evm-hardhat/src/tasks/oapp/wire/index.ts
@@ -91,18 +91,18 @@ const action: ActionType<TaskArgs> = async (
     )
     const createSigner = safe ? createGnosisSignerFactory(signer) : createSignerFactory(signer)
 
+    // Then create the wire flow
     const wireFlow = createWireFlow({
         logger,
+        // We use hardhat subtasks to provide the option to override certain behaviors on a more granular level
         executeConfig: ({ graph }) => hre.run(configureSubtask, { graph } satisfies SubtaskConfigureTaskArgs),
-        signAndSend: ({ transactions }) => (
-            console.warn('HERERE', transactions),
+        signAndSend: ({ transactions }) =>
             hre.run(signAndSendSubtask, {
                 ci,
                 logger,
                 createSigner,
                 transactions,
-            } satisfies SignAndSendTaskArgs)
-        ),
+            } satisfies SignAndSendTaskArgs),
     })
 
     // And run the wire flow

--- a/packages/ua-devtools-evm-hardhat/src/tasks/oapp/wire/index.ts
+++ b/packages/ua-devtools-evm-hardhat/src/tasks/oapp/wire/index.ts
@@ -1,24 +1,25 @@
 import { task } from 'hardhat/config'
 import type { ActionType } from 'hardhat/types'
 import { SUBTASK_LZ_OAPP_CONFIG_LOAD, SUBTASK_LZ_OAPP_WIRE_CONFIGURE, TASK_LZ_OAPP_WIRE } from '@/constants/tasks'
-import { createLogger, setDefaultLogLevel, printJson, pluralizeNoun } from '@layerzerolabs/io-devtools'
+import { createLogger, printJson, setDefaultLogLevel } from '@layerzerolabs/io-devtools'
+import { OAppOmniGraph } from '@layerzerolabs/ua-devtools'
 import {
     types,
     SUBTASK_LZ_SIGN_AND_SEND,
     createGnosisSignerFactory,
     createSignerFactory,
-    formatOmniTransaction,
 } from '@layerzerolabs/devtools-evm-hardhat'
-import { OmniTransaction } from '@layerzerolabs/devtools'
-import { printLogo, printRecords } from '@layerzerolabs/io-devtools/swag'
+import { createWireFlow } from '@layerzerolabs/devtools'
+import { printLogo } from '@layerzerolabs/io-devtools/swag'
 import type { SignAndSendResult } from '@layerzerolabs/devtools'
-import type { SubtaskConfigureTaskArgs } from './types'
+
+import type { SignerDefinition } from '@layerzerolabs/devtools-evm'
 import type { SignAndSendTaskArgs } from '@layerzerolabs/devtools-evm-hardhat/tasks'
 
-import './subtask.configure'
-import { SubtaskLoadConfigTaskArgs } from '@/tasks/oapp/types'
-import type { SignerDefinition } from '@layerzerolabs/devtools-evm'
+import type { SubtaskConfigureTaskArgs, SubtaskLoadConfigTaskArgs } from '@/tasks/oapp/types'
 import { OAppOmniGraphHardhatSchema } from '@/oapp'
+
+import './subtask.configure'
 
 interface TaskArgs {
     oappConfig: string
@@ -73,67 +74,16 @@ const action: ActionType<TaskArgs> = async (
     // And we'll create a logger for ourselves
     const logger = createLogger()
 
-    if (assert) {
-        logger.info(`Running in assertion mode`)
-    } else if (dryRun) {
-        logger.info(`Running in dry run mode`)
-    }
-
     // Now we can load and validate the config
-    const graph = await hre.run(loadConfigSubtask, {
+    //
+    // To maintain compatibility with the legacy hardhat-based CLI,
+    // we use a subtask to do this
+    logger.debug(`Using ${loadConfigSubtask} subtask to load the config`)
+    const graph: OAppOmniGraph = await hre.run(loadConfigSubtask, {
         configPath: oappConfigPath,
         schema: OAppOmniGraphHardhatSchema,
         task: TASK_LZ_OAPP_WIRE,
     } satisfies SubtaskLoadConfigTaskArgs)
-
-    // At this point we are ready to create the list of transactions
-    logger.verbose(`Creating a list of wiring transactions`)
-
-    // We'll get the list of OmniTransactions using a subtask to allow for developers
-    // to use this as a hook and extend the configuration
-    logger.debug(`Using ${configureSubtask} subtask to get the configuration`)
-    const transactions: OmniTransaction[] = await hre.run(configureSubtask, {
-        graph,
-    } satisfies SubtaskConfigureTaskArgs)
-
-    // Flood users with debug output
-    logger.verbose(`Created a list of wiring transactions`)
-    logger.debug(`Following transactions are necessary:\n\n${printJson(transactions)}`)
-
-    // If there are no transactions that need to be executed, we'll just exit
-    if (transactions.length === 0) {
-        logger.info(`The OApp is wired, no action is necessary`)
-
-        return [[], [], []]
-    } else if (assert) {
-        // If we are in assertion mode, we'll print out the transactions and exit with code 1
-        // if there is anything left to configure
-        logger.error(`The OApp is not fully wired, following transactions are necessary:`)
-
-        // Print the outstanding transactions
-        printRecords(transactions.map(formatOmniTransaction))
-
-        // And set the exit code to failure
-        process.exitCode = process.exitCode || 1
-
-        return [[], [], transactions]
-    }
-
-    // If we are in dry run mode, we'll just print the transactions and exit
-    if (dryRun) {
-        printRecords(transactions.map(formatOmniTransaction))
-
-        return [[], [], transactions]
-    }
-
-    // Tell the user about the transactions
-    logger.info(
-        pluralizeNoun(
-            transactions.length,
-            `There is 1 transaction required to configure the OApp`,
-            `There are ${transactions.length} transactions required to configure the OApp`
-        )
-    )
 
     // Now let's create the signer
     logger.debug(
@@ -141,21 +91,24 @@ const action: ActionType<TaskArgs> = async (
     )
     const createSigner = safe ? createGnosisSignerFactory(signer) : createSignerFactory(signer)
 
-    // Now sign & send the transactions
-    logger.debug(`Using ${signAndSendSubtask} subtask to sign & send the transactions`)
-    const signAndSendResult: SignAndSendResult = await hre.run(signAndSendSubtask, {
-        transactions,
-        ci,
-        createSigner,
-    } satisfies SignAndSendTaskArgs)
+    const wireFlow = createWireFlow({
+        logger,
+        executeConfig: ({ graph }) => hre.run(configureSubtask, { graph } satisfies SubtaskConfigureTaskArgs),
+        signAndSend: ({ transactions }) =>
+            hre.run(signAndSendSubtask, {
+                ci,
+                logger,
+                createSigner,
+                transactions,
+            } satisfies SignAndSendTaskArgs),
+    })
 
-    // Mark the process as unsuccessful if there were any errors (only if it has not yet been marked as such)
-    const [, failed] = signAndSendResult
-    if (failed.length !== 0) {
-        process.exitCode = process.exitCode || 1
-    }
-
-    return signAndSendResult
+    // And run the wire flow
+    return wireFlow({
+        graph,
+        assert,
+        dryRun,
+    })
 }
 
 task(TASK_LZ_OAPP_WIRE, 'Wire LayerZero OApp', action)

--- a/tests/ua-devtools-evm-hardhat-test/test/task/oapp/wire.test.ts
+++ b/tests/ua-devtools-evm-hardhat-test/test/task/oapp/wire.test.ts
@@ -42,6 +42,13 @@ describe(`task ${TASK_LZ_OAPP_WIRE}`, () => {
     // Helper matcher object that checks for OmniTransaction objects
     const expectTransaction = { data: expect.any(String), point: expectOmniPoint, description: expect.any(String) }
     const expectTransactionWithReceipt = { receipt: expect.any(Object), transaction: expectTransaction }
+    const expectLogger = expect.objectContaining({
+        info: expect.any(Function),
+        warn: expect.any(Function),
+        error: expect.any(Function),
+        debug: expect.any(Function),
+        verbose: expect.any(Function),
+    })
 
     const CONFIGS_BASE_DIR = relative(cwd(), join(__dirname, '__data__', 'configs'))
     const configPathFixture = (fileName: string): string => {
@@ -283,6 +290,7 @@ describe(`task ${TASK_LZ_OAPP_WIRE}`, () => {
                     transactions: expect.any(Array),
                     ci: false,
                     createSigner,
+                    logger: expectLogger,
                 },
                 {},
                 undefined
@@ -318,6 +326,7 @@ describe(`task ${TASK_LZ_OAPP_WIRE}`, () => {
                     transactions: expect.any(Array),
                     ci: false,
                     createSigner,
+                    expectLogger,
                 },
                 {},
                 undefined
@@ -347,6 +356,7 @@ describe(`task ${TASK_LZ_OAPP_WIRE}`, () => {
                     transactions: expect.any(Array),
                     ci: false,
                     createSigner,
+                    expectLogger,
                 },
                 {},
                 undefined

--- a/tests/ua-devtools-evm-hardhat-test/test/task/oapp/wire.test.ts
+++ b/tests/ua-devtools-evm-hardhat-test/test/task/oapp/wire.test.ts
@@ -319,8 +319,12 @@ describe(`task ${TASK_LZ_OAPP_WIRE}`, () => {
             const createSigner = createGnosisSignerFactoryMock.mock.results[0]?.value
             expect(typeof createSigner).toBe('function')
 
+            console.warn('RESULTSSSSSS')
+            console.warn(createGnosisSignerFactoryMock.mock.results)
+
             // Now we check that the sign and send subtask has been called with the correct signer factory
-            expect(hreRunSpy).toHaveBeenCalledWith(
+            expect(hreRunSpy).toHaveBeenNthCalledWith(
+                4,
                 SUBTASK_LZ_SIGN_AND_SEND,
                 {
                     transactions: expect.any(Array),

--- a/tests/ua-devtools-evm-hardhat-test/test/task/oapp/wire.test.ts
+++ b/tests/ua-devtools-evm-hardhat-test/test/task/oapp/wire.test.ts
@@ -330,7 +330,7 @@ describe(`task ${TASK_LZ_OAPP_WIRE}`, () => {
                     transactions: expect.any(Array),
                     ci: false,
                     createSigner,
-                    expectLogger,
+                    logger: expectLogger,
                 },
                 {},
                 undefined

--- a/tests/ua-devtools-evm-hardhat-test/test/task/oapp/wire.test.ts
+++ b/tests/ua-devtools-evm-hardhat-test/test/task/oapp/wire.test.ts
@@ -319,12 +319,8 @@ describe(`task ${TASK_LZ_OAPP_WIRE}`, () => {
             const createSigner = createGnosisSignerFactoryMock.mock.results[0]?.value
             expect(typeof createSigner).toBe('function')
 
-            console.warn('RESULTSSSSSS')
-            console.warn(createGnosisSignerFactoryMock.mock.results)
-
             // Now we check that the sign and send subtask has been called with the correct signer factory
-            expect(hreRunSpy).toHaveBeenNthCalledWith(
-                4,
+            expect(hreRunSpy).toHaveBeenCalledWith(
                 SUBTASK_LZ_SIGN_AND_SEND,
                 {
                     transactions: expect.any(Array),
@@ -360,7 +356,7 @@ describe(`task ${TASK_LZ_OAPP_WIRE}`, () => {
                     transactions: expect.any(Array),
                     ci: false,
                     createSigner,
-                    expectLogger,
+                    logger: expectLogger,
                 },
                 {},
                 undefined
@@ -391,6 +387,7 @@ describe(`task ${TASK_LZ_OAPP_WIRE}`, () => {
                     transactions: expect.any(Array),
                     ci: false,
                     createSigner,
+                    logger: expectLogger,
                 },
                 {},
                 undefined


### PR DESCRIPTION
### In this PR

- Moving the OApp wiring logic into a platform-agnostic place (i.e. not a hardhat-specific one) to be reused by both the hardhat and the standalone CLIs