### PR TITLE
🪲 config get regression

### DIFF
--- a/.changeset/bright-beds-train.md
+++ b/.changeset/bright-beds-train.md
@@ -1,0 +1,5 @@
+---
+"@layerzerolabs/ua-devtools-evm-hardhat": patch
+---
+
+fix lz:oapp:config:get regression

--- a/packages/ua-devtools-evm-hardhat/src/tasks/oapp/config.get.ts
+++ b/packages/ua-devtools-evm-hardhat/src/tasks/oapp/config.get.ts
@@ -41,8 +41,8 @@ const action: ActionType<TaskArgs> = async ({ logLevel = 'info', oappConfig }, h
         const endpointV2Sdk = await oAppSdk.getEndpointSDK()
 
         // OApp User Set Config
-        const receiveCustomConfig = await getReceiveConfig(endpointV2Sdk, to.eid, to.address, true)
-        const sendCustomConfig = await getSendConfig(endpointV2Sdk, to.eid, to.address, true)
+        const receiveCustomConfig = await getReceiveConfig(endpointV2Sdk, to.eid, from.address, true)
+        const sendCustomConfig = await getSendConfig(endpointV2Sdk, to.eid, from.address, true)
         const [sendCustomLibrary, sendCustomUlnConfig, sendCustomExecutorConfig] = sendCustomConfig ?? []
         const [receiveCustomLibrary, receiveCustomUlnConfig] = receiveCustomConfig ?? []
 
@@ -53,8 +53,8 @@ const action: ActionType<TaskArgs> = async ({ logLevel = 'info', oappConfig }, h
         const [receiveDefaultLibrary, receiveDefaultUlnConfig] = receiveDefaultConfig ?? []
 
         // OApp Config
-        const receiveOAppConfig = await getReceiveConfig(endpointV2Sdk, to.eid, to.address)
-        const sendOAppConfig = await getSendConfig(endpointV2Sdk, to.eid, to.address)
+        const receiveOAppConfig = await getReceiveConfig(endpointV2Sdk, to.eid, from.address)
+        const sendOAppConfig = await getSendConfig(endpointV2Sdk, to.eid, from.address)
         const [sendOAppLibrary, sendOAppUlnConfig, sendOAppExecutorConfig] = sendOAppConfig ?? []
         const [receiveOAppLibrary, receiveOAppUlnConfig] = receiveOAppConfig ?? []
 


### PR DESCRIPTION
#988 introduced a regression where `to.address` is used when it should be `from.address`.  This caused inappropriate values to be returned to the CLI for the `lz:oapp:config:get` task only.  It did not affect the wiring task which did not suffer the same bug.

This was tested against a testnet deployed OFT to ensure proper functionality of the task was restored.