### PR TITLE
pin typescript to 5.5.3

### DIFF
--- a/examples/native-oft-adapter/package.json
+++ b/examples/native-oft-adapter/package.json
@@ -57,7 +57,7 @@
     "solhint": "^4.1.1",
     "solidity-bytes-utils": "^0.8.2",
     "ts-node": "^10.9.2",
-    "typescript": "^5.4.4"
+    "typescript": "5.5.3"
   },
   "engines": {
     "node": ">=18.16.0"

--- a/examples/oapp-read/package.json
+++ b/examples/oapp-read/package.json
@@ -56,7 +56,7 @@
     "solhint": "^4.1.1",
     "solidity-bytes-utils": "^0.8.2",
     "ts-node": "^10.9.2",
-    "typescript": "^5.4.4"
+    "typescript": "5.5.3"
   },
   "engines": {
     "node": ">=18.16.0"

--- a/examples/oapp/package.json
+++ b/examples/oapp/package.json
@@ -56,7 +56,7 @@
     "solhint": "^4.1.1",
     "solidity-bytes-utils": "^0.8.2",
     "ts-node": "^10.9.2",
-    "typescript": "^5.4.4"
+    "typescript": "5.5.3"
   },
   "engines": {
     "node": ">=18.16.0"

--- a/examples/oft-adapter/package.json
+++ b/examples/oft-adapter/package.json
@@ -57,7 +57,7 @@
     "solhint": "^4.1.1",
     "solidity-bytes-utils": "^0.8.2",
     "ts-node": "^10.9.2",
-    "typescript": "^5.4.4"
+    "typescript": "5.5.3"
   },
   "engines": {
     "node": ">=18.16.0"

--- a/examples/oft-solana/package.json
+++ b/examples/oft-solana/package.json
@@ -95,7 +95,7 @@
     "solhint": "^4.1.1",
     "solidity-bytes-utils": "^0.8.2",
     "ts-node": "^10.9.2",
-    "typescript": "^5.4.4"
+    "typescript": "5.5.3"
   },
   "engines": {
     "node": ">=18.16.0"

--- a/examples/oft-upgradeable/package.json
+++ b/examples/oft-upgradeable/package.json
@@ -63,7 +63,7 @@
     "solhint": "^4.1.1",
     "solidity-bytes-utils": "^0.8.2",
     "ts-node": "^10.9.2",
-    "typescript": "^5.4.4"
+    "typescript": "5.5.3"
   },
   "engines": {
     "node": ">=18.16.0"

--- a/examples/oft/package.json
+++ b/examples/oft/package.json
@@ -58,7 +58,7 @@
     "solhint": "^4.1.1",
     "solidity-bytes-utils": "^0.8.2",
     "ts-node": "^10.9.2",
-    "typescript": "^5.4.4"
+    "typescript": "5.5.3"
   },
   "engines": {
     "node": ">=18.16.0"

--- a/examples/onft721-zksync/package.json
+++ b/examples/onft721-zksync/package.json
@@ -61,7 +61,7 @@
     "solhint": "^4.1.1",
     "solidity-bytes-utils": "^0.8.2",
     "ts-node": "^10.9.2",
-    "typescript": "^5.4.4"
+    "typescript": "5.5.3"
   },
   "engines": {
     "node": ">=18.16.0"

--- a/examples/onft721/package.json
+++ b/examples/onft721/package.json
@@ -55,7 +55,7 @@
     "solhint": "^4.1.1",
     "solidity-bytes-utils": "^0.8.2",
     "ts-node": "^10.9.2",
-    "typescript": "^5.4.4"
+    "typescript": "5.5.3"
   },
   "engines": {
     "node": ">=18.16.0"

--- a/examples/uniswap-read/package.json
+++ b/examples/uniswap-read/package.json
@@ -57,7 +57,7 @@
     "solhint": "^4.1.1",
     "solidity-bytes-utils": "^0.8.2",
     "ts-node": "^10.9.2",
-    "typescript": "^5.4.4"
+    "typescript": "5.5.3"
   },
   "engines": {
     "node": ">=18.16.0"

--- a/packages/build-devtools/package.json
+++ b/packages/build-devtools/package.json
@@ -46,10 +46,10 @@
     "ts-node": "^10.9.2",
     "tslib": "~2.6.2",
     "tsup": "~8.0.1",
-    "typescript": "^5.4.4"
+    "typescript": "5.5.3"
   },
   "peerDependencies": {
     "tsup": "^8.0.1",
-    "typescript": "^5.4.4"
+    "typescript": "5.5.3"
   }
 }

