### PR TITLE
compute price scaling in multisig creation

### DIFF
--- a/examples/oft-solana/tasks/solana/createOFT.ts
+++ b/examples/oft-solana/tasks/solana/createOFT.ts
@@ -13,7 +13,7 @@ import {
     publicKey,
     transactionBuilder,
 } from '@metaplex-foundation/umi'
-import { fromWeb3JsPublicKey, toWeb3JsKeypair, toWeb3JsPublicKey } from '@metaplex-foundation/umi-web3js-adapters'
+import { fromWeb3JsPublicKey, toWeb3JsPublicKey } from '@metaplex-foundation/umi-web3js-adapters'
 import { TOKEN_PROGRAM_ID } from '@solana/spl-token'
 import { PublicKey } from '@solana/web3.js'
 import bs58 from 'bs58'
@@ -187,10 +187,13 @@ task('lz:oft:solana:create', 'Mints new SPL Token and creates new OFT Store acco
             const additionalMinters = additionalMintersAsStrings?.map((minter) => new PublicKey(minter)) ?? []
             const mintAuthorityPublicKey = await createMintAuthorityMultisig(
                 connection,
-                toWeb3JsKeypair(umiWalletKeyPair),
+                umi,
+                eid,
+                umiWalletSigner,
                 toWeb3JsPublicKey(oftStorePda),
                 toWeb3JsPublicKey(tokenProgramId), // Only configurable for MABA
-                additionalMinters
+                additionalMinters,
+                computeUnitPriceScaleFactor
             )
             console.log(`created SPL multisig @ ${mintAuthorityPublicKey.toBase58()}`)
             await checkMultisigSigners(connection, mintAuthorityPublicKey, [

--- a/examples/oft-solana/tasks/solana/setAuthority.ts
+++ b/examples/oft-solana/tasks/solana/setAuthority.ts
@@ -135,10 +135,13 @@ task('lz:oft:solana:setauthority', 'Create a new Mint Authority SPL multisig and
             const mint = new PublicKey(mintStr)
             const newMintAuthority = await createMintAuthorityMultisig(
                 connection,
-                toWeb3JsKeypair(umiWalletSigner),
+                umi,
+                eid,
+                umiWalletSigner,
                 new PublicKey(oftStorePda.toString()),
                 new PublicKey(tokenProgram.toString()),
-                additionalMinters
+                additionalMinters,
+                computeUnitPriceScaleFactor
             )
             console.log(`New Mint Authority: ${newMintAuthority.toBase58()}`)
             const signers = await checkMultisigSigners(connection, newMintAuthority, [


### PR DESCRIPTION
Testing:
```
LZ_ENABLE_SOLANA_OFT_EXAMPLE=1 LAYERZERO_EXAMPLES_REPOSITORY_REF=#fix/compute-price-multisig-creation npx create-lz-oapp@latest
```

Test OFT with only OFT store = true:
multisig: https://explorer.solana.com/address/5dnMbnXh9zGNNCcviCndF6eR45RLUfagRqbNXZwz8Zjw?cluster=devnet (it can be seen it correctly has only oftStore as signer)
deployment:
```
{
    "programId": "EiLAuRV68vj8KLQ6JuRQVs78hQRszcYHVz2fEYtnd3Yv",
    "mint": "CjeHnKTgAoc6gLmdWcfrRE5FERj1F6JsnaN9d2rFpq8r",
    "mintAuthority": "5dnMbnXh9zGNNCcviCndF6eR45RLUfagRqbNXZwz8Zjw",
    "escrow": "HcgW66FnUS22bhqVQfjAFUhW64QaejHXBTHmcPsq3hBZ",
    "oftStore": "GmLWtaEk3atQDppohN8QAVpBzXJHAUJj5canshRWbXZ6"
}
```

Another create oft run to check if compute price is now applied correctly (manually added logs):
```
➜  solana-msig-cp git:(master) ✗ pnpm hardhat lz:oft:solana:create --eid 40168 --program-id EiLAuRV68vj8KLQ6JuRQVs78hQRszcYHVz2fEYtnd3Yv --only-oft-store true   
bigint: Failed to load bindings, pure JS will be used (try npm run rebuild?)
✔ You have chosen `--only-oft-store true`. This means that only the OFT Store will be able to mint new tokens and that the Freeze Authority will be immediately renounced.  Continue? … yes
{ computeUnitPrice: 51009n, computeUnits: 2890 }
{ computeUnitPriceScaleFactor: 4, newComputeUnitPrice: 204036n }
createMultisigTx: https://solscan.io/tx/5WYS6XdzrAsEE9XjHNy2jiUnuW6dyTA7qH1R6sqUqwRRx2oSj5eD2DGL9tagg1togocPpLDR6QEqSCu9mpPi3xgH?cluster=devnet
created SPL multisig @ eCDXZFJeJjinHLu2KZFXVU3TffaZUKEQzqEvqweHq6K
{ computeUnitPrice: 69599n, computeUnits: 63489 }
{ computeUnitPriceScaleFactor: 4, newComputeUnitPrice: 278396n }
createTokenTx: https://solscan.io/tx/5BSARBkdMWHx1gqFqzgwztkM8XRq8k4qSDxKdKaVHZq45QDf51rzHrKwkipSrekzJ8wbrhDuRAPXfiHCfiXYxfYU?cluster=devnet
{ computeUnitPrice: 56268n, computeUnits: 60548 }
{ computeUnitPriceScaleFactor: 4, newComputeUnitPrice: 225072n }
initOftTx: https://solscan.io/tx/3phuXi3GXJrbsMg2v8rGnWoBxW3JiNSLdYJRQXURa1Be4spVQchg4qdRUzLKmav2Pog9wFXfkwogz1zMxhJ8auus?cluster=devnet
{ computeUnitPrice: 56616n, computeUnits: 6274 }
{ computeUnitPriceScaleFactor: 4, newComputeUnitPrice: 226464n }
setAuthorityTx: https://solscan.io/tx/3Qnn7m3oAbn1kzFpXHq1QfrkNtaLir648hzQGL4DpobozqFKXtMTHBPrcMbZTtEhPVQbmzWCH74493WuXtDZcB9W?cluster=devnet
Accounts have been saved to ./deployments/solana-testnet/OFT.json
...
{
    "programId": "EiLAuRV68vj8KLQ6JuRQVs78hQRszcYHVz2fEYtnd3Yv",
    "mint": "FXukpnGB1uk5WLmhZX4NTEEmxi7cY77o5ryZ3vXyVsg4",
    "mintAuthority": "eCDXZFJeJjinHLu2KZFXVU3TffaZUKEQzqEvqweHq6K",
    "escrow": "CZamGJH4zKsGY53DMfPq1mvxXYVQqEpcjph2aLxTznYw",
    "oftStore": "DSffpDmTMLv7hGN7g64zoqJzQJuDZJtUxNZ3mSrM71Zt"
}
```

can be seen applied correctly (https://solscan.io/tx/5WYS6XdzrAsEE9XjHNy2jiUnuW6dyTA7qH1R6sqUqwRRx2oSj5eD2DGL9tagg1togocPpLDR6QEqSCu9mpPi3xgH?cluster=devnet)
<img width="1028" alt="image" src="https://github.com/user-attachments/assets/8f1a06df-4c3d-4dde-b3e1-164d34345ea8" />

Another create OFT run with compute factor set to 1:
```
➜  solana-msig-cp git:(master) ✗ pnpm hardhat lz:oft:solana:create --eid 40168 --program-id EiLAuRV68vj8KLQ6JuRQVs78hQRszcYHVz2fEYtnd3Yv --only-oft-store true --compute-unit-price-scale-factor 1
bigint: Failed to load bindings, pure JS will be used (try npm run rebuild?)
✔ You have chosen `--only-oft-store true`. This means that only the OFT Store will be able to mint new tokens and that the Freeze Authority will be immediately renounced.  Continue? … yes
{ computeUnitPrice: 44387n, computeUnits: 2890 }
{ computeUnitPriceScaleFactor: 1, newComputeUnitPrice: 44387n }
createMultisigTx: https://solscan.io/tx/52gzJebpo1a4jvwWKBwyaeR1mNAD6sA3h76MpVJgoLxRDhQ5nqHk4EgZ3hiUrP5pGeoKVDBYcVHt1kRHJqxyH3uL?cluster=devnet
created SPL multisig @ APyBZAEgUXYvMr2SZwai2jNZha8MR5KC2xExT3YxmPFp
...
```
<img width="826" alt="image" src="https://github.com/user-attachments/assets/a1791c9a-e341-4260-9c1a-800b28c043d1" />

another run with additional minters:
```
➜  solana-msig-cp git:(master) ✗ pnpm hardhat lz:oft:solana:create --eid 40168 --program-id EiLAuRV68vj8KLQ6JuRQVs78hQRszcYHVz2fEYtnd3Yv --additional-minters Fty7h4FYAN7z8yjqaJExMHXbUoJYMcRjWYmggSxLbHp8 
bigint: Failed to load bindings, pure JS will be used (try npm run rebuild?)
{ computeUnitPrice: 57317n, computeUnits: 3080 }
{ computeUnitPriceScaleFactor: 4, newComputeUnitPrice: 229268n }
createMultisigTx: https://solscan.io/tx/3UcX9r7ZQeaS2ANLxQC2EfvHegd61eAv3HvFo96e2RdbDeN9PPmsNzWiXG5z4bWhd7AwYfsvGrncAkytmHjzoR8P?cluster=devnet
created SPL multisig @ DvehfJPQwd2yLJJxv5E6GQ9oqfKF9GosJDBiaa9oqyXp
{ computeUnitPrice: 70968n, computeUnits: 55989 }
{ computeUnitPriceScaleFactor: 4, newComputeUnitPrice: 283872n }
createTokenTx: https://solscan.io/tx/3EUXT2K8CcBtMoCmeWALmkjnn61ejC2D4LGp9eoVG4v2zqLkKZFiaNnZF69eVr82se7zPxqxxZ3sdRZaLA5QZQcu?cluster=devnet
{ computeUnitPrice: 62621n, computeUnits: 57548 }
{ computeUnitPriceScaleFactor: 4, newComputeUnitPrice: 250484n }
initOftTx: https://solscan.io/tx/3jrqyWv9xYkiyBJFfKxw6ueEYZFS1XH7WFvEncyxwrxQwWu5DPiXCkC55DKj53UpkBLrCZ3Ex3jpyPJ5aP9wAPrN?cluster=devnet
{ computeUnitPrice: 60115n, computeUnits: 6322 }
{ computeUnitPriceScaleFactor: 4, newComputeUnitPrice: 240460n }
setAuthorityTx: https://solscan.io/tx/3Qriak3rqH4gGGtn1g6yNDzUD7ZHDEiRrjTePJ2rxJtBvYWD37JuAskwjAnkNabiMbSYgYTahptuTSxWXnZFioA4?cluster=devnet
Accounts have been saved to ./deployments/solana-testnet/OFT.json
...
{
    "programId": "EiLAuRV68vj8KLQ6JuRQVs78hQRszcYHVz2fEYtnd3Yv",
    "mint": "DAhkJcN7LdePeQ7WsB7nVMRsCTmFnbx1mVwwmVDw5qSN",
    "mintAuthority": "DvehfJPQwd2yLJJxv5E6GQ9oqfKF9GosJDBiaa9oqyXp",
    "escrow": "BpteZEQnkYwbncy2wqHrogp5xG6smzzj86vwx9dnh6LC",
    "oftStore": "BscXC1BSVVj48HH1zJPPYHD6VJE1PoeV1cbh1An5T9wp"
}
```

test set authority to see if it works and uses compute unit price scaling factor correctly
```
➜  solana-msig-cp git:(master) ✗ pnpm hardhat lz:oft:solana:setauthority --eid 40168 --mint DAhkJcN7LdePeQ7WsB7nVMRsCTmFnbx1mVwwmVDw5qSN --program-id EiLAuRV68vj8KLQ6JuRQVs78hQRszcYHVz2fEYtnd3Yv --escrow BpteZEQnkYwbncy2wqHrogp5xG6smzzj86vwx9dnh6LC --additional-minters Fty7h4FYAN7z8yjqaJExMHXbUoJYMcRjWYmggSxLbHp8,6XUjWDp8VxdbofFMTwZEGftRBhafN7S4xo7GD6yGXmRH
bigint: Failed to load bindings, pure JS will be used (try npm run rebuild?)
{ computeUnitPrice: 55000n, computeUnits: 3271 }
{ computeUnitPriceScaleFactor: 4, newComputeUnitPrice: 220000n }
createMultisigTx: https://solscan.io/tx/5XMdVoGi63SDKhhvCwiqXVS2LQ7iMmfyB7Z2rYs9DhZpk7X8PVXUK6j5Z6jy7PBJ9jp8Rgy8SJmoK6X2DxMaPtvQ?cluster=devnet
New Mint Authority: 2Js7ow9PRTQeQ6SiYsL6wVmr9D6KJZMUuAJKs1cGgrDw
New Mint Authority Signers: BscXC1BSVVj48HH1zJPPYHD6VJE1PoeV1cbh1An5T9wp, Fty7h4FYAN7z8yjqaJExMHXbUoJYMcRjWYmggSxLbHp8, 6XUjWDp8VxdbofFMTwZEGftRBhafN7S4xo7GD6yGXmRH
Current MintTokens Authority: DvehfJPQwd2yLJJxv5E6GQ9oqfKF9GosJDBiaa9oqyXp
{ computeUnitPrice: 52500n, computeUnits: 3984 }
{ computeUnitPriceScaleFactor: 4, newComputeUnitPrice: 210000n }
SetAuthorityTx(MintTokens): https://solscan.io/tx/2xWdPJGo9fsD48gPAJDE99rcfLHbnUGyMdNVkvJeqsaTd3RqpARTB6hP7TcEUBDCZMmRE3JQZeq6moUFTY8mQnnD?cluster=devnet
Current FreezeAccount Authority: DvehfJPQwd2yLJJxv5E6GQ9oqfKF9GosJDBiaa9oqyXp
{ computeUnitPrice: 54423n, computeUnits: 4144 }
{ computeUnitPriceScaleFactor: 4, newComputeUnitPrice: 217692n }
SetAuthorityTx(FreezeAccount): https://solscan.io/tx/5EBM55o1cp4BNzDkThhNq1rLftHRDam5HK7BerzvmuQHXmwy6VrDNA9UQPUfTk4BbYuZctJHmetwbGkUUARHcSFe?cluster=devnet
```