### PR TITLE
Update DVNsToAddresses to filter out deprecated dvns

### DIFF
--- a/.changeset/strange-apricots-deny.md
+++ b/.changeset/strange-apricots-deny.md
@@ -1,0 +1,5 @@
+---
+"@layerzerolabs/metadata-tools": minor
+---
+
+Filter out deprecated DVN addresses

--- a/packages/metadata-tools/src/config-metadata.ts
+++ b/packages/metadata-tools/src/config-metadata.ts
@@ -46,7 +46,8 @@ export function DVNsToAddresses(dvns: string[], chainKey: string, metadata: IMet
         for (const [dvnAddress, dvnDetails] of metadataDVNs) {
             if (dvnDetails.canonicalName === dvn && !dvnDetails.lzReadCompatible && dvnDetails.version === 2) {
                 if (dvnDetails.deprecated) {
-                    console.log(`Warning: DVN "${dvn}" is deprecated.`)
+                    console.log(`Warning: DVN "${dvn}" is deprecated. Ignoring ...`)
+                    continue
                 }
 
                 dvnAddresses.push(dvnAddress)

--- a/packages/metadata-tools/src/config-metadata.ts
+++ b/packages/metadata-tools/src/config-metadata.ts
@@ -44,12 +44,12 @@ export function DVNsToAddresses(dvns: string[], chainKey: string, metadata: IMet
 
         let i = 0
         for (const [dvnAddress, dvnDetails] of metadataDVNs) {
-            if (dvnDetails.canonicalName === dvn && !dvnDetails.lzReadCompatible && dvnDetails.version === 2) {
-                if (dvnDetails.deprecated) {
-                    console.log(`Warning: DVN "${dvn}" is deprecated. Ignoring ...`)
-                    continue
-                }
-
+            if (
+                !dvnDetails.deprecated &&
+                dvnDetails.canonicalName === dvn &&
+                !dvnDetails.lzReadCompatible &&
+                dvnDetails.version === 2
+            ) {
                 dvnAddresses.push(dvnAddress)
                 break
             }

--- a/packages/metadata-tools/test/config-metadata.test.ts
+++ b/packages/metadata-tools/test/config-metadata.test.ts
@@ -112,5 +112,15 @@ describe('config-metadata', () => {
                 '0x8ddf05f9a5c488b4973897e278b58895bf87cb24',
             ])
         })
+
+        it('should ignore deprecated DVNs incase of multiple DVNs', () => {
+            expect(DVNsToAddresses(['Bitgo'], 'fuji', metadata)).toStrictEqual([
+                '0xa1d84e5576299acda9ffed53195eadbe60d48e83',
+            ])
+        })
+
+        it('should throw error if all DVNs are deprecated', () => {
+            expect(() => DVNsToAddresses(['Deprec'], 'fuji', metadata)).toThrow(`Can't find all DVNs: "Deprec".`)
+        })
     })
 })

--- a/packages/metadata-tools/test/config-metadata.test.ts
+++ b/packages/metadata-tools/test/config-metadata.test.ts
@@ -120,7 +120,9 @@ describe('config-metadata', () => {
         })
 
         it('should throw error if all DVNs are deprecated', () => {
-            expect(() => DVNsToAddresses(['Deprec'], 'fuji', metadata)).toThrow(`Can't find all DVNs: "Deprec".`)
+            expect(() => DVNsToAddresses(['Deprec'], 'fuji', metadata)).toThrow(
+                `Can't find DVN: "Deprec" on chainKey: "fuji". Double check you're using valid DVN canonical name (not an address).`
+            )
         })
     })
 })

--- a/packages/metadata-tools/test/data/fuji.json
+++ b/packages/metadata-tools/test/data/fuji.json
@@ -85,7 +85,8 @@
     "0x8ca279897cde74350bd880737fd60c047d6d3d64": {
       "version": 2,
       "canonicalName": "Bitgo",
-      "id": "bitgo"
+      "id": "bitgo",
+      "deprecated": true
     },
     "0x9f0e79aeb198750f963b6f30b99d87c6ee5a0467": {
       "version": 2,
@@ -136,6 +137,17 @@
       "version": 2,
       "canonicalName": "BWare",
       "id": "bware-labs"
+    },
+    "0xa1d84e5576299acda9ffed53195eadbe60d48e83": {
+      "version": 2,
+      "canonicalName": "Bitgo",
+      "id": "bitgo"
+    },
+    "0xb1c95f6687299acda9ffed53195eadcf71d49f94": {
+      "version": 2,
+      "canonicalName": "Deprec",
+      "id": "deprec",
+      "deprecated": true
     }
   },
   "rpcs": [


### PR DESCRIPTION
`metadata-tools` can be used in `layerzero.config.ts` to `generateConnectionsConfig`. However if deprecated DVNs are listed, they are not properly filtered out and running `pnpm hardhat lz:oapp:wire` sometimes wires up their oapp to the deprecated dvn which will cause transactions to be inflight indefinitely.
___
In https://metadata.layerzero-api.com/v1/metadata/deployments
we can see config like
```
"dvns": {
   "0x3ed2211f49ce343d70cb8ded927ca6c4a6198101": {
    "version": 2,
    "canonicalName": "Bitgo",
    "id": "bitgo"
   },
   "0xdd1da938b19614d6db8c3973c89908df234ad1ce": {
    "version": 2,
    "canonicalName": "IntellectEU"
   },
   "0xe67ef84173d024603a844c4aea6a3a15ccccc32c": {
    "version": 2,
    "canonicalName": "Blockdaemon",
    "id": "blockdaemon"
   },
   "0xd44e25bea2bedcceceb7e104d5843a55d208e8a9": {
    "version": 2,
    "canonicalName": "Japan Blockchain Foundation",
    "id": "joc"
   },
   "0x02feab4e6ca6eebd60d85347762de70ca9ce162a": {
    "id": "bitgo",
    "version": 2,
    "canonicalName": "Bitgo",
    "deprecated": true
   },
```
…
Here we see two different Bitgo entires, one is deprecated, one is not
However, when wiring up the paths using
`pnpm hardhat lz:oapp:wire` it doesn’t filter out the deprecated dvn
I faced this issue in https://scan-testnet.layerzero-api.com/v1/messages/tx/0x2cacc12e4a5c47fc8f51671aa32577773a22cee8aba83e240ec7af0fec98f290
where it tries to use the deprecated dvn `0x02feab4e6ca6eebd60d85347762de70ca9ce162a`
and fails verification causing transaction to be inflight indefinitely