--- a/packages/build-lz-options/package.json
+++ b/packages/build-lz-options/package.json
@@ -49,7 +49,7 @@
     "react": "^17.0.2",
     "ts-node": "^10.9.2",
     "tsup": "~8.0.1",
-    "typescript": "^5.4.4"
+    "typescript": "5.5.3"
   },
   "engines": {
     "node": ">=18"

--- a/packages/create-lz-oapp/package.json
+++ b/packages/create-lz-oapp/package.json
@@ -54,7 +54,7 @@
     "tiged": "^2.12.6",
     "ts-node": "^10.9.2",
     "tsup": "~8.0.1",
-    "typescript": "^5.4.4",
+    "typescript": "5.5.3",
     "which": "~4.0.0"
   },
   "engines": {

--- a/packages/decode-lz-options/package.json
+++ b/packages/decode-lz-options/package.json
@@ -49,7 +49,7 @@
     "react": "^17.0.2",
     "ts-node": "^10.9.2",
     "tsup": "~8.0.1",
-    "typescript": "^5.4.4"
+    "typescript": "5.5.3"
   },
   "engines": {
     "node": ">=18"

--- a/packages/devtools-cli/package.json
+++ b/packages/devtools-cli/package.json
@@ -57,7 +57,7 @@
     "react": "^17.0.2",
     "ts-node": "^10.9.2",
     "tsup": "~8.0.1",
-    "typescript": "^5.4.4",
+    "typescript": "5.5.3",
     "zod": "^3.22.4"
   },
   "engines": {

--- a/packages/devtools-evm-hardhat/package.json
+++ b/packages/devtools-evm-hardhat/package.json
@@ -76,7 +76,7 @@
     "ts-node": "^10.9.2",
     "tslib": "~2.6.2",
     "tsup": "~8.0.1",
-    "typescript": "^5.4.4"
+    "typescript": "5.5.3"
   },
   "peerDependencies": {
     "@ethersproject/abi": "^5.7.0",

--- a/packages/devtools-evm/package.json
+++ b/packages/devtools-evm/package.json
@@ -65,7 +65,7 @@
     "ts-node": "^10.9.2",
     "tslib": "~2.6.2",
     "tsup": "~8.0.1",
-    "typescript": "^5.4.4",
+    "typescript": "5.5.3",
     "zod": "^3.22.4"
   },
   "peerDependencies": {

--- a/packages/devtools-solana/package.json
+++ b/packages/devtools-solana/package.json
@@ -61,7 +61,7 @@
     "ts-node": "^10.9.2",
     "tslib": "~2.6.2",
     "tsup": "~8.0.1",
-    "typescript": "^5.4.4",
+    "typescript": "5.5.3",
     "zod": "^3.22.4"
   },
   "peerDependencies": {

--- a/packages/devtools-ton/package.json
+++ b/packages/devtools-ton/package.json
@@ -47,7 +47,7 @@
     "ts-node": "^10.9.2",
     "tslib": "~2.6.2",
     "tsup": "~8.0.1",
-    "typescript": "^5.4.4"
+    "typescript": "5.5.3"
   },
   "peerDependencies": {
     "@layerzerolabs/devtools": "~0.4.2",

--- a/packages/devtools/package.json
+++ b/packages/devtools/package.json
@@ -50,7 +50,7 @@
     "ts-node": "^10.9.2",
     "tslib": "~2.6.2",
     "tsup": "~8.0.1",
-    "typescript": "^5.4.4",
+    "typescript": "5.5.3",
     "zod": "^3.22.4"
   },
   "peerDependencies": {

--- a/packages/export-deployments/package.json
+++ b/packages/export-deployments/package.json
@@ -27,7 +27,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "typescript": "^5.4.4"
+    "typescript": "5.5.3"
   },
   "devDependencies": {
     "@layerzerolabs/io-devtools": "~0.1.12",

--- a/packages/io-devtools/package.json
+++ b/packages/io-devtools/package.json
@@ -60,7 +60,7 @@
     "ts-node": "^10.9.2",
     "tslib": "~2.6.2",
     "tsup": "~8.0.1",
-    "typescript": "^5.4.4",
+    "typescript": "5.5.3",
     "zod": "^3.22.4"
   },
   "peerDependencies": {

--- a/packages/omnicounter-devtools-evm/package.json
+++ b/packages/omnicounter-devtools-evm/package.json
@@ -48,7 +48,7 @@
     "ts-node": "^10.9.2",
     "tslib": "~2.6.2",
     "tsup": "~8.0.1",
-    "typescript": "^5.4.4",
+    "typescript": "5.5.3",
     "zod": "^3.22.4"
   },
   "peerDependencies": {

--- a/packages/omnicounter-devtools/package.json
+++ b/packages/omnicounter-devtools/package.json
@@ -41,7 +41,7 @@
     "ts-node": "^10.9.2",
     "tslib": "~2.6.2",
     "tsup": "~8.0.1",
-    "typescript": "^5.4.4",
+    "typescript": "5.5.3",
     "zod": "^3.22.4"
   },
   "peerDependencies": {

--- a/packages/protocol-devtools-evm/package.json
+++ b/packages/protocol-devtools-evm/package.json
@@ -60,7 +60,7 @@
     "ts-node": "^10.9.2",
     "tslib": "~2.6.2",
     "tsup": "~8.0.1",
-    "typescript": "^5.4.4",
+    "typescript": "5.5.3",
     "zod": "^3.22.4"
   },
   "peerDependencies": {

--- a/packages/protocol-devtools-solana/package.json
+++ b/packages/protocol-devtools-solana/package.json
@@ -63,7 +63,7 @@
     "ts-node": "^10.9.2",
     "tslib": "~2.6.2",
     "tsup": "~8.0.1",
-    "typescript": "^5.4.4",
+    "typescript": "5.5.3",
     "zod": "^3.22.4"
   },
   "peerDependencies": {

--- a/packages/protocol-devtools/package.json
+++ b/packages/protocol-devtools/package.json
@@ -44,7 +44,7 @@
     "ts-node": "^10.9.2",
     "tslib": "~2.6.2",
     "tsup": "~8.0.1",
-    "typescript": "^5.4.4",
+    "typescript": "5.5.3",
     "zod": "^3.22.4"
   },
   "peerDependencies": {

--- a/packages/test-devtools-evm-foundry/package.json
+++ b/packages/test-devtools-evm-foundry/package.json
@@ -27,7 +27,7 @@
     "@types/node": "~18.18.14",
     "solidity-bytes-utils": "^0.8.2",
     "ts-node": "^10.9.2",
-    "typescript": "^5.4.4"
+    "typescript": "5.5.3"
   },
   "peerDependencies": {
     "@layerzerolabs/lz-evm-messagelib-v2": "^3.0.12",

--- a/packages/test-devtools-evm-hardhat/package.json
+++ b/packages/test-devtools-evm-hardhat/package.json
@@ -46,7 +46,7 @@
     "ts-node": "^10.9.2",
     "tslib": "~2.6.2",
     "tsup": "~8.0.1",
-    "typescript": "^5.4.4"
+    "typescript": "5.5.3"
   },
   "peerDependencies": {
     "hardhat": "^2.22.10",

--- a/packages/test-devtools-solana/package.json
+++ b/packages/test-devtools-solana/package.json
@@ -37,7 +37,7 @@
     "ts-node": "^10.9.2",
     "tslib": "~2.6.2",
     "tsup": "~8.0.1",
-    "typescript": "^5.4.4"
+    "typescript": "5.5.3"
   },
   "peerDependencies": {
     "@solana/web3.js": "^1.95.8",

--- a/packages/test-devtools-ton/package.json
+++ b/packages/test-devtools-ton/package.json
@@ -37,6 +37,6 @@
     "ts-node": "^10.9.2",
     "tslib": "~2.6.2",
     "tsup": "~8.0.1",
-    "typescript": "^5.4.4"
+    "typescript": "5.5.3"
   }
 }

