### PR TITLE
🗞️ Aptos node image

### DIFF
--- a/.github/workflows/reusable-publish-docker.yaml
+++ b/.github/workflows/reusable-publish-docker.yaml
@@ -51,6 +51,47 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
   #
+  # Build the Aptos node image and push it as digests
+  #
+  # We build the node images after we're done with the base so that we can use the docker layer cache
+  # instead of rebuilding the whole thing from scratch
+  #
+  build-node-aptos:
+    name: Build Aptos node image
+    runs-on: ubuntu-latest-16xlarge
+    needs:
+      - build-base
+
+    permissions:
+      contents: read
+      packages: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - linux/amd64
+          - linux/arm64
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Build image & push the digest
+        uses: ./.github/workflows/actions/docker-build-image
+        with:
+          # The name of the image
+          image: devtools-dev-node-aptos-local-testnet
+          # The target stage of the Dockerfile
+          target: node-aptos-local-testnet
+          # Since the digests will be shared across jobs as artifacts,
+          # we need a unique name (per workflow) for these artifacts
+          digest-name: node-aptos-local-testnet
+          platform: ${{ matrix.platform }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+  #
   # Build the EVM node image and push it as digests
   #
   # We build the node images after we're done with the base so that we can use the docker layer cache
@@ -131,6 +172,7 @@ jobs:
           platform: ${{ matrix.platform }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+
   #
   # Build the TON node image and push it as digests
   #
@@ -195,6 +237,32 @@ jobs:
           #
           # This needs to match the digest name of the build stage
           digest-name: base
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+  #
+  # Collect the Aptos node image digests and push them to GHCR
+  #
+  push-node-aptos:
+    name: Push Aptos node image
+    runs-on: ubuntu-latest-4xlarge
+    needs:
+      - build-node-aptos-local-testnet
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Push image
+        uses: ./.github/workflows/actions/docker-push-image
+        with:
+          # The name of the image
+          image: devtools-dev-node-aptos-local-testnet
+          # Since the digests will be shared across jobs as artifacts,
+          # we need a unique name (per workflow) for these artifacts
+          #
+          # This needs to match the digest name of the build stage
+          digest-name: node-aptos-local-testnet
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/reusable-publish-docker.yaml
+++ b/.github/workflows/reusable-publish-docker.yaml
@@ -247,7 +247,7 @@ jobs:
     name: Push Aptos node image
     runs-on: ubuntu-latest-4xlarge
     needs:
-      - build-node-aptos-local-testnet
+      - build-node-aptos
 
     steps:
       - name: Checkout repository

--- a/Dockerfile
+++ b/Dockerfile
@@ -368,29 +368,12 @@ RUN \
 #   .-.-.   .-.-.   .-.-.   .-.-.   .-.-.   .-.-.   .-.-.   .-.-
 #  / / \ \ / / \ \ / / \ \ / / \ \ / / \ \ / / \ \ / / \ \ / / \
 # `-'   `-`-'   `-`-'   `-`-'   `-`-'   `-`-'   `-`-'   `-`-'
-FROM $BASE_IMAGE AS node-aptos-local-testnet-builder
-
-# This stage only exists so that we can reuse the docker layer cache
-# when providing $BASE_IMAGE
-# 
-# Docker does not allow COPY --from=${ARG} syntax so we create this stage
-# using the $BASE_IMAGE ARG and then copy from it to node-aptos-local-testnet
-
-#   .-.-.   .-.-.   .-.-.   .-.-.   .-.-.   .-.-.   .-.-.   .-.-
-#  / / \ \ / / \ \ / / \ \ / / \ \ / / \ \ / / \ \ / / \ \ / / \
-# `-'   `-`-'   `-`-'   `-`-'   `-`-'   `-`-'   `-`-'   `-`-'
-#
-#              Image that builds an Aptos node
-#
-#   .-.-.   .-.-.   .-.-.   .-.-.   .-.-.   .-.-.   .-.-.   .-.-
-#  / / \ \ / / \ \ / / \ \ / / \ \ / / \ \ / / \ \ / / \ \ / / \
-# `-'   `-`-'   `-`-'   `-`-'   `-`-'   `-`-'   `-`-'   `-`-'
 FROM machine AS node-aptos-local-testnet
 
 ENV PATH="/root/.aptos/bin:$PATH"
 
 # Get aptos CLI
-COPY --from=node-aptos-local-testnet-builder /root/.aptos/bin /root/.aptos/bin
+COPY --from=aptos /root/.aptos/bin /root/.aptos/bin
 
 # We'll provide a default healthcheck by asking for the chain information
 HEALTHCHECK --interval=2s --retries=20 CMD curl -f http://0.0.0.0:8080/v1 || exit 1

--- a/docker-compose.local.yaml
+++ b/docker-compose.local.yaml
@@ -14,6 +14,13 @@ services:
   #                Expose nodes on host ports
   #
   # .oOo.oOo.oOo.oOo.oOo.oOo.oOo.oOo.oOo.oOo.oOo.oOo.oOo.oOo.oOo.
+  network-aptos:
+    ports:
+      # The Node API
+      - "10004:8080"
+      # The faucet API
+      - "10005:8081"
+
   network-vengaboys:
     ports:
       - "10001:8545"

--- a/docker-compose.templates.yaml
+++ b/docker-compose.templates.yaml
@@ -33,6 +33,20 @@ services:
         max-size: "5m"
         compress: "false"
 
+  # Aptos node for testing purposes
+  aptos-node:
+    build:
+      dockerfile: Dockerfile
+      target: node-aptos
+      args:
+        APTOS_NODE_IMAGE: ${DEVTOOLS_APTOS_NODE_IMAGE:-node-aptos-local-testnet}
+
+    logging:
+      driver: local
+      options:
+        max-size: "5m"
+        compress: "false"
+
   # EVM node for testing purposes
   evm-node:
     extends:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -11,6 +11,18 @@
 services:
   # ~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~
   #
+  #                       The Aptos local node
+  #
+  # .oOo.oOo.oOo.oOo.oOo.oOo.oOo.oOo.oOo.oOo.oOo.oOo.oOo.oOo.oOo.
+  # TODO This node is not yet made a dependency of the tests container
+  # since we don't have any tests running against Aptos
+  network-aptos:
+    extends:
+      file: docker-compose.templates.yaml
+      service: aptos-node
+
+  # ~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~
+  #
   #       EVM Network nodes, one for every hardhat network
   #
   # .oOo.oOo.oOo.oOo.oOo.oOo.oOo.oOo.oOo.oOo.oOo.oOo.oOo.oOo.oOo.


### PR DESCRIPTION
### In this PR

- Add a `Dockerfile` target for Aptos local node image
- Add a build step to the docker publishing workflow
- Add templates to the compose setup - for now we won't make the `network-aptos` a dependency of `tests` since we don't have any tests yet

The action run for this change is [here](https://github.com/LayerZero-Labs/devtools/actions/runs/11806130469)