### PR TITLE
fix CLI commands instruction in solana 

### DIFF
--- a/examples/oft-solana/README.md
+++ b/examples/oft-solana/README.md
@@ -208,7 +208,7 @@ pnpm hardhat lz:oft:solana:create --eid 40168 --program-id <PROGRAM_ID> --mint <
 ```
 
 :warning: You may specify the `--additional-minters` flag to add a CSV of additional minter keys to the mint
-multisig. If you do not want to, you must specify `--only-oft-store store`. If you choose the latter approach, you can never
+multisig. If you do not want to, you must specify `--only-oft-store true`. If you choose the latter approach, you can never
 substitute in a different mint authority.
 
 ### Update [layerzero.config.ts](./layerzero.config.ts)
@@ -250,7 +250,7 @@ With a squads multisig, you can simply append the `--multisigKey` flag to the en
 
 ### Mint OFT on Solana
 
-:information_source: This is only possible if you specified your deployer address as part of the `--additional-minters` flag when creating the Solana OFT. If you had chosen `--only-oft-store`, you will not be able to mint your OFT on Solana.
+:information_source: This is only possible if you specified your deployer address as part of the `--additional-minters` flag when creating the Solana OFT. If you had chosen `--only-oft-store true`, you will not be able to mint your OFT on Solana.
 
 First, you need to create the Associated Token Account for your address.
 

--- a/examples/oft-solana/README.md
+++ b/examples/oft-solana/README.md
@@ -164,8 +164,7 @@ This section only applies if you are unable to land your deployment transaction 
 ```bash
 sh -c "$(curl -sSfL https://release.solana.com/v1.18.26/install)"
 ```
-
-You can run `npx hardhat solana:get-priority-fees --eid <SOLANA_EID> --address <PROGRAM_ID>` and use the `averageFeeExcludingZeros` value.
+You can run `npx hardhat lz:solana:get-priority-fees --eid <SOLANA_EID> --address <PROGRAM_ID>` and use the `averageFeeExcludingZeros` value.
 
 :information_source: The average is calculated from getting the prioritization fees across recent blocks, but some blocks may have `0` as the prioritization fee. `averageFeeExcludingZeros` ignores blocks with `0` prioritization fees.
 

--- a/examples/oft-solana/README.md
+++ b/examples/oft-solana/README.md
@@ -164,6 +164,7 @@ This section only applies if you are unable to land your deployment transaction 
 ```bash
 sh -c "$(curl -sSfL https://release.solana.com/v1.18.26/install)"
 ```
+
 You can run `npx hardhat lz:solana:get-priority-fees --eid <SOLANA_EID> --address <PROGRAM_ID>` and use the `averageFeeExcludingZeros` value.
 
 :information_source: The average is calculated from getting the prioritization fees across recent blocks, but some blocks may have `0` as the prioritization fee. `averageFeeExcludingZeros` ignores blocks with `0` prioritization fees.

--- a/examples/oft-solana/README.md
+++ b/examples/oft-solana/README.md
@@ -14,7 +14,7 @@
 
 - Rust `v1.75.0`
 - Anchor `v0.29`
-- Solana CLI `v.1.17.31`
+- Solana CLI `v1.17.31`
 - Docker
 - Node.js
 

--- a/examples/oft-solana/tasks/common/wire.ts
+++ b/examples/oft-solana/tasks/common/wire.ts
@@ -87,6 +87,11 @@ task(TASK_LZ_OAPP_WIRE)
         // Then we grab the programId from the args
         const programId = args.solanaProgramId
 
+        if (!programId) {
+            logger.error('Missing --solana-program-id CLI argument')
+            return
+        }
+
         const configurator = args.internalConfigurator
 
         //

--- a/examples/oft-solana/tasks/common/wire.ts
+++ b/examples/oft-solana/tasks/common/wire.ts
@@ -44,10 +44,6 @@ task(TASK_LZ_OAPP_WIRE)
         keyPair,
         true
     )
-    // The next (optional) parameter is the OFT program ID
-    //
-    // Only pass this if you deployed a new OFT program, if you are using the default
-    // LayerZero OFT program you can omit this
     .addParam('solanaProgramId', 'The OFT program ID to use', undefined, publicKey, true)
     .addParam('multisigKey', 'The MultiSig key', undefined, publicKey, true)
     // We use this argument to get around the fact that we want to both override the task action for the wiring task

--- a/examples/oft-solana/tasks/solana/createOFT.ts
+++ b/examples/oft-solana/tasks/solana/createOFT.ts
@@ -167,7 +167,9 @@ task('lz:oft:solana:create', 'Mints new SPL Token and creates new OFT Store acco
             const { programId, lockBox, escrowPK, oftStorePda, eddsa } = deriveKeys(programIdStr)
             if (!additionalMintersAsStrings) {
                 if (!onlyOftStore) {
-                    throw new Error('If you want to proceed with only the OFTStore, please specify --onlyOFTStore')
+                    throw new Error(
+                        'If you want to proceed with only the OFTStore, please specify --only-oft-store true'
+                    )
                 }
                 console.log(
                     'No additional minters specified.  This will result in only the OFTStore being able to mint new tokens.'

--- a/examples/oft-solana/tasks/solana/setAuthority.ts
+++ b/examples/oft-solana/tasks/solana/setAuthority.ts
@@ -119,7 +119,9 @@ task('lz:oft:solana:setauthority', 'Create a new Mint Authority SPL multisig and
             const tokenProgram = publicKey(tokenProgramStr)
             if (!additionalMintersAsStrings) {
                 if (!onlyOftStore) {
-                    throw new Error('If you want to proceed with only the OFTStore, please specify --onlyOFTStore')
+                    throw new Error(
+                        'If you want to proceed with only the OFTStore, please specify --only-oft-store true'
+                    )
                 }
                 console.log(
                     'No additional minters specified.  This will result in only the OFTStore being able to mint new tokens.'


### PR DESCRIPTION
1. get priority fees command was missing "lz:" prefix so it was broken
2. show meaningful error if wire command is running without solana program id
before: `error:   [OApp] Failed to check OApp configuration: TypeError: Cannot read properties of undefined (reading 'toBase58')`
after: `error:   Missing --solana-program-id CLI argument`
3. fix --only-oft-store param instruction