--- a/packages/test-devtools/package.json
+++ b/packages/test-devtools/package.json
@@ -39,7 +39,7 @@
     "ts-node": "^10.9.2",
     "tslib": "~2.6.2",
     "tsup": "~8.0.1",
-    "typescript": "^5.4.4"
+    "typescript": "5.5.3"
   },
   "peerDependencies": {
     "@layerzerolabs/lz-definitions": "^3.0.21",

--- a/packages/toolbox-foundry/package.json
+++ b/packages/toolbox-foundry/package.json
@@ -23,7 +23,7 @@
     "solidity-bytes-utils": "^0.8.2",
     "ts-node": "^10.9.2",
     "tsup": "~8.0.1",
-    "typescript": "^5.4.4"
+    "typescript": "5.5.3"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/toolbox-hardhat/package.json
+++ b/packages/toolbox-hardhat/package.json
@@ -67,7 +67,7 @@
     "jest": "^29.7.0",
     "ts-node": "^10.9.2",
     "tsup": "~8.0.1",
-    "typescript": "^5.4.4"
+    "typescript": "5.5.3"
   },
   "peerDependencies": {
     "@nomicfoundation/hardhat-ethers": "^3.0.2",

--- a/packages/ua-devtools-evm-hardhat/package.json
+++ b/packages/ua-devtools-evm-hardhat/package.json
@@ -36,7 +36,7 @@
   },
   "dependencies": {
     "p-memoize": "~4.0.4",
-    "typescript": "^5.4.4"
+    "typescript": "5.5.3"
   },
   "devDependencies": {
     "@ethersproject/abi": "^5.7.0",

--- a/packages/ua-devtools-evm/package.json
+++ b/packages/ua-devtools-evm/package.json
@@ -57,7 +57,7 @@
     "ts-node": "^10.9.2",
     "tslib": "~2.6.2",
     "tsup": "~8.0.1",
-    "typescript": "^5.4.4",
+    "typescript": "5.5.3",
     "zod": "^3.22.4"
   },
   "peerDependencies": {

--- a/packages/ua-devtools-solana/package.json
+++ b/packages/ua-devtools-solana/package.json
@@ -69,7 +69,7 @@
     "ts-node": "^10.9.2",
     "tslib": "~2.6.2",
     "tsup": "~8.0.1",
-    "typescript": "^5.4.4",
+    "typescript": "5.5.3",
     "zod": "^3.22.4"
   },
   "peerDependencies": {

--- a/packages/ua-devtools/package.json
+++ b/packages/ua-devtools/package.json
@@ -45,7 +45,7 @@
     "ts-node": "^10.9.2",
     "tslib": "~2.6.2",
     "tsup": "~8.0.1",
-    "typescript": "^5.4.4",
+    "typescript": "5.5.3",
     "zod": "^3.22.4"
   },
   "peerDependencies": {

--- a/packages/verify-contract/package.json
+++ b/packages/verify-contract/package.json
@@ -43,7 +43,7 @@
     "got": "12.6.1",
     "jest": "^29.7.0",
     "tsup": "^8.0.1",
-    "typescript": "^5.4.4",
+    "typescript": "5.5.3",
     "zod": "^3.22.4"
   },
   "publishConfig": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -186,7 +186,7 @@ importers:
         specifier: ^10.9.2
         version: 10.9.2(@swc/core@1.4.0)(@types/node@18.18.14)(typescript@5.5.3)
       typescript:
