### PR TITLE
🪲 rm unnecessary view

### DIFF
--- a/examples/oft-adapter-aptos-move/test/evm/foundry/MyOFT.t.sol
+++ b/examples/oft-adapter-aptos-move/test/evm/foundry/MyOFT.t.sol
@@ -62,7 +62,7 @@ contract MyOFTTest is TestHelperOz5 {
         deal(address(bOFT), userB, initialBalance);
     }
 
-    function test_constructor() public view {
+    function test_constructor() public {
         assertEq(aOFT.owner(), address(this));
         assertEq(bOFT.owner(), address(this));
 

--- a/examples/oft-aptos-move/test/evm/foundry/MyOFT.t.sol
+++ b/examples/oft-aptos-move/test/evm/foundry/MyOFT.t.sol
@@ -62,7 +62,7 @@ contract MyOFTTest is TestHelperOz5 {
         deal(address(bOFT), userB, initialBalance);
     }
 
-    function test_constructor() public view {
+    function test_constructor() public {
         assertEq(aOFT.owner(), address(this));
         assertEq(bOFT.owner(), address(this));
 


### PR DESCRIPTION
Fixes pnpm "compile" script for "oft-aptos-move" and "oft-adapter-aptos-move" examples.