### PR TITLE
fix: update to refer to QuickNode dashboard

### DIFF
--- a/examples/oft-solana/README.md
+++ b/examples/oft-solana/README.md
@@ -172,7 +172,7 @@ This section only applies if you are unable to land your deployment transaction 
 sh -c "$(curl -sSfL https://release.solana.com/v1.18.26/install)"
 ```
 
-You can run `npx hardhat lz:solana:get-priority-fees --eid <SOLANA_EID> --address <PROGRAM_ID>` and use the `averageFeeExcludingZeros` value.
+You can run refer QuickNode's [Solana Priority Fee Tracker](https://www.quicknode.com/gas-tracker/solana) to know what value you'd need to pass into the `--with-compute-unit-price` flag.
 
 :information_source: The average is calculated from getting the prioritization fees across recent blocks, but some blocks may have `0` as the prioritization fee. `averageFeeExcludingZeros` ignores blocks with `0` prioritization fees.
 


### PR DESCRIPTION
1. existing script to get prioritization fees is a hit and miss (a lot of misses)
2. some partners have recently been blocked due to the script returning 0 for all values
3. the existing script is ideal for when we want to send transactions that write to an account that already exists, but not for deploying programs