-        specifier: ^5.4.4
+        specifier: 5.5.3
         version: 5.5.3
 
   examples/oapp:
@@ -297,7 +297,7 @@ importers:
         specifier: ^10.9.2
         version: 10.9.2(@swc/core@1.4.0)(@types/node@18.18.14)(typescript@5.5.3)
       typescript:
-        specifier: ^5.4.4
+        specifier: 5.5.3
         version: 5.5.3
 
   examples/oapp-read:
@@ -408,7 +408,7 @@ importers:
         specifier: ^10.9.2
         version: 10.9.2(@swc/core@1.4.0)(@types/node@18.18.14)(typescript@5.5.3)
       typescript:
-        specifier: ^5.4.4
+        specifier: 5.5.3
         version: 5.5.3
 
   examples/oft:
@@ -525,7 +525,7 @@ importers:
         specifier: ^10.9.2
         version: 10.9.2(@swc/core@1.4.0)(@types/node@18.18.14)(typescript@5.5.3)
       typescript:
-        specifier: ^5.4.4
+        specifier: 5.5.3
         version: 5.5.3
 
   examples/oft-adapter:
@@ -639,7 +639,7 @@ importers:
         specifier: ^10.9.2
         version: 10.9.2(@swc/core@1.4.0)(@types/node@18.18.14)(typescript@5.5.3)
       typescript:
-        specifier: ^5.4.4
+        specifier: 5.5.3
         version: 5.5.3
 
   examples/oft-solana:
@@ -864,7 +864,7 @@ importers:
         specifier: ^10.9.2
         version: 10.9.2(@swc/core@1.4.0)(@types/node@18.18.14)(typescript@5.5.3)
       typescript:
