### PR TITLE
chore: add optimizer and optimizer runs since foundry disabled optimizer on default

### DIFF
--- a/examples/lzapp-migration/foundry.toml
+++ b/examples/lzapp-migration/foundry.toml
@@ -5,6 +5,8 @@ out = 'out'
 test = 'test/foundry'
 cache_path = 'cache/foundry'
 verbosity = 3
+optimizer = true
+optimizer_runs = 20_000
 libs = [
     # We provide a set of useful contract utilities
     # in the lib directory of @layerzerolabs/toolbox-foundry:

--- a/examples/mint-burn-oft-adapter/foundry.toml
+++ b/examples/mint-burn-oft-adapter/foundry.toml
@@ -5,6 +5,8 @@ out = 'out'
 test = 'test/foundry'
 cache_path = 'cache/foundry'
 verbosity = 3
+optimizer = true
+optimizer_runs = 20_000
 libs = [
     # We provide a set of useful contract utilities
     # in the lib directory of @layerzerolabs/toolbox-foundry:

--- a/examples/oapp/foundry.toml
+++ b/examples/oapp/foundry.toml
@@ -5,6 +5,8 @@ out = 'out'
 test = 'test/foundry'
 cache_path = 'cache/foundry'
 verbosity = 3
+optimizer = true
+optimizer_runs = 20_000
 libs = [
     # We provide a set of useful contract utilities
     # in the lib directory of @layerzerolabs/toolbox-foundry:

--- a/examples/oft-adapter/foundry.toml
+++ b/examples/oft-adapter/foundry.toml
@@ -5,6 +5,8 @@ out = 'out'
 test = 'test/foundry'
 cache_path = 'cache/foundry'
 verbosity = 3
+optimizer = true
+optimizer_runs = 20_000
 libs = [
     # We provide a set of useful contract utilities
     # in the lib directory of @layerzerolabs/toolbox-foundry:

--- a/examples/oft/foundry.toml
+++ b/examples/oft/foundry.toml
@@ -5,6 +5,8 @@ out = 'out'
 test = 'test/foundry'
 cache_path = 'cache/foundry'
 verbosity = 3
+optimizer = true
+optimizer_runs = 20_000
 libs = [
     # We provide a set of useful contract utilities
     # in the lib directory of @layerzerolabs/toolbox-foundry:

--- a/examples/onft721-zksync/foundry.toml
+++ b/examples/onft721-zksync/foundry.toml
@@ -5,6 +5,8 @@ out = 'out'
 test = 'test/foundry'
 cache_path = 'cache/foundry'
 verbosity = 3
+optimizer = true
+optimizer_runs = 20_000
 libs = [
     # We provide a set of useful contract utilities
     # in the lib directory of @layerzerolabs/toolbox-foundry:

--- a/examples/onft721/foundry.toml
+++ b/examples/onft721/foundry.toml
@@ -5,6 +5,8 @@ out = 'out'
 test = 'test/foundry'
 cache_path = 'cache/foundry'
 verbosity = 3
+optimizer = true
+optimizer_runs = 20_000
 libs = [
     # We provide a set of useful contract utilities
     # in the lib directory of @layerzerolabs/toolbox-foundry:


### PR DESCRIPTION
https://x.com/gakonst/status/1881802255202193584

> In the coming weeks, we'll be shipping our last few breaking changes to Foundry (e.g., turning off the optimizer by default, which was recently shipped).

