### PR TITLE
docs(solana): remove receiveLibraryTimeoutConfig

### DIFF
--- a/examples/oft-solana/layerzero.config.ts
+++ b/examples/oft-solana/layerzero.config.ts
@@ -69,12 +69,6 @@ const config: OAppOmniGraphHardhat = {
             //         receiveLibrary: '7a4WjyR8VZ7yZz5XJAKm39BUGn5iT9CKcv2pmG9tdXVH',
             //         gracePeriod: BigInt(0),
             //     },
-            //     // Optional Receive Library Timeout for when the Old Receive Library Address will no longer be valid
-            //     // Note:  This configuring `receiveLibraryTimeoutConfig` using devtools is not currently available for Solana.
-            //     // receiveLibraryTimeoutConfig: {
-            //     //     lib: '0x0000000000000000000000000000000000000000',
-            //     //     expiry: BigInt(0),
-            //     // },
             //     // Optional Send Configuration
             //     // @dev Controls how the `from` chain sends messages to the `to` chain.
             //     sendConfig: {


### PR DESCRIPTION
- removing receiveLibraryTimeoutConfig from solana to sepolia entry in example
- this is not yet supported, and as @ryandgoulding pointed out, not needed as on Solana there's only one receive library right now
- leaving it in can lead to some devs (who uncomment it) experiencing a confusing error, as one did today. they faced `Error: An error occurred while getting the OApp configuration: TypeError: getReceiveLibraryTimeout() not implemented on Solana Endpoint SDK
` when running the wire command