### PR TITLE
🪲 Prevent infinite growth of turbo cache

### DIFF
--- a/.github/workflows/actions/setup-build-cache/action.yaml
+++ b/.github/workflows/actions/setup-build-cache/action.yaml
@@ -8,21 +8,7 @@ runs:
     # This step will speed up workflow runs that don't touch the whole codebase
     # (or the ones that don't touch the codebase at all)
     - name: Cache turbo build setup
-      uses: actions/cache@v4
-      with:
-        path: node_modules/.cache/turbo
-        key: ${{ runner.os }}-turbo-${{ github.ref_name }}-${{ github.sha }}
-        # The hierarchy of restoring the cache goes as follows:
-        #
-        # - First we try to match an existing cache from the same branch
-        # - Then we try to match a cache from the target branch of this PR (if this is not a PR, this cache will never exist)
-        # - Then we try to match a cache from the default branch
-        # - Then we try to match any cache
-        restore-keys: |
-          ${{ runner.os }}-turbo-${{ github.ref_name }}-
-          ${{ runner.os }}-turbo-${{ github.base_ref }}-
-          ${{ runner.os }}-turbo-${{ github.event.repository.default_branch }}-
-          ${{ runner.os }}-turbo-
+      uses: rharkor/caching-for-turbo@439abec0d28d21b192fa8817b744ffdf1ee5ac0d
 
     # Cache hardhat compilers
     #

--- a/.github/workflows/reusable-test.yaml
+++ b/.github/workflows/reusable-test.yaml
@@ -127,6 +127,9 @@ jobs:
       - name: Setup environment
         uses: ./.github/workflows/actions/setup-environment
 
+      - name: Setup build cache
+        uses: ./.github/workflows/actions/setup-build-cache
+
       # There is a small bug in docker compose that will cause 401 if we don't pull the base image manually
       #
       # See more here https://github.com/docker/compose-cli/issues/1545

--- a/docker-compose.registry.yaml
+++ b/docker-compose.registry.yaml
@@ -84,6 +84,8 @@ services:
         pnpm release:version
         pnpm release:publish
     volumes:
+      # Build cache
+      - ./node_modules/.cache/turbo:/app/node_modules/.cache/turbo
       # We'll need to provide the changeset files for this step
       - ./.changeset:/app/.changeset
 


### PR DESCRIPTION
### In this PR

- The turbo cache on the CI has a storage leak - it grows indefinitely as new entries are being added but never removed. Our current cache is 6GB large and keeps growing. The issue on turborepo's github is [still open](https://github.com/vercel/turborepo/issues/863) so an alternative action is used that leverages github actions' cache layer