### PR TITLE
feat: calldata as an execution mode + default gasLimit 

### DIFF
--- a/examples/oft-aptos-move/README.md
+++ b/examples/oft-aptos-move/README.md
@@ -148,6 +148,7 @@ pnpm run lz:sdk:evm:wire --oapp-config move.layerzero.config.ts [--simulate true
 
 --simulate <true> and --mnemonic-index <value> are optional.
 --mnemonic-index <value> is the index of the mnemonic to use for the EVM account. If not specified, EVM_PRIVATE_KEY from .env is used. else the mnemonic is used along with the index.
+--only-calldata <true> is optional. If specified, only the calldata is generated and not the transaction (this is primarily for multisig wallets).
 
 For Move-VM:
 

--- a/packages/devtools-move/cli/operations/evm-wire.ts
+++ b/packages/devtools-move/cli/operations/evm-wire.ts
@@ -23,6 +23,14 @@ class EVMWireOperation implements INewOperation {
                 default: '-1',
             },
         },
+        {
+            name: '--only-calldata',
+            arg: {
+                help: 'Whether to only generate calldata',
+                required: false,
+                default: 'false',
+            },
+        },
     ]
 
     async impl(args: any): Promise<void> {

--- a/packages/devtools-move/tasks/evm/utils/types.ts
+++ b/packages/devtools-move/tasks/evm/utils/types.ts
@@ -4,6 +4,7 @@ import { PopulatedTransaction, ethers, providers } from 'ethers'
 
 import type { OAppEdgeConfig, OAppNodeConfig } from '@layerzerolabs/toolbox-hardhat'
 
+export type ExecutionMode = 'calldata' | 'broadcast' | 'dry-run'
 export type TxTypes =
     | 'setPeer'
     | 'setDelegate'

--- a/packages/devtools-move/tasks/evm/wire-evm.ts
+++ b/packages/devtools-move/tasks/evm/wire-evm.ts
@@ -164,13 +164,17 @@ async function wireEvm(args: any) {
     try {
         anvilForkNode = new AnvilForkNode(rpcUrlSelfMap, 8545)
 
-        if (args.simulate === 'true') {
-            const forkRpcMap = await anvilForkNode.startNodes()
-            await executeTransactions(omniContracts, TxTypeEidMapping, forkRpcMap, 'dry-run', privateKey, args)
+        if (args.only_calldata === 'true') {
+            await executeTransactions(omniContracts, TxTypeEidMapping, rpcUrlSelfMap, 'calldata', privateKey, args)
         } else {
-            console.warn('--simulate set to false\n Skipping simulation and going directly to broadcast')
+            if (args.simulate === 'true') {
+                const forkRpcMap = await anvilForkNode.startNodes()
+                await executeTransactions(omniContracts, TxTypeEidMapping, forkRpcMap, 'dry-run', privateKey, args)
+            } else {
+                console.warn('--simulate set to false\n Skipping simulation and going directly to broadcast')
+            }
+            await executeTransactions(omniContracts, TxTypeEidMapping, rpcUrlSelfMap, 'broadcast', privateKey, args)
         }
-        await executeTransactions(omniContracts, TxTypeEidMapping, rpcUrlSelfMap, 'broadcast', privateKey, args)
     } catch (error) {
         throw new Error(`Failed to wire EVM contracts: ${error}`)
     } finally {


### PR DESCRIPTION
1. using `--only-calldata` as an execution mode skips transaction submission and only logs in transactions under `/transactions/${--oapp-config}/calldata/run-id.json`
2. Testnets have flaky `gasLimit` and may not always pass. Defaulting on a million (`1_000_000`) should it fail (don't worry the excess gas is refunded, also this is mostly for testnets)