### PR TITLE
Added `oapp-evm` testing

### DIFF
--- a/.changeset/real-buttons-deny.md
+++ b/.changeset/real-buttons-deny.md
@@ -1,0 +1,5 @@
+---
+"@layerzerolabs/oapp-evm": minor
+---
+
+OApp-evm testing + ERC20Mock

--- a/packages/oapp-evm/test/OApp.t.sol
+++ b/packages/oapp-evm/test/OApp.t.sol
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: UNLICENSED
+
+pragma solidity ^0.8.0;
+
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
+import { ERC20Mock } from "./mocks/ERC20Mock.sol";
+import { OAppMock } from "./mocks/OAppMock.sol";
+import { TestHelperOz5 } from "@layerzerolabs/test-devtools-evm-foundry/contracts/TestHelperOz5.sol";
+import { MessagingParams, MessagingReceipt } from "@layerzerolabs/lz-evm-protocol-v2/contracts/interfaces/ILayerZeroEndpointV2.sol";
+import { OptionsBuilder } from "../contracts/oapp/libs/OptionsBuilder.sol";
+import { console } from "forge-std/console.sol";
+
+contract OAppTest is TestHelperOz5 {
+    using OptionsBuilder for bytes;
+
+    uint32 private aEid = 1;
+    ERC20Mock nativeTokenMock_A = new ERC20Mock("NativeTokens_A", "NAT_A");
+
+    uint32 private bEid = 2;
+    ERC20Mock nativeTokenMock_B = new ERC20Mock("NativeTokens_B", "NAT_B");
+
+    OAppMock private aOApp;
+    OAppMock private bOApp;
+
+    address private userA = address(0x1);
+    address private userB = address(0x2);
+    address private refundAddress = address(0x3);
+    
+    uint256 private initialBalance = 100 ether;
+
+    bytes32 receiverB32 = bytes32(uint256(uint160(address(bOApp))));
+    string message = "Hello world";
+
+    address endpoint;
+
+    bytes options;
+
+    function setUp() public override {
+        vm.deal(userA, 1000 ether);
+        vm.deal(userB, 1000 ether);
+
+        super.setUp();
+        setUpEndpoints(2, LibraryType.UltraLightNode);
+
+        aOApp = OAppMock(
+            _deployOApp(type(OAppMock).creationCode, abi.encode(address(endpoints[aEid]), address(this)))
+        );
+
+        bOApp = OAppMock(
+            _deployOApp(type(OAppMock).creationCode, abi.encode(address(endpoints[bEid]), address(this)))
+        );
+
+        address[] memory oapps = new address[](2);
+        oapps[0] = address(aOApp);
+        oapps[1] = address(bOApp);
+        this.wireOApps(oapps);
+
+        endpoint = address(aOApp.endpoint());
+        options = OptionsBuilder.newOptions().addExecutorLzReceiveOption(200000, 0);
+    }
+
+    function test_constructor() public {
+        assertEq(aOApp.owner(), address(this));
+        assertEq(bOApp.owner(), address(this));
+
+        assertEq(address(aOApp.endpoint()), address(endpoints[aEid]));
+        assertEq(address(bOApp.endpoint()), address(endpoints[bEid]));
+    }
+    function test_Send() public {
+        vm.startPrank(userA);
+
+        MessagingParams memory msgParams = MessagingParams(bEid, receiverB32, abi.encode(message), options, false);
+
+        uint256 quoteFee = aOApp.endpoint().quote(msgParams, address(this)).nativeFee;
+        uint256 twiceQuoteFee = quoteFee * 2;
+
+        MessagingReceipt memory receipt = aOApp.endpoint().send{value: twiceQuoteFee}(msgParams, refundAddress);
+
+        assertEq(receipt.fee.nativeFee, quoteFee);
+        assertEq(receipt.fee.lzTokenFee, 0);
+
+        assertEq(address(endpoint).balance, 0);
+        assertEq(refundAddress.balance, quoteFee);
+        assertEq((endpointSetup.sendLibs[0]).balance, quoteFee);
+    }
+
+    function test_OAppSend() public {
+        vm.startPrank(userA);
+
+        uint256 quoteFee = aOApp.quote(bEid, message, options, false).nativeFee;
+        uint256 twiceQuoteFee = quoteFee * 2;
+
+        MessagingReceipt memory receipt = aOApp.send{value: twiceQuoteFee}(bEid, message, options, twiceQuoteFee);
+        verifyPackets(bEid, addressToBytes32(address(bOApp)));
+
+        assertEq(receipt.fee.nativeFee, quoteFee);
+        assertEq(receipt.fee.lzTokenFee, 0);
+
+        assertEq(address(endpoint).balance, 0);
+        assertEq((endpointSetup.sendLibs[0]).balance, quoteFee);
+    }
+}

