### PR TITLE
add a jest-only target to make snapshot tests easier to run

### DIFF
--- a/.changeset/selfish-chairs-roll.md
+++ b/.changeset/selfish-chairs-roll.md
@@ -1,0 +1,22 @@
+---
+"@layerzerolabs/ua-devtools-evm-hardhat-v1-test": patch
+"@layerzerolabs/protocol-devtools-evm": patch
+"@layerzerolabs/devtools-evm-hardhat": patch
+"@layerzerolabs/export-deployments-test": patch
+"@layerzerolabs/export-deployments": patch
+"@layerzerolabs/protocol-devtools": patch
+"@layerzerolabs/devtools-solana": patch
+"@layerzerolabs/ua-devtools-evm": patch
+"@layerzerolabs/verify-contract": patch
+"@layerzerolabs/build-devtools": patch
+"create-lz-oapp": patch
+"@layerzerolabs/metadata-tools": patch
+"@layerzerolabs/devtools-cli-test": patch
+"@layerzerolabs/devtools-evm-test": patch
+"@layerzerolabs/devtools-evm": patch
+"@layerzerolabs/io-devtools": patch
+"@layerzerolabs/ua-devtools": patch
+"@layerzerolabs/devtools": patch
+---
+
+add "test:jest" script

--- a/package.json
+++ b/package.json
@@ -21,7 +21,9 @@
     "stop": "docker compose down",
     "test": "$npm_execpath turbo run test $DOCKER_COMPOSE_RUN_TESTS_TURBO_ARGS",
     "test:ci": "docker compose run --build --rm $DOCKER_COMPOSE_ARGS tests",
+    "test:jest": "$npm_execpath turbo run test:jest $DOCKER_COMPOSE_RUN_TESTS_TURBO_ARGS",
     "test:local": ". bin/env && $npm_execpath start && $npm_execpath test",