-        specifier: ^5.4.4
+        specifier: 5.5.3
         version: 5.5.3
 
   examples/oft-upgradeable:
@@ -996,7 +996,7 @@ importers:
         specifier: ^10.9.2
         version: 10.9.2(@swc/core@1.4.0)(@types/node@18.18.14)(typescript@5.5.3)
       typescript:
-        specifier: ^5.4.4
+        specifier: 5.5.3
         version: 5.5.3
 
   examples/onft721:
@@ -1107,7 +1107,7 @@ importers:
         specifier: ^10.9.2
         version: 10.9.2(@swc/core@1.4.0)(@types/node@18.18.14)(typescript@5.5.3)
       typescript:
-        specifier: ^5.4.4
+        specifier: 5.5.3
         version: 5.5.3
 
   examples/onft721-zksync:
@@ -1230,7 +1230,7 @@ importers:
         specifier: ^10.9.2
         version: 10.9.2(@swc/core@1.4.0)(@types/node@18.18.14)(typescript@5.5.3)
       typescript:
-        specifier: ^5.4.4
+        specifier: 5.5.3
         version: 5.5.3
 
   examples/uniswap-read:
@@ -1344,7 +1344,7 @@ importers:
         specifier: ^10.9.2
         version: 10.9.2(@swc/core@1.4.0)(@types/node@18.18.14)(typescript@5.5.3)
       typescript:
-        specifier: ^5.4.4
+        specifier: 5.5.3
         version: 5.5.3
 
   packages/build-devtools:
@@ -1374,7 +1374,7 @@ importers:
         specifier: ~8.0.1
         version: 8.0.1(@swc/core@1.4.0)(ts-node@10.9.2)(typescript@5.5.3)
       typescript:
-        specifier: ^5.4.4
+        specifier: 5.5.3
         version: 5.5.3
 
   packages/build-lz-options:
@@ -1432,7 +1432,7 @@ importers:
         specifier: ~8.0.1
         version: 8.0.1(ts-node@10.9.2)(typescript@5.5.3)
       typescript:
-        specifier: ^5.4.4
+        specifier: 5.5.3
         version: 5.5.3
 
   packages/create-lz-oapp:
@@ -1505,7 +1505,7 @@ importers:
         specifier: ~8.0.1
         version: 8.0.1(@swc/core@1.4.0)(ts-node@10.9.2)(typescript@5.5.3)
       typescript:
-        specifier: ^5.4.4
+        specifier: 5.5.3
         version: 5.5.3
       which:
         specifier: ~4.0.0
@@ -1566,7 +1566,7 @@ importers:
         specifier: ~8.0.1
         version: 8.0.1(ts-node@10.9.2)(typescript@5.5.3)
       typescript:
-        specifier: ^5.4.4
+        specifier: 5.5.3
         version: 5.5.3
 
   packages/devtools:
@@ -1624,7 +1624,7 @@ importers:
         specifier: ~8.0.1
         version: 8.0.1(@swc/core@1.4.0)(ts-node@10.9.2)(typescript@5.5.3)
       typescript:
-        specifier: ^5.4.4
+        specifier: 5.5.3
         version: 5.5.3
       zod:
         specifier: ^3.22.4
@@ -1679,7 +1679,7 @@ importers:
         specifier: ~8.0.1
         version: 8.0.1(ts-node@10.9.2)(typescript@5.5.3)
       typescript:
-        specifier: ^5.4.4
+        specifier: 5.5.3
         version: 5.5.3
       zod:
         specifier: ^3.22.4
@@ -1770,7 +1770,7 @@ importers:
         specifier: ~8.0.1
         version: 8.0.1(@swc/core@1.4.0)(ts-node@10.9.2)(typescript@5.5.3)
       typescript:
-        specifier: ^5.4.4
+        specifier: 5.5.3
         version: 5.5.3
       zod:
         specifier: ^3.22.4
@@ -1870,7 +1870,7 @@ importers:
         specifier: ~8.0.1
         version: 8.0.1(@swc/core@1.4.0)(ts-node@10.9.2)(typescript@5.5.3)
       typescript:
-        specifier: ^5.4.4
+        specifier: 5.5.3
         version: 5.5.3
 
   packages/devtools-solana:
@@ -1946,7 +1946,7 @@ importers:
         specifier: ~8.0.1
         version: 8.0.1(@swc/core@1.4.0)(ts-node@10.9.2)(typescript@5.5.3)
       typescript:
