### PR TITLE
🧹 ESLint update journey: fixing small warnings [1/N]

### DIFF
--- a/examples/native-oft-adapter/test/hardhat/MyNativeOFTAdapter.test.ts
+++ b/examples/native-oft-adapter/test/hardhat/MyNativeOFTAdapter.test.ts
@@ -33,9 +33,7 @@ describe('MyNativeOFTAdapter Test', function () {
         // Fetching the first three signers (accounts) from Hardhat's local Ethereum network
         const signers = await ethers.getSigners()
 
-        ownerA = signers.at(0)!
-        ownerB = signers.at(1)!
-        endpointOwner = signers.at(2)!
+        ;[ownerA, ownerB, endpointOwner] = signers
 
         // The EndpointV2Mock contract comes from @layerzerolabs/test-devtools-evm-hardhat package
         // and its artifacts are connected as external artifacts to this project

--- a/examples/native-oft-adapter/test/hardhat/MyOFT.test.ts
+++ b/examples/native-oft-adapter/test/hardhat/MyOFT.test.ts
@@ -30,9 +30,7 @@ describe('MyOFT Test', function () {
         // Fetching the first three signers (accounts) from Hardhat's local Ethereum network
         const signers = await ethers.getSigners()
 
-        ownerA = signers.at(0)!
-        ownerB = signers.at(1)!
-        endpointOwner = signers.at(2)!
+        ;[ownerA, ownerB, endpointOwner] = signers
 
         // The EndpointV2Mock contract comes from @layerzerolabs/test-devtools-evm-hardhat package
         // and its artifacts are connected as external artifacts to this project

--- a/examples/oapp-read/test/hardhat/MyOAppRead.test.ts
+++ b/examples/oapp-read/test/hardhat/MyOAppRead.test.ts
@@ -30,9 +30,7 @@ describe('MyOApp Test', function () {
         // Fetching the first three signers (accounts) from Hardhat's local Ethereum network
         const signers = await ethers.getSigners()
 
-        ownerA = signers.at(0)!
-        ownerB = signers.at(1)!
-        endpointOwner = signers.at(2)!
+        ;[ownerA, ownerB, endpointOwner] = signers
 
         // The EndpointV2Mock contract comes from @layerzerolabs/test-devtools-evm-hardhat package
         // and its artifacts are connected as external artifacts to this project

--- a/examples/oapp/test/hardhat/MyOApp.test.ts
+++ b/examples/oapp/test/hardhat/MyOApp.test.ts
@@ -28,9 +28,7 @@ describe('MyOApp Test', function () {
         // Fetching the first three signers (accounts) from Hardhat's local Ethereum network
         const signers = await ethers.getSigners()
 
-        ownerA = signers.at(0)!
-        ownerB = signers.at(1)!
-        endpointOwner = signers.at(2)!
+        ;[ownerA, ownerB, endpointOwner] = signers
 
         // The EndpointV2Mock contract comes from @layerzerolabs/test-devtools-evm-hardhat package
         // and its artifacts are connected as external artifacts to this project

--- a/examples/oft-adapter/test/hardhat/MyOFTAdapter.test.ts
+++ b/examples/oft-adapter/test/hardhat/MyOFTAdapter.test.ts
@@ -37,9 +37,7 @@ describe('MyOFTAdapter Test', function () {
         // Fetching the first three signers (accounts) from Hardhat's local Ethereum network
         const signers = await ethers.getSigners()
 
-        ownerA = signers.at(0)!
-        ownerB = signers.at(1)!
-        endpointOwner = signers.at(2)!
+        ;[ownerA, ownerB, endpointOwner] = signers
 
         // The EndpointV2Mock contract comes from @layerzerolabs/test-devtools-evm-hardhat package
         // and its artifacts are connected as external artifacts to this project

--- a/examples/oft-solana/test/hardhat/MyOFT.test.ts
+++ b/examples/oft-solana/test/hardhat/MyOFT.test.ts
@@ -30,9 +30,7 @@ describe('MyOFT Test', function () {
         // Fetching the first three signers (accounts) from Hardhat's local Ethereum network
         const signers = await ethers.getSigners()
 
-        ownerA = signers.at(0)!
-        ownerB = signers.at(1)!
-        endpointOwner = signers.at(2)!
+        ;[ownerA, ownerB, endpointOwner] = signers
 
         // The EndpointV2Mock contract comes from @layerzerolabs/test-devtools-evm-hardhat package
         // and its artifacts are connected as external artifacts to this project

--- a/examples/oft-upgradeable/test/hardhat/MyOFTUpgradeable.test.ts
+++ b/examples/oft-upgradeable/test/hardhat/MyOFTUpgradeable.test.ts
@@ -24,9 +24,7 @@ describe('MyOFTUpgradeable Test', () => {
         // Fetching the first three signers (accounts) from Hardhat's local Ethereum network
         const signers = await ethers.getSigners()
 
-        ownerA = signers.at(0)!
-        ownerB = signers.at(1)!
-        endpointOwner = signers.at(2)!
+        ;[ownerA, ownerB, endpointOwner] = signers
 
         // The EndpointV2Mock contract comes from @layerzerolabs/test-devtools-evm-hardhat package
         // and its artifacts are connected as external artifacts to this project

--- a/examples/oft/test/hardhat/MyOFT.test.ts
+++ b/examples/oft/test/hardhat/MyOFT.test.ts
@@ -30,9 +30,7 @@ describe('MyOFT Test', function () {
         // Fetching the first three signers (accounts) from Hardhat's local Ethereum network
         const signers = await ethers.getSigners()
 
-        ownerA = signers.at(0)!
-        ownerB = signers.at(1)!
-        endpointOwner = signers.at(2)!
+        ;[ownerA, ownerB, endpointOwner] = signers
 
         // The EndpointV2Mock contract comes from @layerzerolabs/test-devtools-evm-hardhat package
         // and its artifacts are connected as external artifacts to this project

--- a/examples/onft721/test/hardhat/MyONFT721.test.ts
+++ b/examples/onft721/test/hardhat/MyONFT721.test.ts
@@ -30,9 +30,7 @@ describe('MyONFT721 Test', function () {
         // Fetching the first three signers (accounts) from Hardhat's local Ethereum network
         const signers = await ethers.getSigners()
 
-        ownerA = signers.at(0)!
-        ownerB = signers.at(1)!
-        endpointOwner = signers.at(2)!
+        ;[ownerA, ownerB, endpointOwner] = signers
 
         // The EndpointV2Mock contract comes from @layerzerolabs/test-devtools-evm-hardhat package
         // and its artifacts are connected as external artifacts to this project

--- a/examples/uniswap-read/test/hardhat/UniswapV3QuoteDemo.test.ts
+++ b/examples/uniswap-read/test/hardhat/UniswapV3QuoteDemo.test.ts
@@ -24,8 +24,7 @@ describe('UniswapV3QuoteDemo Test', function () {
         // Fetching the first three signers (accounts) from Hardhat's local Ethereum network
         const signers = await ethers.getSigners()
 
-        ownerA = signers.at(0)!
-        endpointOwner = signers.at(1)!
+        ;[ownerA, endpointOwner] = signers
 
         // The EndpointV2Mock contract comes from @layerzerolabs/test-devtools-evm-hardhat package
         // and its artifacts are connected as external artifacts to this project


### PR DESCRIPTION
### In this PR

- This is the first PR in a series aimed at synchronizing the linting rules with `@layerzerolabs/eslint-config-next` (so that we can update the packages that are now stuck on version `2.3.39`), with smaller ESLint warnings addressed