### PR TITLE
🪲 Solana EndpointV2SDK should use `delegate` as the `admin`

### DIFF
--- a/.changeset/green-trainers-scream.md
+++ b/.changeset/green-trainers-scream.md
@@ -1,0 +1,5 @@
+---
+"@layerzerolabs/protocol-devtools-solana": patch
+---
+
+Fix squads client to use correct delegate


### PR DESCRIPTION
Currently, the Solana EndpointV2SDK uses the local hot wallet as the `admin` all of the time.  Although this works well when the OFT is owned by an EOA, it is 100% incorrect after an alternative delegate has been set.

This change swaps in the `delegate` in appropriate places, fixing the bug.