### PR TITLE
🧹 Use concurrently for parallel compilation

### DIFF
--- a/.changeset/shy-beds-call.md
+++ b/.changeset/shy-beds-call.md
@@ -1,0 +1,13 @@
+---
+"@layerzerolabs/native-oft-adapter-example": patch
+"@layerzerolabs/oft-upgradeable-example": patch
+"@layerzerolabs/uniswap-read-example": patch
+"@layerzerolabs/oft-adapter-example": patch
+"@layerzerolabs/oft-solana-example": patch
+"@layerzerolabs/oapp-read-example": patch
+"@layerzerolabs/onft721-example": patch
+"@layerzerolabs/oapp-example": patch
+"@layerzerolabs/oft-example": patch
+---
+
+Use concurrently for parallel compilation task

--- a/examples/oapp/package.json
+++ b/examples/oapp/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "scripts": {
     "clean": "rm -rf artifacts cache out",
-    "compile": "$npm_execpath run compile:forge && $npm_execpath run compile:hardhat",
+    "compile": "concurrently -c auto --names forge,hardhat '$npm_execpath run compile:forge' '$npm_execpath run compile:hardhat'",
     "compile:forge": "forge build",
     "compile:hardhat": "hardhat compile",
     "lint": "$npm_execpath run lint:js && $npm_execpath run lint:sol",


### PR DESCRIPTION
### In this PR

- Use `concurrently` to parallelize the `compile` scripts in examples
- The shortcut `pnpm:compile:*` version of concurrently command cannot be used since examples might use different package managers