-        specifier: ^5.4.4
+        specifier: 5.5.3
         version: 5.5.3
       zod:
         specifier: ^3.22.4
@@ -2000,13 +2000,13 @@ importers:
         specifier: ~8.0.1
         version: 8.0.1(@swc/core@1.4.0)(ts-node@10.9.2)(typescript@5.5.3)
       typescript:
-        specifier: ^5.4.4
+        specifier: 5.5.3
         version: 5.5.3
 
   packages/export-deployments:
     dependencies:
       typescript:
-        specifier: ^5.4.4
+        specifier: 5.5.3
         version: 5.5.3
     devDependencies:
       '@layerzerolabs/io-devtools':
@@ -2113,7 +2113,7 @@ importers:
         specifier: ~8.0.1
         version: 8.0.1(@swc/core@1.4.0)(ts-node@10.9.2)(typescript@5.5.3)
       typescript:
-        specifier: ^5.4.4
+        specifier: 5.5.3
         version: 5.5.3
       zod:
         specifier: ^3.22.4
@@ -2341,7 +2341,7 @@ importers:
         specifier: ~8.0.1
         version: 8.0.1(@swc/core@1.4.0)(ts-node@10.9.2)(typescript@5.5.3)
       typescript:
-        specifier: ^5.4.4
+        specifier: 5.5.3
         version: 5.5.3
       zod:
         specifier: ^3.22.4
@@ -2399,7 +2399,7 @@ importers:
         specifier: ~8.0.1
         version: 8.0.1(@swc/core@1.4.0)(ts-node@10.9.2)(typescript@5.5.3)
       typescript:
-        specifier: ^5.4.4
+        specifier: 5.5.3
         version: 5.5.3
       zod:
         specifier: ^3.22.4
@@ -2477,7 +2477,7 @@ importers:
         specifier: ~8.0.1
         version: 8.0.1(@swc/core@1.4.0)(ts-node@10.9.2)(typescript@5.5.3)
       typescript:
-        specifier: ^5.4.4
+        specifier: 5.5.3
         version: 5.5.3
       zod:
         specifier: ^3.22.4
@@ -2553,7 +2553,7 @@ importers:
         specifier: ~8.0.1
         version: 8.0.1(@swc/core@1.4.0)(ts-node@10.9.2)(typescript@5.5.3)
       typescript:
-        specifier: ^5.4.4
+        specifier: 5.5.3
         version: 5.5.3
       zod:
         specifier: ^3.22.4
@@ -2638,7 +2638,7 @@ importers:
         specifier: ~8.0.1
         version: 8.0.1(@swc/core@1.4.0)(ts-node@10.9.2)(typescript@5.5.3)
       typescript:
-        specifier: ^5.4.4
+        specifier: 5.5.3
         version: 5.5.3
       zod:
         specifier: ^3.22.4
@@ -2669,7 +2669,7 @@ importers:
         specifier: ~8.0.1
         version: 8.0.1(ts-node@10.9.2)(typescript@5.5.3)
       typescript:
-        specifier: ^5.4.4
+        specifier: 5.5.3
         version: 5.5.3
 
   packages/test-devtools-evm-foundry:
@@ -2709,7 +2709,7 @@ importers:
         specifier: ^10.9.2
         version: 10.9.2(@swc/core@1.4.0)(@types/node@18.18.14)(typescript@5.5.3)
       typescript:
-        specifier: ^5.4.4
+        specifier: 5.5.3
         version: 5.5.3
 
   packages/test-devtools-evm-hardhat:
@@ -2751,7 +2751,7 @@ importers:
         specifier: ~8.0.1
         version: 8.0.1(ts-node@10.9.2)(typescript@5.5.3)
       typescript:
-        specifier: ^5.4.4
+        specifier: 5.5.3
         version: 5.5.3
 
   packages/test-devtools-solana:
@@ -2775,7 +2775,7 @@ importers:
         specifier: ~8.0.1
         version: 8.0.1(ts-node@10.9.2)(typescript@5.5.3)
       typescript:
-        specifier: ^5.4.4
+        specifier: 5.5.3
         version: 5.5.3
 
   packages/test-devtools-ton:
@@ -2805,7 +2805,7 @@ importers:
         specifier: ~8.0.1
         version: 8.0.1(@swc/core@1.4.0)(ts-node@10.9.2)(typescript@5.5.3)
       typescript:
