### PR TITLE
feat(oft-solana): add fallback for when `getSimulationComputeUnits` fails

### DIFF
--- a/.changeset/swift-days-cheat.md
+++ b/.changeset/swift-days-cheat.md
@@ -1,0 +1,5 @@
+---
+"@layerzerolabs/oft-solana-example": minor
+---
+
+fallback for getSimulationComputeUnits

--- a/examples/oft-solana/tasks/solana/createOFT.ts
+++ b/examples/oft-solana/tasks/solana/createOFT.ts
@@ -27,7 +27,14 @@ import { OFT_DECIMALS as DEFAULT_SHARED_DECIMALS, oft, types } from '@layerzerol
 import { checkMultisigSigners, createMintAuthorityMultisig } from './multisig'
 import { assertAccountInitialized } from './utils'
 
-import { addComputeUnitInstructions, deriveConnection, deriveKeys, getExplorerTxLink, output } from './index'
+import {
+    TransactionType,
+    addComputeUnitInstructions,
+    deriveConnection,
+    deriveKeys,
+    getExplorerTxLink,
+    output,
+} from './index'
 
 const DEFAULT_LOCAL_DECIMALS = 9
 
@@ -245,7 +252,8 @@ task('lz:oft:solana:create', 'Mints new SPL Token and creates new OFT Store acco
                     eid,
                     txBuilder,
                     umiWalletSigner,
-                    computeUnitPriceScaleFactor
+                    computeUnitPriceScaleFactor,
+                    TransactionType.CreateToken
                 )
                 const createTokenTx = await txBuilder.sendAndConfirm(umi)
                 await assertAccountInitialized(connection, toWeb3JsPublicKey(mint.publicKey))
@@ -275,7 +283,8 @@ task('lz:oft:solana:create', 'Mints new SPL Token and creates new OFT Store acco
                 eid,
                 txBuilder,
                 umiWalletSigner,
-                computeUnitPriceScaleFactor
+                computeUnitPriceScaleFactor,
+                TransactionType.InitOft
             )
             const { signature } = await txBuilder.sendAndConfirm(umi)
             console.log(`initOftTx: ${getExplorerTxLink(bs58.encode(signature), isTestnet)}`)
@@ -304,7 +313,8 @@ task('lz:oft:solana:create', 'Mints new SPL Token and creates new OFT Store acco
                     eid,
                     txBuilder,
                     umiWalletSigner,
-                    computeUnitPriceScaleFactor
+                    computeUnitPriceScaleFactor,
+                    TransactionType.SetAuthority
                 )
                 const { signature } = await txBuilder.sendAndConfirm(umi)
                 console.log(`setAuthorityTx: ${getExplorerTxLink(bs58.encode(signature), isTestnet)}`)

--- a/examples/oft-solana/tasks/solana/createOFTAdapter.ts
+++ b/examples/oft-solana/tasks/solana/createOFTAdapter.ts
@@ -8,7 +8,14 @@ import { types as devtoolsTypes } from '@layerzerolabs/devtools-evm-hardhat'
 import { EndpointId } from '@layerzerolabs/lz-definitions'
 import { OFT_DECIMALS, oft, types } from '@layerzerolabs/oft-v2-solana-sdk'
 
