### PR TITLE
feat(oft-solana): if only oft store, set freeze authority immediately to none

### DIFF
--- a/examples/oft-solana/README.md
+++ b/examples/oft-solana/README.md
@@ -196,7 +196,7 @@ sh -c "$(curl -sSfL https://release.solana.com/v1.17.31/install)"
 
 :information_source: For **OFT** and **OFT Mint-And-Burn Adapter**, you have the option to specify additional signers through the `--additional-minters` flag. If you choose not to, you must pass in `--only-oft-store true`, which means only the **OFT Store** will be a signer for the \_Mint Authority Multisig\*.
 
-:warning: If you choose to go with `--only-oft-store`, you will not be able to add in other signers/minters or update the Mint Authority. You will also not be able to renounce the Freeze Authority. The Mint Authority and Freeze Authority will be fixed to the Mint Authority Multisig address.
+:warning: If you choose to go with `--only-oft-store`, you will not be able to add in other signers/minters or update the Mint Authority, and the Freeze Authority will be immediately renounced. The token Mint Authority will be fixed Mint Authority Multisig address while the Freeze Authority will be set to None.
 
 #### For OFT:
 

--- a/examples/oft-solana/tasks/solana/createOFT.ts
+++ b/examples/oft-solana/tasks/solana/createOFT.ts
@@ -178,9 +178,11 @@ task('lz:oft:solana:create', 'Mints new SPL Token and creates new OFT Store acco
                 }
             }
 
-            await promptToContinue(
-                'You have chosen `--only-oft-store true`. This means that only the OFT Store will be able to mint new tokens and that the Freeze Authority will be immediately renounced.  Continue?'
-            )
+            if (onlyOftStore) {
+                await promptToContinue(
+                    'You have chosen `--only-oft-store true`. This means that only the OFT Store will be able to mint new tokens and that the Freeze Authority will be immediately renounced.  Continue?'
+                )
+            }
 
             const additionalMinters = additionalMintersAsStrings?.map((minter) => new PublicKey(minter)) ?? []
             const mintAuthorityPublicKey = await createMintAuthorityMultisig(


### PR DESCRIPTION
Currently, if a Solana OFT is created with `--only-oft-store true`, the Freeze Authority for the token is set to the Multisig Account. Most projects would like the Freeze Authority to be renounced. We should have this as the default when `--only-oft-store true` is selected.

I tested on devnet:

```
pnpm hardhat lz:oft:solana:create --eid 40168 --program-id CAVtbZAtbkerztLHC6Xary6KDmgdNnv1cDBEctVdNEY2 --only-oft-store true
bigint: Failed to load bindings, pure JS will be used (try npm run rebuild?)
(node:15320) [DEP0040] DeprecationWarning: The `punycode` module is deprecated. Please use a userland alternative instead.
(Use `node --trace-deprecation ...` to show where the warning was created)
✔ You have chosen `--only-oft-store true`. This means that only the OFT Store will be able to mint new tokens and that the Freeze Authority will be immediately renounced.  Continue? … yes
created SPL multisig @ 8P6W1bXHXDDWNGft2gnQSZ5St9apxKn57baDdqG1gg4D
createTokenTx: https://explorer.solana.com/tx/dzwM1x3z8oma1Nn6auYVzyMbUJNMNfmyntfzA8dBzQ6VKxSHYzD9Y5NsMayR6wbPHtx8eUWDrWKwh7yM38dvZhL?cluster=devnet
initOftTx: https://explorer.solana.com/tx/3UyNdN2Fy8aF8Qc8zUZDRZGtsJVUxFcgFaXvtG8C5UVaSRvQGfQjWx9NysB9j816TfCjzZsfgVWU5GJcwdfjExyz?cluster=devnet
setAuthorityTx: https://explorer.solana.com/tx/5KVxytk8zNGc3PhoveiNCUNGnSHcDsxrMVXX5fopG13rtuE8PjRGbotQvn9Ck6G4yFFnLS6P6ZACoQjSPgxb8SEv?cluster=devnet
Accounts have been saved to ./deployments/solana-testnet/OFT.json`
```
Mint Authority set to the multisig, Freeze Authority set to None.

also tested that `--additional-minters` is still working as expected
```
pnpm hardhat lz:oft:solana:create --eid 40168 --program-id CAVtbZAtbkerztLHC6Xary6KDmgdNnv1cDBEctVdNEY2 --additional-minters EKXXXF8kzh4Bnq1HBHVwZgA5egJJWLDYqXmJTQtbbd5D 
bigint: Failed to load bindings, pure JS will be used (try npm run rebuild?)
(node:30274) [DEP0040] DeprecationWarning: The `punycode` module is deprecated. Please use a userland alternative instead.
(Use `node --trace-deprecation ...` to show where the warning was created)
created SPL multisig @ CWuouYYNd3wW7uP1nQTHDNQKmXChUNPZNxrqp3j1SPbv
createTokenTx: https://explorer.solana.com/tx/5nWGG2y7VL6xm1whZSNJ2mStrFtWf2nD1cfwsuyahMSbTNgocuT8XSrbYSiYn5qHfAsPTcctZHEnYfYiMLMGRsqn?cluster=devnet
initOftTx: https://explorer.solana.com/tx/3eocokWgH94oyMfSn7ZZHzjUDwxEacvPRMogMtq7euE7kK7N8ShrcJShXWjC6FAvDJz8kRbHPBxH2pBAbrhGWciK?cluster=devnet
setAuthorityTx: https://explorer.solana.com/tx/61W1J9GoTTpYNN5CxTETSFQQ1BvrpHppcf1BF6rYR6wiNEdGNtWrHQwEk1ytbynqJVFkyZL4yZSd3hjYsu7JCJmc?cluster=devnet
Accounts have been saved to ./deployments/solana-testnet/OFT.json
```
Mint Authority and Freeze Authority are set to the multisig wallet, which has 2 signers: OFT Store and the address I specified in additional minters.