### PR TITLE
🧹 $npm_execpath forge -> forge in package.json

### DIFF
--- a/packages/oapp-evm-upgradeable/package.json
+++ b/packages/oapp-evm-upgradeable/package.json
@@ -30,8 +30,8 @@
   ],
   "scripts": {
     "clean": "rm -rf .turbo cache artifacts",
-    "compile": "$npm_execpath forge build",
-    "test": "$npm_execpath forge test"
+    "compile": "forge build",
+    "test": "forge test"
   },
   "dependencies": {
     "ethers": "^5.7.2"

--- a/packages/oapp-evm/package.json
+++ b/packages/oapp-evm/package.json
@@ -29,8 +29,8 @@
   ],
   "scripts": {
     "clean": "rm -rf .turbo cache artifacts",
-    "compile": "$npm_execpath forge build",
-    "test": "$npm_execpath forge test"
+    "compile": "forge build",
+    "test": "forge test"
   },
   "dependencies": {
     "ethers": "^5.7.2"

--- a/packages/oft-evm-upgradeable/package.json
+++ b/packages/oft-evm-upgradeable/package.json
@@ -39,9 +39,9 @@
   "scripts": {
     "clean": "rimraf .turbo cache out artifacts",
     "compile": "$npm_execpath compile:forge",
-    "compile:forge": "$npm_execpath forge build",
+    "compile:forge": "forge build",
     "test": "$npm_execpath test:forge",
-    "test:forge": "$npm_execpath forge test"
+    "test:forge": "forge test"
   },
   "devDependencies": {
     "@layerzerolabs/lz-evm-messagelib-v2": "^3.0.12",

--- a/packages/oft-evm/package.json
+++ b/packages/oft-evm/package.json
@@ -39,9 +39,9 @@
   "scripts": {
     "clean": "rimraf .turbo cache out artifacts",
     "compile": "$npm_execpath compile:forge",
-    "compile:forge": "$npm_execpath forge build",
+    "compile:forge": "forge build",
     "test": "$npm_execpath test:forge",
-    "test:forge": "$npm_execpath forge test"
+    "test:forge": "forge test"
   },
   "devDependencies": {
     "@layerzerolabs/lz-evm-messagelib-v2": "^3.0.12",


### PR DESCRIPTION
"compile": "$npm_execpath forge build" is now     "compile": "forge build",

 Reason: `forge` is not a yarn command