-import { addComputeUnitInstructions, deriveConnection, deriveKeys, getExplorerTxLink, output } from './index'
+import {
+    TransactionType,
+    addComputeUnitInstructions,
+    deriveConnection,
+    deriveKeys,
+    getExplorerTxLink,
+    output,
+} from './index'
 
 interface CreateOFTAdapterTaskArgs {
     /**
@@ -81,7 +88,8 @@ task('lz:oft-adapter:solana:create', 'Creates new OFT Adapter (OFT Store PDA)')
                 eid,
                 txBuilder,
                 umiWalletSigner,
-                computeUnitPriceScaleFactor
+                computeUnitPriceScaleFactor,
+                TransactionType.InitOft
             )
             const { signature } = await txBuilder.sendAndConfirm(umi)
             console.log(`initOftTx: ${getExplorerTxLink(bs58.encode(signature), eid == EndpointId.SOLANA_V2_TESTNET)}`)

--- a/examples/oft-solana/tasks/solana/index.ts
+++ b/examples/oft-solana/tasks/solana/index.ts
@@ -166,7 +166,7 @@ export enum TransactionType {
 
 const TransactionCuEstimates: Record<TransactionType, number> = {
     // for the sample values, they are: devnet, mainnet
-    [TransactionType.CreateToken]: 70_000, // actual sample: 59073, 55785
+    [TransactionType.CreateToken]: 125_000, // actual sample: (59073, 123539), 55785 (more volatile as it has CPI to Metaplex)
     [TransactionType.CreateMultisig]: 5_000, // actual sample: 3,230
     [TransactionType.InitOft]: 70_000, // actual sample: 59207, 65198 (note: this is the only transaction that createOFTAdapter does)
     [TransactionType.SetAuthority]: 8_000, // actual sample: 6424, 6472

--- a/examples/oft-solana/tasks/solana/index.ts
+++ b/examples/oft-solana/tasks/solana/index.ts
@@ -155,22 +155,54 @@ export const getAddressLookupTable = async (connection: Connection, umi: Umi, fr
     }
 }
 
+export enum TransactionType {
+    CreateToken,
+    CreateTokenAdapter,
+    CreateMultisig,
+    InitOft,
+    SetAuthority,
+    InitConfig,
+    SendOFT,
+}
+
+const TransactionCuEstimates: Record<TransactionType, number> = {
+    // for the sample values, they are: devnet, mainnet
+    [TransactionType.CreateToken]: 70_000, // actual sample: 59073, 55785
+    [TransactionType.CreateTokenAdapter]: 70_000, // TBC
+    [TransactionType.CreateMultisig]: 70_000, // TBC
+    [TransactionType.InitOft]: 70_000, // actual sample: 59207, 65198
+    [TransactionType.SetAuthority]: 8_000, // actual sample: 6424, 6472
+    [TransactionType.InitConfig]: 42_000, // actual sample: 33157, 40657
+    [TransactionType.SendOFT]: 230_000, // actual sample: 217,784
+}
+
 export const getComputeUnitPriceAndLimit = async (
     connection: Connection,
     ixs: Instruction[],
     wallet: KeypairSigner,
-    lookupTableAccount: AddressLookupTableAccount
+    lookupTableAccount: AddressLookupTableAccount,
+    transactionType: TransactionType
 ) => {
     const { averageFeeExcludingZeros } = await getFee(connection)
     const priorityFee = Math.round(averageFeeExcludingZeros)
     const computeUnitPrice = BigInt(priorityFee)
 
-    const computeUnits = await getSimulationComputeUnits(
-        connection,
-        ixs.map((ix) => toWeb3JsInstruction(ix)),
-        toWeb3JsPublicKey(wallet.publicKey),
-        [lookupTableAccount]
-    )
+    let computeUnits
+
+    try {
+        computeUnits = await getSimulationComputeUnits(
+            connection,
+            ixs.map((ix) => toWeb3JsInstruction(ix)),
+            toWeb3JsPublicKey(wallet.publicKey),
+            [lookupTableAccount]
+        )
+    } catch (e) {
+        console.error(`Error retrieving simulations compute units from RPC:`, e)
+        console.log(
+            `Falling back to hardcoded estimate for ${transactionType}: ${TransactionCuEstimates[transactionType]} CUs`
+        )
+        computeUnits = TransactionCuEstimates[transactionType]
+    }
 
     if (!computeUnits) {
         throw new Error('Unable to compute units')
@@ -188,7 +220,8 @@ export const addComputeUnitInstructions = async (
     eid: EndpointId,
     txBuilder: TransactionBuilder,
     umiWalletSigner: KeypairSigner,
-    computeUnitPriceScaleFactor: number
+    computeUnitPriceScaleFactor: number,
+    transactionType: TransactionType
 ) => {
     const computeUnitLimitScaleFactor = 1.1 // hardcoded to 1.1 as the estimations are not perfect and can fall slightly short of the actual CU usage on-chain
     const { addressLookupTableInput, lookupTableAccount } = await getAddressLookupTable(connection, umi, eid)
@@ -196,7 +229,8 @@ export const addComputeUnitInstructions = async (
         connection,
         txBuilder.getInstructions(),
         umiWalletSigner,
-        lookupTableAccount
+        lookupTableAccount,
+        transactionType
     )
     // Since transaction builders are immutable, we must be careful to always assign the result of the add and prepend
     // methods to a new variable.

--- a/examples/oft-solana/tasks/solana/index.ts
+++ b/examples/oft-solana/tasks/solana/index.ts
@@ -156,18 +156,18 @@ export const getAddressLookupTable = async (connection: Connection, umi: Umi, fr
 }
 
 export enum TransactionType {
-    CreateToken,
-    CreateMultisig,
-    InitOft,
-    SetAuthority,
-    InitConfig,
-    SendOFT,
+    CreateToken = 'CreateToken',
+    CreateMultisig = 'CreateMultisig',
+    InitOft = 'InitOft',
+    SetAuthority = 'SetAuthority',
+    InitConfig = 'InitConfig',
+    SendOFT = 'SendOFT',
 }
 
 const TransactionCuEstimates: Record<TransactionType, number> = {
     // for the sample values, they are: devnet, mainnet
     [TransactionType.CreateToken]: 70_000, // actual sample: 59073, 55785
-    [TransactionType.CreateMultisig]: 70_000, // TBC
+    [TransactionType.CreateMultisig]: 5_000, // actual sample: 3,230
     [TransactionType.InitOft]: 70_000, // actual sample: 59207, 65198 (note: this is the only transaction that createOFTAdapter does)
     [TransactionType.SetAuthority]: 8_000, // actual sample: 6424, 6472
     [TransactionType.InitConfig]: 42_000, // actual sample: 33157, 40657

--- a/examples/oft-solana/tasks/solana/index.ts
+++ b/examples/oft-solana/tasks/solana/index.ts
@@ -29,6 +29,7 @@ import bs58 from 'bs58'
 import { backOff } from 'exponential-backoff'
 
 import { formatEid } from '@layerzerolabs/devtools'
+import { promptToContinue } from '@layerzerolabs/io-devtools'
 import { EndpointId, endpointIdToNetwork } from '@layerzerolabs/lz-definitions'
 import { OftPDA } from '@layerzerolabs/oft-v2-solana-sdk'
 
@@ -204,6 +205,14 @@ export const getComputeUnitPriceAndLimit = async (
         )
     } catch (e) {
         console.error(`Error retrieving simulations compute units from RPC:`, e)
+        const continueByUsingHardcodedEstimate = await promptToContinue(
+            'Failed to call simulateTransaction on the RPC. This can happen when the network is congested. Would you like to use hardcoded estimates (TransactionCuEstimates) ? This may result in slightly overpaying for the transaction.'
+        )
+        if (!continueByUsingHardcodedEstimate) {
+            throw new Error(
+                'Failed to call simulateTransaction on the RPC and user chose to not continue with hardcoded estimate.'
+            )
+        }
         console.log(
             `Falling back to hardcoded estimate for ${transactionType}: ${TransactionCuEstimates[transactionType]} CUs`
         )

--- a/examples/oft-solana/tasks/solana/index.ts
+++ b/examples/oft-solana/tasks/solana/index.ts
@@ -157,7 +157,6 @@ export const getAddressLookupTable = async (connection: Connection, umi: Umi, fr
 
 export enum TransactionType {
     CreateToken,
-    CreateTokenAdapter,
     CreateMultisig,
     InitOft,
     SetAuthority,
@@ -168,9 +167,8 @@ export enum TransactionType {
 const TransactionCuEstimates: Record<TransactionType, number> = {
     // for the sample values, they are: devnet, mainnet
     [TransactionType.CreateToken]: 70_000, // actual sample: 59073, 55785
-    [TransactionType.CreateTokenAdapter]: 70_000, // TBC
     [TransactionType.CreateMultisig]: 70_000, // TBC
-    [TransactionType.InitOft]: 70_000, // actual sample: 59207, 65198
+    [TransactionType.InitOft]: 70_000, // actual sample: 59207, 65198 (note: this is the only transaction that createOFTAdapter does)
     [TransactionType.SetAuthority]: 8_000, // actual sample: 6424, 6472
     [TransactionType.InitConfig]: 42_000, // actual sample: 33157, 40657
     [TransactionType.SendOFT]: 230_000, // actual sample: 217,784

--- a/examples/oft-solana/tasks/solana/multisig.ts
+++ b/examples/oft-solana/tasks/solana/multisig.ts
@@ -15,7 +15,7 @@ import { EndpointId } from '@layerzerolabs/lz-definitions'
 
 import { assertAccountInitialized } from './utils'
 
-import { addComputeUnitInstructions, getExplorerTxLink } from '.'
+import { TransactionType, addComputeUnitInstructions, getExplorerTxLink } from '.'
 
 export async function createMultisig(
     connection: Connection,
@@ -58,7 +58,8 @@ export async function createMultisig(
             eid,
             txBuilder,
             umiWalletSigner,
-            computeUnitPriceScaleFactor
+            computeUnitPriceScaleFactor,
+            TransactionType.CreateMultisig
         )
     }
 

--- a/examples/oft-solana/tasks/solana/sendOFT.ts
+++ b/examples/oft-solana/tasks/solana/sendOFT.ts
@@ -10,7 +10,13 @@ import { EndpointId } from '@layerzerolabs/lz-definitions'
 import { addressToBytes32 } from '@layerzerolabs/lz-v2-utilities'
 import { oft } from '@layerzerolabs/oft-v2-solana-sdk'
 
-import { addComputeUnitInstructions, deriveConnection, getExplorerTxLink, getLayerZeroScanLink } from './index'
+import {
+    TransactionType,
+    addComputeUnitInstructions,
+    deriveConnection,
+    getExplorerTxLink,
+    getLayerZeroScanLink,
+} from './index'
 
 interface Args {
     amount: number
@@ -119,7 +125,8 @@ task('lz:oft:solana:send', 'Send tokens from Solana to a target EVM chain')
                 fromEid,
                 txBuilder,
                 umiWalletSigner,
-                computeUnitPriceScaleFactor
+                computeUnitPriceScaleFactor,
+                TransactionType.SendOFT
             )
             const { signature } = await txBuilder.sendAndConfirm(umi)
             const transactionSignatureBase58 = bs58.encode(signature)

--- a/examples/oft-solana/tasks/solana/setAuthority.ts
+++ b/examples/oft-solana/tasks/solana/setAuthority.ts
@@ -11,7 +11,7 @@ import { OftPDA } from '@layerzerolabs/oft-v2-solana-sdk'
 
 import { checkMultisigSigners, createMintAuthorityMultisig } from './multisig'
 
-import { addComputeUnitInstructions, deriveConnection, getExplorerTxLink } from './index'
+import { TransactionType, addComputeUnitInstructions, deriveConnection, getExplorerTxLink } from './index'
 
 interface SetAuthorityTaskArgs {
     /**
@@ -194,7 +194,8 @@ task('lz:oft:solana:setauthority', 'Create a new Mint Authority SPL multisig and
                     eid,
                     txBuilder,
                     umiWalletSigner,
-                    computeUnitPriceScaleFactor
+                    computeUnitPriceScaleFactor,
+                    TransactionType.SetAuthority
                 )
                 const { signature } = await txBuilder.sendAndConfirm(umi)
                 console.log(


### PR DESCRIPTION
## Motivation
We've found that in times of network congestion, the RPC method that supports the `getSimulationComputeUnits` function would fail, resulting in scripts being stuck as every transaction currently relies on `getSimulationComputeUnits`.  This blocks the deployment of Solana OFTs.

## Solution
Given that as part of a Solana OFT deployment, we are executing a standard set of instructions, we can introduce a fallback by way of hardcoded CU estimates for each transaction type. The following is introduced into `examples/oft-solana/tasks/solana/index.ts`:

```
export enum TransactionType {
    CreateToken = 'CreateToken',
    CreateMultisig = 'CreateMultisig',
    InitOft = 'InitOft',
    SetAuthority = 'SetAuthority',
    InitConfig = 'InitConfig',
    SendOFT = 'SendOFT',
}

const TransactionCuEstimates: Record<TransactionType, number> = {
    // for the sample values, they are: devnet, mainnet
    [TransactionType.CreateToken]: 125_000, // actual sample: (59073, 123539), 55785 (more volatile as it has CPI to Metaplex)
    [TransactionType.CreateMultisig]: 5_000, // actual sample: 3,230
    [TransactionType.InitOft]: 70_000, // actual sample: 59207, 65198 (note: this is the only transaction that createOFTAdapter does)
    [TransactionType.SetAuthority]: 8_000, // actual sample: 6424, 6472
    [TransactionType.InitConfig]: 42_000, // actual sample: 33157, 40657
    [TransactionType.SendOFT]: 230_000, // actual sample: 217,784
}
```

We use the fallback in `getComputeUnitPriceAndLimit`:

```
...
export const getComputeUnitPriceAndLimit = async (
    connection: Connection,
    ixs: Instruction[],
    wallet: KeypairSigner,
    lookupTableAccount: AddressLookupTableAccount,
    transactionType: TransactionType
) => {
    const { averageFeeExcludingZeros } = await getFee(connection)
    const priorityFee = Math.round(averageFeeExcludingZeros)
    const computeUnitPrice = BigInt(priorityFee)

    let computeUnits

    try {
        computeUnits = await getSimulationComputeUnits(
            connection,
            ixs.map((ix) => toWeb3JsInstruction(ix)),
            toWeb3JsPublicKey(wallet.publicKey),
            [lookupTableAccount]
        )
    } catch (e) {
        console.error(`Error retrieving simulations compute units from RPC:`, e)
        console.log(
            `Falling back to hardcoded estimate for ${transactionType}: ${TransactionCuEstimates[transactionType]} CUs`
        )
        computeUnits = TransactionCuEstimates[transactionType]
    }
    ...
```

Notes:

- The transaction with the most volatile CU count is `createToken` as it has CPIs into the Metaplex program. More basic transactions like `setAuthority` have more stable CU count.
- Estimates may need to be updated if they are found to be insufficient.
- Based on errors reported recently, `getSimulationComputeUnits` (to estimate CU limit) is the one failing and not `getRecentPrioritizationFees` (rpc method to estimate CU price)

## Testing

To test, init a new repo with the following: 
```
LAYERZERO_EXAMPLES_REPOSITORY_REF=#nazreen/oft-solana/get-simulation-cu-constants LZ_ENABLE_SOLANA_OFT_EXAMPLE=1 npx create-lz-oapp@latest
```

To simulate the `getSimulationComputeUnits` method failing in times of RPC congestion, make the following temporary edit to the try block of `getSimulationComputeUnits` in`examples/oft-solana/tasks/solana/index.ts`:

```
    try {
        computeUnits = await backOff(
            () => {
                console.log('attempting to call RPC method') <-- this should be logged N times, where N is the numOfAttempts value
                throw 'Simulating Error' <--
                return getSimulationComputeUnits(
                    connection,
                    ixs.map((ix) => toWeb3JsInstruction(ix)),
                    toWeb3JsPublicKey(wallet.publicKey),
                    [lookupTableAccount]
                )
            },
            {
                maxDelay: 3000,
                numOfAttempts: 3,
            }
        )
    } 
```

Then, run any of the Solana scripts, such as

```
pnpm hardhat lz:oft:solana:create --eid 40168 --program-id <PROGRAM_ID> --only-oft-store true --amount 10000000000
```

You should then see the following prompt:

```
Failed to call simulateTransaction on the RPC. This can happen when the network is congested. Would you like to use hardcoded estimates (TransactionCuEstimates) ? This may result in slightly overpaying for the transaction. › (Y/n)
```