### PR TITLE
add solana support to metadata-tools

### DIFF
--- a/.changeset/new-horses-pull.md
+++ b/.changeset/new-horses-pull.md
@@ -1,0 +1,5 @@
+---
+"@layerzerolabs/metadata-tools": minor
+---
+
+add solana support to metadata-tools

--- a/packages/metadata-tools/src/types.ts
+++ b/packages/metadata-tools/src/types.ts
@@ -26,7 +26,7 @@ export interface IMetadata {
             relayerV2?: { address: string }
             ultraLightNodeV2?: { address: string }
             nonceContract?: { address: string }
-            executor?: { address: string }
+            executor?: { address: string; pda?: string }
             deadDVN?: { address: string }
             endpointV2?: { address: string }
             sendUln302?: { address: string }

--- a/packages/metadata-tools/test/data/solana-mainnet.json
+++ b/packages/metadata-tools/test/data/solana-mainnet.json
@@ -1,6 +1,6 @@
 {
-  "created": "2024-12-12T03:31:22.000Z",
-  "updated": "2024-12-12T03:31:22.000Z",
+  "created": "2025-01-07T18:33:21.000Z",
+  "updated": "2025-01-07T18:33:21.000Z",
   "tableName": "layerzero-chain_metadata",
   "environment": "mainnet",
   "blockExplorers": [
@@ -17,7 +17,8 @@
         "address": "8ahPGPjEbpgGaZx2NV1iG5Shj7TDwvsjkEDcGWjt94TP"
       },
       "executor": {
-        "address": "AwrbHeCyniXaQhiJZkLhgWdUCteeWSGaSN1sTfLiY7xK"
+        "pda": "AwrbHeCyniXaQhiJZkLhgWdUCteeWSGaSN1sTfLiY7xK",
+        "address": "6doghB248px58JSSwG4qejQ46kFMW4AMj7vzJnWZHNZn"
       },
       "endpointV2": {
         "address": "76y77prsiCMvXMjuoZ5VRrhG5qYBrUMYTE5WgHqgjEn6"

--- a/packages/metadata-tools/test/data/solana-testnet.json
+++ b/packages/metadata-tools/test/data/solana-testnet.json
@@ -17,7 +17,8 @@
         "address": "8ahPGPjEbpgGaZx2NV1iG5Shj7TDwvsjkEDcGWjt94TP"
       },
       "executor": {
-        "address": "AwrbHeCyniXaQhiJZkLhgWdUCteeWSGaSN1sTfLiY7xK"
+        "pda": "AwrbHeCyniXaQhiJZkLhgWdUCteeWSGaSN1sTfLiY7xK",
+        "address": "6doghB248px58JSSwG4qejQ46kFMW4AMj7vzJnWZHNZn"
       },
       "endpointV2": {
         "address": "76y77prsiCMvXMjuoZ5VRrhG5qYBrUMYTE5WgHqgjEn6"


### PR DESCRIPTION
Offchain team returns now proper executor address in metadata endpoint, so we can make our metadata-tools package fully working for EVM <> Solana scenarios.

Generated config output confirmed by local test suite ([snapshot](https://github.com/LayerZero-Labs/devtools/blob/main/packages/metadata-tools/test/__snapshots__/config-metadata.test.ts.snap)).