--- a/packages/oapp-evm/test/mocks/ERC20Mock.sol
+++ b/packages/oapp-evm/test/mocks/ERC20Mock.sol
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.20;
+
+import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+
+contract ERC20Mock is ERC20 {
+    constructor(string memory _name, string memory _symbol) ERC20(_name, _symbol) {}
+
+    function mint(address _to, uint256 _amount) public {
+        _mint(_to, _amount);
+    }
+}

--- a/packages/oapp-evm/test/mocks/OAppMock.sol
+++ b/packages/oapp-evm/test/mocks/OAppMock.sol
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.22;
+
+import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";
+import { OApp, MessagingFee, Origin } from "../../contracts/oapp/OApp.sol";
+import { MessagingReceipt } from "@layerzerolabs/lz-evm-protocol-v2/contracts/interfaces/ILayerZeroEndpointV2.sol";
+
+contract OAppMock is OApp {
+    constructor(address _endpoint, address _delegate) OApp(_endpoint, _delegate) Ownable(_delegate) {}
+
+    string public data = "Nothing received yet.";
+
+    /**
+     * @notice Sends a message from the source chain to a destination chain.
+     * @param _dstEid The endpoint ID of the destination chain.
+     * @param _message The message string to be sent.
+     * @param _options Additional options for message execution.
+     * @dev Encodes the message as bytes and sends it using the `_lzSend` internal function.
+     * @return receipt A `MessagingReceipt` struct containing details of the message sent.
+     */
+    function send(
+        uint32 _dstEid,
+        string memory _message,
+        bytes calldata _options,
+        uint256 _nativeFee
+    ) external payable returns (MessagingReceipt memory receipt) {
+        bytes memory _payload = abi.encode(_message);
+        receipt = _lzSend(_dstEid, _payload, _options, MessagingFee(_nativeFee, 0), payable(msg.sender));
+    }
+
+    /**
+     * @notice Quotes the gas needed to pay for the full omnichain transaction in native gas or ZRO token.
+     * @param _dstEid Destination chain's endpoint ID.
+     * @param _message The message.
+     * @param _options Message execution options (e.g., for sending gas to destination).
+     * @param _payInLzToken Whether to return fee in ZRO token.
+     * @return fee A `MessagingFee` struct containing the calculated gas fee in either the native token or ZRO token.
+     */
+    function quote(
+        uint32 _dstEid,
+        string memory _message,
+        bytes memory _options,
+        bool _payInLzToken
+    ) public view returns (MessagingFee memory fee) {
+        bytes memory payload = abi.encode(_message);
+        fee = _quote(_dstEid, payload, _options, _payInLzToken);
+    }
+
+    /**
+     * @dev Internal function override to handle incoming messages from another chain.
+     * @dev _origin A struct containing information about the message sender.
+     * @dev _guid A unique global packet identifier for the message.
+     * @param payload The encoded message payload being received.
+     *
+     * @dev The following params are unused in the current implementation of the OApp.
+     * @dev _executor The address of the Executor responsible for processing the message.
+     * @dev _extraData Arbitrary data appended by the Executor to the message.
+     *
+     * Decodes the received payload and processes it as per the business logic defined in the function.
+     */
+    function _lzReceive(
+        Origin calldata /*_origin*/,
+        bytes32 /*_guid*/,
+        bytes calldata payload,
+        address /*_executor*/,
+        bytes calldata /*_extraData*/
+    ) internal override {
+        data = abi.decode(payload, (string));
+    }
+}


### PR DESCRIPTION
Added `ERC20Mock` and `OAppMock` to `test/mocks` for `OApp.t.sol`

Tested `OApp` across `OApp.endpoint().send()` and `OApp.send()`