-        specifier: ^5.4.4
+        specifier: 5.5.3
         version: 5.5.3
 
   packages/toolbox-foundry:
@@ -2832,7 +2832,7 @@ importers:
         specifier: ~8.0.1
         version: 8.0.1(@swc/core@1.4.0)(ts-node@10.9.2)(typescript@5.5.3)
       typescript:
-        specifier: ^5.4.4
+        specifier: 5.5.3
         version: 5.5.3
 
   packages/toolbox-hardhat:
@@ -2947,7 +2947,7 @@ importers:
         specifier: ~8.0.1
         version: 8.0.1(@swc/core@1.4.0)(ts-node@10.9.2)(typescript@5.5.3)
       typescript:
-        specifier: ^5.4.4
+        specifier: 5.5.3
         version: 5.5.3
 
   packages/ua-devtools:
@@ -2995,7 +2995,7 @@ importers:
         specifier: ~8.0.1
         version: 8.0.1(@swc/core@1.4.0)(ts-node@10.9.2)(typescript@5.5.3)
       typescript:
-        specifier: ^5.4.4
+        specifier: 5.5.3
         version: 5.5.3
       zod:
         specifier: ^3.22.4
@@ -3077,7 +3077,7 @@ importers:
         specifier: ~8.0.1
         version: 8.0.1(@swc/core@1.4.0)(ts-node@10.9.2)(typescript@5.5.3)
       typescript:
-        specifier: ^5.4.4
+        specifier: 5.5.3
         version: 5.5.3
       zod:
         specifier: ^3.22.4
@@ -3089,7 +3089,7 @@ importers:
         specifier: ~4.0.4
         version: 4.0.4
       typescript:
-        specifier: ^5.4.4
+        specifier: 5.5.3
         version: 5.5.3
     devDependencies:
       '@ethersproject/abi':
@@ -3274,7 +3274,7 @@ importers:
         specifier: ~8.0.1
         version: 8.0.1(@swc/core@1.4.0)(ts-node@10.9.2)(typescript@5.5.3)
       typescript:
-        specifier: ^5.4.4
+        specifier: 5.5.3
         version: 5.5.3
       zod:
         specifier: ^3.22.4
@@ -3322,7 +3322,7 @@ importers:
         specifier: ^8.0.1
         version: 8.0.1(@swc/core@1.4.0)(typescript@5.5.3)
       typescript:
-        specifier: ^5.4.4
+        specifier: 5.5.3
         version: 5.5.3
       zod:
         specifier: ^3.22.4
@@ -3466,7 +3466,7 @@ importers:
         specifier: ~2.6.2
         version: 2.6.3
       typescript:
-        specifier: ^5.4.4
+        specifier: 5.5.3
         version: 5.5.3
 
   tests/devtools-evm-hardhat-test:
@@ -3595,7 +3595,7 @@ importers:
         specifier: ^10.9.2
         version: 10.9.2(@swc/core@1.4.0)(@types/node@18.18.14)(typescript@5.5.3)
       typescript:
-        specifier: ^5.4.4
+        specifier: 5.5.3
         version: 5.5.3
 
   tests/devtools-evm-test:
@@ -3658,7 +3658,7 @@ importers:
         specifier: ^10.9.2
         version: 10.9.2(@swc/core@1.4.0)(@types/node@18.18.14)(typescript@5.5.3)
       typescript:
-        specifier: ^5.4.4
+        specifier: 5.5.3
         version: 5.5.3
 
   tests/export-deployments-test:
@@ -3724,7 +3724,7 @@ importers:
         specifier: ~2.6.2
         version: 2.6.2
       typescript:
-        specifier: ^5.4.4
+        specifier: 5.5.3
         version: 5.5.3
 
   tests/test-evm-node:
@@ -3739,7 +3739,7 @@ importers:
         specifier: ~2.6.2
         version: 2.6.2
       typescript:
-        specifier: ^5.4.4
+        specifier: 5.5.3
         version: 5.5.3
 
   tests/test-setup-devtools-evm-hardhat:
@@ -3796,7 +3796,7 @@ importers:
         specifier: ~8.0.1
         version: 8.0.1(ts-node@10.9.2)(typescript@5.5.3)
       typescript:
-        specifier: ^5.4.4
+        specifier: 5.5.3
         version: 5.5.3
 
   tests/ua-devtools-evm-hardhat-test:
