### PR TITLE
[bug fix] AccountNotInitialized when InitOft in createOFT task

### DIFF
--- a/examples/oft-solana/tasks/solana/createOFT.ts
+++ b/examples/oft-solana/tasks/solana/createOFT.ts
@@ -203,6 +203,7 @@ task('lz:oft:solana:create', 'Mints new SPL Token and creates new OFT Store acco
                 }
                 const createTokenTx = await txBuilder.sendAndConfirm(umi)
                 console.log(`createTokenTx: ${getExplorerTxLink(bs58.encode(createTokenTx.signature), isTestnet)}`)
+                await new Promise((resolve) => setTimeout(resolve, 30000)) // Wait for 30s (30000 ms)
             }
 
             const lockboxSigner = createSignerFromKeypair({ eddsa: eddsa }, lockBox)


### PR DESCRIPTION
- when trying to create Solana OFT using `pnpm hardhat lz:oft:solana:create`, it always report
```
(base)  zhangchi@C4WQ36D2W1---Chi's-MacBook-Pro  ~/code/oft-solana  pnpm hardhat lz:oft:solana:create --eid 40168 --program-id HVyr1MU52zXpf4LDf9Uvd2nfzdSL5nQgqv2uTvULjwSe --only-oft-store true
bigint: Failed to load bindings, pure JS will be used (try npm run rebuild?)
storePda:  DKy8dpZ5p4fwtaibGWWgn2nLRZvtuHLX238gCZs7LJ27
No additional minters specified.  This will result in only the OFTStore being able to mint new tokens.
created SPL multisig @ GTEKmMS9651kv2Go8srie7MJTewJJuT365k6Qu8riaRa
createTokenTx: https://explorer.solana.com/tx/2dz1DE3RBZywyLHNzESn5WAn7ihbetG3tLj7JytPbp46t64VXpD6dGfvnnLayEgf8NWAWLeUfQngoyJ6oCZwRQNm?cluster=devnet
An unexpected error occurred:

SendTransactionError: Simulation failed. 
Message: Transaction simulation failed: Error processing Instruction 0: custom program error: 0xbc4. 
Logs: 
[
  "Program HVyr1MU52zXpf4LDf9Uvd2nfzdSL5nQgqv2uTvULjwSe invoke [1]",
  "Program log: Instruction: InitOft",
  "Program log: AnchorError caused by account: token_mint. Error Code: AccountNotInitialized. Error Number: 3012. Error Message: The program expected this account to be already initialized.",
  "Program HVyr1MU52zXpf4LDf9Uvd2nfzdSL5nQgqv2uTvULjwSe consumed 6198 of 200000 compute units",
  "Program HVyr1MU52zXpf4LDf9Uvd2nfzdSL5nQgqv2uTvULjwSe failed: custom program error: 0xbc4"
]. 
Catch the `SendTransactionError` and call `getLogs()` on it for full details.
    at Connection.sendEncodedTransaction (/Users/zhangchi/code/oft-
```
- However token_mint account is definitely initialized after createToken Tx
- It turns out this is RPC caching issue, we have to wait a while for RPC cache to refresh

I am using official devnet RPC: https://api.devnet.solana.com

@nazreen @St0rmBr3w @DanL0 