+    "test:local:jest": ". bin/env && $npm_execpath start && $npm_execpath test:jest",
     "test:user": "docker compose -f docker-compose.registry.yaml run --build --rm $DOCKER_COMPOSE_ARGS tests"
   },
   "lint-staged": {

--- a/packages/build-devtools/package.json
+++ b/packages/build-devtools/package.json
@@ -35,7 +35,8 @@
     "dev": "$npm_execpath tsup --watch",
     "lint": "$npm_execpath eslint '**/*.{js,ts,json}'",
     "lint:fix": "eslint --fix '**/*.{js,ts,json}'",
-    "test": "jest --ci --runInBand"
+    "test": "$npm_execpath test:jest",
+    "test:jest": "jest --ci --runInBand"
   },
   "devDependencies": {
     "@swc/core": "^1.4.0",

--- a/packages/create-lz-oapp/package.json
+++ b/packages/create-lz-oapp/package.json
@@ -27,7 +27,8 @@
     "lint": "$npm_execpath eslint '**/*.{js,ts,json}'",
     "lint:fix": "eslint --fix '**/*.{js,ts,json}'",
     "start": "./cli.js",
-    "test": "jest --ci"
+    "test": "$npm_execpath test:jest",
+    "test:jest": "jest --ci"
   },
   "dependencies": {
     "yoga-layout-prebuilt": "^1.10.0"

--- a/packages/devtools-evm-hardhat/package.json
+++ b/packages/devtools-evm-hardhat/package.json
@@ -40,7 +40,8 @@
     "dev": "$npm_execpath tsup --watch",
     "lint": "$npm_execpath eslint '**/*.{js,ts,json}'",
     "lint:fix": "eslint --fix '**/*.{js,ts,json}'",
-    "test": "jest --ci --forceExit"
+    "test": "$npm_execpath test:jest",
+    "test:jest": "jest --ci --forceExit"
   },
   "dependencies": {
     "@layerzerolabs/export-deployments": "~0.0.12",

--- a/packages/devtools-evm/package.json
+++ b/packages/devtools-evm/package.json
@@ -33,7 +33,8 @@
     "dev": "$npm_execpath tsup --watch",
     "lint": "$npm_execpath eslint '**/*.{js,ts,json}'",
     "lint:fix": "eslint --fix '**/*.{js,ts,json}'",
-    "test": "jest --ci"
+    "test": "$npm_execpath test:jest",
+    "test:jest": "jest --ci"
   },
   "dependencies": {
     "@safe-global/api-kit": "^1.3.0",

--- a/packages/devtools-solana/package.json
+++ b/packages/devtools-solana/package.json
@@ -33,7 +33,8 @@
     "dev": "$npm_execpath tsup --watch",
     "lint": "$npm_execpath eslint '**/*.{js,ts,json}'",
     "lint:fix": "eslint --fix '**/*.{js,ts,json}'",
-    "test": "jest --ci"
+    "test": "$npm_execpath test:jest",
+    "test:jest": "jest --ci"
   },
   "dependencies": {
     "@safe-global/api-kit": "^1.3.0",

--- a/packages/devtools/package.json
+++ b/packages/devtools/package.json
@@ -28,7 +28,8 @@
     "dev": "$npm_execpath tsup --watch",
     "lint": "$npm_execpath eslint '**/*.{js,ts,json}'",
     "lint:fix": "eslint --fix '**/*.{js,ts,json}'",
-    "test": "jest --ci --forceExit"
+    "test": "$npm_execpath test:jest",
+    "test:jest": "jest --ci --forceExit"
   },
   "dependencies": {
     "bs58": "^6.0.0",

--- a/packages/export-deployments/package.json
+++ b/packages/export-deployments/package.json
@@ -24,7 +24,8 @@
     "lint": "$npm_execpath eslint '**/*.{js,ts,json}'",
     "lint:fix": "eslint --fix '**/*.{js,ts,json}'",
     "start": "node ./cli.js",
-    "test": "jest"
+    "test": "$npm_execpath test:jest",
+    "test:jest": "jest"
   },
   "dependencies": {
     "typescript": "^5.4.4"

--- a/packages/io-devtools/package.json
+++ b/packages/io-devtools/package.json
@@ -34,7 +34,8 @@
     "dev": "$npm_execpath tsup --watch",
     "lint": "$npm_execpath eslint '**/*.{js,ts,json}'",
     "lint:fix": "eslint --fix '**/*.{js,ts,json}'",
-    "test": "jest --ci"
+    "test": "$npm_execpath test:jest",
+    "test:jest": "jest --ci"
   },
   "dependencies": {
     "chalk": "^4.1.2",

--- a/packages/metadata-tools/package.json
+++ b/packages/metadata-tools/package.json
@@ -33,7 +33,8 @@
     "dev": "$npm_execpath tsup --watch",
     "lint": "$npm_execpath eslint '**/*.{js,ts,json}'",
     "lint:fix": "eslint --fix '**/*.{js,ts,json}'",
-    "test": "jest"
+    "test": "$npm_execpath test:jest",
+    "test:jest": "jest"
   },
   "devDependencies": {
     "@layerzerolabs/devtools-evm-hardhat": "~2.0.4",

--- a/packages/protocol-devtools-evm/package.json
+++ b/packages/protocol-devtools-evm/package.json
@@ -33,7 +33,8 @@
     "dev": "$npm_execpath tsup --watch",
     "lint": "$npm_execpath eslint '**/*.{js,ts,json}'",
     "lint:fix": "eslint --fix '**/*.{js,ts,json}'",
-    "test": "jest --ci"
+    "test": "$npm_execpath test:jest",
+    "test:jest": "jest --ci"
   },
   "dependencies": {
     "p-memoize": "~4.0.4"

--- a/packages/protocol-devtools/package.json
+++ b/packages/protocol-devtools/package.json
@@ -29,7 +29,8 @@
     "dev": "$npm_execpath tsup --watch",
     "lint": "$npm_execpath eslint '**/*.{js,ts,json}'",
     "lint:fix": "eslint --fix '**/*.{js,ts,json}'",
-    "test": "jest --ci"
+    "test": "$npm_execpath test:jest",
+    "test:jest": "jest --ci"
   },
   "devDependencies": {
     "@layerzerolabs/devtools": "~0.4.4",

--- a/packages/ua-devtools-evm/package.json
+++ b/packages/ua-devtools-evm/package.json
@@ -28,7 +28,8 @@
     "dev": "$npm_execpath tsup --watch",
     "lint": "$npm_execpath eslint '**/*.{js,ts,json}'",
     "lint:fix": "eslint --fix '**/*.{js,ts,json}'",
-    "test": "jest --ci"
+    "test": "$npm_execpath test:jest",
+    "test:jest": "jest --ci"
   },
   "dependencies": {
     "p-memoize": "~4.0.4"

--- a/packages/ua-devtools/package.json
+++ b/packages/ua-devtools/package.json
@@ -28,7 +28,8 @@
     "dev": "$npm_execpath tsup --watch",
     "lint": "$npm_execpath eslint '**/*.{js,ts,json}'",
     "lint:fix": "eslint --fix '**/*.{js,ts,json}'",
-    "test": "jest --ci"
+    "test": "$npm_execpath test:jest",
+    "test:jest": "jest --ci"
   },
   "devDependencies": {
     "@layerzerolabs/devtools": "~0.4.4",

--- a/packages/verify-contract/package.json
+++ b/packages/verify-contract/package.json
@@ -27,7 +27,8 @@
     "lint": "$npm_execpath eslint '**/*.{js,ts,json}'",
     "lint:fix": "eslint --fix '**/*.{js,ts,json}'",
     "start": "node ./cli.js",
-    "test": "jest"
+    "test": "$npm_execpath test:jest",
+    "test:jest": "jest"
   },
   "devDependencies": {
     "@ethersproject/abi": "^5.7.0",

--- a/tests/devtools-cli-test/package.json
+++ b/tests/devtools-cli-test/package.json
@@ -14,7 +14,8 @@
     "compile": "$npm_execpath hardhat compile",
     "lint": "$npm_execpath eslint '**/*.{js,ts,json}'",
     "lint:fix": "eslint --fix '**/*.{js,ts,json}'",
-    "test": "jest --ci --runInBand --forceExit"
+    "test": "$npm_execpath test:jest",
+    "test:jest": "jest --ci --runInBand --forceExit"
   },
   "devDependencies": {
     "@babel/core": "^7.23.9",

--- a/tests/devtools-evm-test/package.json
+++ b/tests/devtools-evm-test/package.json
@@ -14,7 +14,8 @@
     "compile": "$npm_execpath hardhat compile",
     "lint": "$npm_execpath eslint '**/*.{js,ts,json}'",
     "lint:fix": "eslint --fix '**/*.{js,ts,json}'",
-    "test": "jest --ci"
+    "test": "$npm_execpath test:jest",
+    "test:jest": "jest --ci"
   },
   "devDependencies": {
     "@ethersproject/abi": "^5.7.0",

--- a/tests/export-deployments-test/package.json
+++ b/tests/export-deployments-test/package.json
@@ -14,7 +14,8 @@
     "compile": "$npm_execpath hardhat compile",
     "lint": "$npm_execpath eslint '**/*.{js,ts,json}'",
     "lint:fix": "eslint --fix '**/*.{js,ts,json}'",
-    "test": "jest --ci --runInBand --forceExit"
+    "test": "$npm_execpath test:jest",
+    "test:jest": "jest --ci --runInBand --forceExit"
   },
   "devDependencies": {
     "@babel/core": "^7.23.9",

--- a/tests/ua-devtools-evm-hardhat-v1-test/package.json
+++ b/tests/ua-devtools-evm-hardhat-v1-test/package.json
@@ -14,7 +14,8 @@
     "compile": "$npm_execpath hardhat compile",
     "lint": "$npm_execpath eslint '**/*.{js,ts,json}'",
     "lint:fix": "eslint --fix '**/*.{js,ts,json}'",
-    "test": "jest --ci --runInBand --forceExit"
+    "test": "$npm_execpath test:jest",
+    "test:jest": "jest --ci --runInBand --forceExit"
   },
   "devDependencies": {
     "@babel/core": "^7.23.9",

--- a/turbo.json
+++ b/turbo.json
@@ -34,6 +34,11 @@
       "cache": false,
       "dependsOn": ["compile", "^build"],
       "outputs": []
+    },
+    "test:jest": {
+      "cache": false,
+      "dependsOn": ["compile", "^build"],
+      "outputs": []
     }
   },
   "globalDependencies": ["tsconfig.json"],


### PR DESCRIPTION
For now, we will not include the following packages for "test:jest":

* devtools-ton: expects a TON node to be running, which our CI system does not currently perform.
* test-devtools-ton: same as above
* devtools-evm-hardhat-test: rarely changes
* ua-devtools-evm-hardhat-test:  same as above