### PR TITLE
feat(oft-solana/wire task): error when no solana secret key passed in

### DIFF
--- a/examples/oft-solana/tasks/common/wire.ts
+++ b/examples/oft-solana/tasks/common/wire.ts
@@ -70,14 +70,13 @@ task(TASK_LZ_OAPP_WIRE)
         //
         //
 
-        if (args.solanaSecretKey == null) {
-            logger.warn(
-                `Missing --solana-secret-key CLI argument. A random keypair will be generated and interaction with solana programs will not be possible`
-            )
+        if (!args.solanaSecretKey) {
+            logger.error('Missing --solana-secret-key CLI argument.')
+            return
         }
 
         // The first step is to create the user Keypair from the secret passed in
-        const wallet = args.solanaSecretKey ?? Keypair.generate()
+        const wallet = args.solanaSecretKey
         const userAccount = wallet.publicKey
 
         // Then we grab the programId from the args


### PR DESCRIPTION
- In wire task, current behavior is to warn (easily overlooked) when no `--solana-secret-key` is passed in and generate a random keypair. This does not make sense and leads to confusion as the resulting error of `Attempt to debit an account but found no record of a prior credit.` is obscure.
- updated behavior: throw error when no`--solana-secret-key` is provided