### PR TITLE
🧹 Fix logic to compare compute setting to static counterparts, rather than evaluating static ComputeSetting directly

### DIFF
--- a/.changeset/eight-llamas-deny.md
+++ b/.changeset/eight-llamas-deny.md
@@ -1,0 +1,5 @@
+---
+"@layerzerolabs/ua-devtools-evm": patch
+---
+
+Fixes an breaking issue when running lz:read:resolve-command with map or reduce compute settings

--- a/packages/ua-devtools-evm/src/read/commandResolver/compute/sdk.ts
+++ b/packages/ua-devtools-evm/src/read/commandResolver/compute/sdk.ts
@@ -28,14 +28,16 @@ export class ComputerEVM extends EVMViewFunctionBase implements IComputerEVM {
         this.validateComputeSetting(computeSetting)
 
         try {
-            const mapper = ComputeSetting.OnlyReduce
-                ? (this.logger.info('OnlyReduce setting is used. Skipping map step.'),
-                  (r: RequestResponsePair) => r.response)
-                : (r: RequestResponsePair) => this.lzMap(compute, r, timeMarker)
-            const reducer = ComputeSetting.OnlyMap
-                ? (this.logger.info('OnlyMap setting is used. Skipping reduce step.'),
-                  (mappedResponses: string[]) => mappedResponses.join(''))
-                : (mappedResponses: string[]) => this.lzReduce(compute, cmd, mappedResponses, timeMarker)
+            const mapper =
+                computeSetting === ComputeSetting.OnlyReduce
+                    ? (this.logger.info('OnlyReduce setting is used. Skipping map step.'),
+                      (r: RequestResponsePair) => r.response)
+                    : (r: RequestResponsePair) => this.lzMap(compute, r, timeMarker)
+            const reducer =
+                computeSetting === ComputeSetting.OnlyMap
+                    ? (this.logger.info('OnlyMap setting is used. Skipping reduce step.'),
+                      (mappedResponses: string[]) => mappedResponses.join(''))
+                    : (mappedResponses: string[]) => this.lzReduce(compute, cmd, mappedResponses, timeMarker)
 
             const applicative = createDefaultApplicative(this.logger)
             const mapped = await applicative(responses.map((r) => () => mapper(r)))


### PR DESCRIPTION
The existing logic evaluates static compute setting values as conditions for ternary expressions, which will always evaluate truthy. They should instead be comparing the existing compute setting to their static counterparts.