### PR TITLE
Update layerzero.config.ts

### DIFF
--- a/examples/oft-solana/layerzero.config.ts
+++ b/examples/oft-solana/layerzero.config.ts
@@ -1,5 +1,5 @@
 import { EndpointId } from '@layerzerolabs/lz-definitions'
-
+import { ExecutorOptionType  } from '@layerzerolabs/lz-v2-utilities';
 import type { OAppOmniGraphHardhat, OmniPointHardhat } from '@layerzerolabs/toolbox-hardhat'
 
 // Note:  Do not use address for EVM OmniPointHardhat contracts.  Contracts are loaded using hardhat-deploy.


### PR DESCRIPTION
The commented-out section uses ExecutorOptionType. 
When you want use "enforcedOptions" in the file and call "npx hardhat lz:oapp:wire" to enable it, it will show the error: "ExecutorOptionType is not defined."
Adding import { ExecutorOptionType } from '@layerzerolabs/lz-v2-utilities'; resolves the issue.