### PR TITLE
🪲 remove duplicate pnpm install script in README

### DIFF
--- a/packages/build-devtools/README.md
+++ b/packages/build-devtools/README.md
@@ -23,7 +23,7 @@ pnpm install @layerzerolabs/build-devtools
 ```
 
 ```bash
-pnpm install @layerzerolabs/build-devtools
+yarn install @layerzerolabs/build-devtools
 ```
 
 ```bash

--- a/packages/io-devtools/README.md
+++ b/packages/io-devtools/README.md
@@ -23,7 +23,7 @@ pnpm install @layerzerolabs/io-devtools
 ```
 
 ```bash
-pnpm install @layerzerolabs/io-devtools
+yarn install @layerzerolabs/io-devtools
 ```
 
 ```bash

--- a/packages/oapp-evm-upgradeable/README.md
+++ b/packages/oapp-evm-upgradeable/README.md
@@ -23,7 +23,7 @@ pnpm install @layerzerolabs/oapp-evm-upgradeable
 ```
 
 ```bash
-pnpm install @layerzerolabs/oapp-evm-upgradeable
+yarn install @layerzerolabs/oapp-evm-upgradeable
 ```
 
 ```bash

--- a/packages/oapp-evm/README.md
+++ b/packages/oapp-evm/README.md
@@ -23,7 +23,7 @@ pnpm install @layerzerolabs/oapp-evm
 ```
 
 ```bash
-pnpm install @layerzerolabs/oapp-evm
+yarn install @layerzerolabs/oapp-evm
 ```
 
 ```bash

--- a/packages/oft-evm-upgradeable/README.md
+++ b/packages/oft-evm-upgradeable/README.md
@@ -23,7 +23,7 @@ pnpm install @layerzerolabs/oft-evm-upgradeable
 ```
 
 ```bash
-pnpm install @layerzerolabs/oft-evm-upgradeable
+yarn install @layerzerolabs/oft-evm-upgradeable
 ```
 
 ```bash

--- a/packages/oft-evm/README.md
+++ b/packages/oft-evm/README.md
@@ -23,7 +23,7 @@ pnpm install @layerzerolabs/oft-evm
 ```
 
 ```bash
-pnpm install @layerzerolabs/oft-evm
+yarn install @layerzerolabs/oft-evm
 ```
 
 ```bash

--- a/packages/protocol-devtools-evm/README.md
+++ b/packages/protocol-devtools-evm/README.md
@@ -21,13 +21,13 @@ Utilities for LayerZero EVM protocol contracts.
 ## Installation
 
 ```bash
-npm install --save @layerzerolabs/protocol-devtools-evm
+pnpm install --save @layerzerolabs/protocol-devtools-evm
 ```
 
 ```bash
-pnpm install @layerzerolabs/protocol-devtools-evm
+yarn install @layerzerolabs/protocol-devtools-evm
 ```
 
 ```bash
-pnpm install @layerzerolabs/protocol-devtools-evm
+npm install @layerzerolabs/protocol-devtools-evm
 ```

--- a/packages/protocol-devtools/README.md
+++ b/packages/protocol-devtools/README.md
@@ -19,13 +19,13 @@
 ## Installation
 
 ```bash
-npm install --save @layerzerolabs/protocol-devtools
+pnpm install --save @layerzerolabs/protocol-devtools
 ```
 
 ```bash
-pnpm install @layerzerolabs/protocol-devtools
+yarn install @layerzerolabs/protocol-devtools
 ```
 
 ```bash
-pnpm install @layerzerolabs/protocol-devtools
+npm install @layerzerolabs/protocol-devtools
 ```


### PR DESCRIPTION
README.md used to contains 2x `pnpm install @layerzerolabs/...` scripts and a `npm install @layerzerolabs/...` script. 

Changed it to be pnpm, yarn, and npm