@@ -3934,7 +3934,7 @@ importers:
         specifier: ~2.6.2
         version: 2.6.2
       typescript:
-        specifier: ^5.4.4
+        specifier: 5.5.3
         version: 5.5.3
 
   tests/ua-devtools-evm-hardhat-v1-test:
@@ -4078,7 +4078,7 @@ importers:
         specifier: ~2.6.2
         version: 2.6.2
       typescript:
-        specifier: ^5.4.4
+        specifier: 5.5.3
         version: 5.5.3
 
 packages:

--- a/tests/devtools-cli-test/package.json
+++ b/tests/devtools-cli-test/package.json
@@ -62,6 +62,6 @@
     "solidity-bytes-utils": "^0.8.2",
     "ts-node": "^10.9.2",
     "tslib": "~2.6.2",
-    "typescript": "^5.4.4"
+    "typescript": "5.5.3"
   }
 }

--- a/tests/devtools-evm-hardhat-test/package.json
+++ b/tests/devtools-evm-hardhat-test/package.json
@@ -58,6 +58,6 @@
     "jest-extended": "^4.0.2",
     "solidity-bytes-utils": "^0.8.2",
     "ts-node": "^10.9.2",
-    "typescript": "^5.4.4"
+    "typescript": "5.5.3"
   }
 }

--- a/tests/devtools-evm-test/package.json
+++ b/tests/devtools-evm-test/package.json
@@ -36,6 +36,6 @@
     "hardhat": "^2.22.10",
     "jest": "^29.7.0",
     "ts-node": "^10.9.2",
-    "typescript": "^5.4.4"
+    "typescript": "5.5.3"
   }
 }

--- a/tests/export-deployments-test/package.json
+++ b/tests/export-deployments-test/package.json
@@ -37,6 +37,6 @@
     "solidity-bytes-utils": "^0.8.2",
     "ts-node": "^10.9.2",
     "tslib": "~2.6.2",
-    "typescript": "^5.4.4"
+    "typescript": "5.5.3"
   }
 }

--- a/tests/test-evm-node/package.json
+++ b/tests/test-evm-node/package.json
@@ -22,6 +22,6 @@
     "hardhat": "^2.22.10",
     "ts-node": "^10.9.2",
     "tslib": "~2.6.2",
-    "typescript": "^5.4.4"
+    "typescript": "5.5.3"
   }
 }

--- a/tests/test-setup-devtools-evm-hardhat/package.json
+++ b/tests/test-setup-devtools-evm-hardhat/package.json
@@ -47,7 +47,7 @@
     "ts-node": "^10.9.2",
     "tslib": "~2.6.2",
     "tsup": "~8.0.1",
-    "typescript": "^5.4.4"
+    "typescript": "5.5.3"
   },
   "peerDependencies": {
     "@ethersproject/providers": "^5.7.2",

--- a/tests/ua-devtools-evm-hardhat-test/package.json
+++ b/tests/ua-devtools-evm-hardhat-test/package.json
@@ -61,6 +61,6 @@
     "solidity-bytes-utils": "^0.8.2",
     "ts-node": "^10.9.2",
     "tslib": "~2.6.2",
-    "typescript": "^5.4.4"
+    "typescript": "5.5.3"
   }
 }

--- a/tests/ua-devtools-evm-hardhat-v1-test/package.json
+++ b/tests/ua-devtools-evm-hardhat-v1-test/package.json
@@ -63,6 +63,6 @@
     "solidity-bytes-utils": "^0.8.2",
     "ts-node": "^10.9.2",
     "tslib": "~2.6.2",
-    "typescript": "^5.4.4"
+    "typescript": "5.5.3"
   }
 }


### PR DESCRIPTION
Fix for the bug:

Environment:
```
MacOS
node.js v20.11.0
```
How to reproduce:
```bash
git clone --recurse-submodules https://github.com/LayerZero-Labs/devtools.git 
cd devtools
pnpm i
pnpm -r build # pnpm build doesn't work because of some io-devtools error
```
Error:
```
packages/verify-contract prebuild$ tsc -noEmit
│ tsconfig.json(5,5): error TS5069: Option 'declarationMap' cannot be specified without specifying option 'declaration' or option 'composite'.
└─ Failed in 1.1s at /Users/danielkmak/projects/devtools-2/packages/verify-contract
```
Full error log: https://gist.github.com/DanL0/2e0afc5b16f4d0731725e7fe7dd9249f