### PR TITLE
Fix/rebase aptos examples/config setting epv2 default library

### DIFF
--- a/packages/devtools-move/tasks/evm/wire-evm.ts
+++ b/packages/devtools-move/tasks/evm/wire-evm.ts
@@ -101,6 +101,13 @@ export async function createEvmOmniContracts(args: any, privateKey: string, chai
 }
 
 export function readPrivateKey(args: any) {
+    if (args.only_calldata === 'true') {
+        console.log('Not loading private key for calldata mode')
+        // returning the first private key that anvil creates from the m
+        // test test test test test test test test test test test junk
+        return '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80'
+    }
+
     const envPath = path.resolve(path.join(args.rootDir, '.env'))
     const env = dotenv.config({ path: envPath })
     if (!env.parsed || env.error?.message !== undefined) {

--- a/packages/devtools-move/tasks/evm/wire/setReceiveConfig.ts
+++ b/packages/devtools-move/tasks/evm/wire/setReceiveConfig.ts
@@ -31,6 +31,9 @@ export async function createSetReceiveConfigTransactions(
                 address.oapp,
                 peerToEid
             )
+            if (currReceiveLibrary.newReceiveLibrary === '') {
+                currReceiveLibrary.newReceiveLibrary = currReceiveLibrary.currReceiveLibrary
+            }
 
             const currReceiveConfig = {
                 ulnConfigBytes: '',
@@ -81,7 +84,11 @@ export async function createSetReceiveConfigTransactions(
 
             if (decodedSetFromConfigParam && decodedSetToConfigParam) {
                 diffPrinter(
-                    createDiffMessage('receive config', Number(eid), Number(peerToEid)),
+                    createDiffMessage(
+                        `receive config @ ${currReceiveLibrary.newReceiveLibrary}`,
+                        Number(eid),
+                        Number(peerToEid)
+                    ),
                     decodedSetFromConfigParam,
                     decodedSetToConfigParam
                 )

--- a/packages/devtools-move/tasks/evm/wire/setReceiveLibrary.ts
+++ b/packages/devtools-move/tasks/evm/wire/setReceiveLibrary.ts
@@ -79,8 +79,7 @@ export async function parseReceiveLibrary(
     eid: eid
 ): Promise<{ currReceiveLibrary: string; newReceiveLibrary: string }> {
     if (receiveLib === undefined || receiveLib.receiveLibrary === undefined) {
-        const currReceiveLibrary = await getDefaultReceiveLibrary(epv2, oappAddress, eid)
-        console.log('currReceiveLibrary', currReceiveLibrary)
+        const currReceiveLibrary = await getDefaultReceiveLibrary(epv2, eid)
 
         return {
             currReceiveLibrary,
@@ -95,8 +94,8 @@ export async function parseReceiveLibrary(
     return { currReceiveLibrary, newReceiveLibrary }
 }
 
-export async function getReceiveLibrary(epv2Contract: Contract, evmAddress: string, aptosEid: eid): Promise<string> {
-    const recvLibParam: RecvLibParam = await epv2Contract.getReceiveLibrary(evmAddress, aptosEid)
+export async function getReceiveLibrary(epv2Contract: Contract, evmAddress: string, peerEid: eid): Promise<string> {
+    const recvLibParam: RecvLibParam = await epv2Contract.getReceiveLibrary(evmAddress, peerEid)
     if (recvLibParam.isDefault) {
         return constants.AddressZero
     }
@@ -111,12 +110,8 @@ export async function getReceiveLibrary(epv2Contract: Contract, evmAddress: stri
     return recvLibAddress
 }
 
-export async function getDefaultReceiveLibrary(
-    epv2Contract: Contract,
-    evmAddress: string,
-    aptosEid: eid
-): Promise<string> {
-    const recvLib = await epv2Contract.getDefaultReceiveLibrary(evmAddress, aptosEid)
+export async function getDefaultReceiveLibrary(epv2Contract: Contract, peerEid: eid): Promise<string> {
+    const recvLib = await epv2Contract.defaultReceiveLibrary(peerEid)
 
     const recvLibAddress = utils.getAddress(recvLib)
 

--- a/packages/devtools-move/tasks/evm/wire/setSendConfig.ts
+++ b/packages/devtools-move/tasks/evm/wire/setSendConfig.ts
@@ -30,6 +30,9 @@ export async function createSetSendConfigTransactions(eidDataMapping: OmniContra
                 address.oapp,
                 peerToEid
             )
+            if (currSendLibrary.newSendLibrary === '') {
+                currSendLibrary.newSendLibrary = currSendLibrary.currSendLibrary
+            }
 
             const currSendConfig = {
                 executorConfigBytes: '',
@@ -109,7 +112,11 @@ export async function createSetSendConfigTransactions(eidDataMapping: OmniContra
             if (decodedCurrSendConfigParam && decodedSetConfigParam) {
                 if (decodedCurrSendConfigParam !== decodedSetConfigParam) {
                     diffPrinter(
-                        createDiffMessage('send config', Number(eid), Number(peerToEid)),
+                        createDiffMessage(
+                            `send config @ ${currSendLibrary.newSendLibrary}`,
+                            Number(eid),
+                            Number(peerToEid)
+                        ),
                         decodedCurrSendConfigParam,
                         decodedSetConfigParam
                     )

--- a/packages/devtools-move/tasks/evm/wire/setSendLibrary.ts
+++ b/packages/devtools-move/tasks/evm/wire/setSendLibrary.ts
@@ -66,7 +66,7 @@ export async function parseSendLibrary(
     eid: eid
 ): Promise<{ currSendLibrary: string; newSendLibrary: string }> {
     if (sendLib === undefined) {
-        const currSendLibrary = await getDefaultSendLibrary(epv2, oappAddress, eid)
+        const currSendLibrary = await getDefaultSendLibrary(epv2, eid)
         return {
             currSendLibrary,
             newSendLibrary: '',
@@ -80,25 +80,21 @@ export async function parseSendLibrary(
     return { currSendLibrary, newSendLibrary }
 }
 
-export async function getSendLibrary(epv2Contract: Contract, evmAddress: string, apnewSEid: eid): Promise<string> {
-    const isDefault = await epv2Contract.isDefaultSendLibrary(evmAddress, apnewSEid)
+export async function getSendLibrary(epv2Contract: Contract, evmAddress: string, peerEid: eid): Promise<string> {
+    const isDefault = await epv2Contract.isDefaultSendLibrary(evmAddress, peerEid)
     if (isDefault) {
         return constants.AddressZero
     }
 
-    const sendLib = await epv2Contract.getSendLibrary(evmAddress, apnewSEid)
+    const sendLib = await epv2Contract.getSendLibrary(evmAddress, peerEid)
     if (sendLib === error_LZ_DefaultSendLibUnavailable) {
         return constants.AddressZero
     }
     return utils.getAddress(sendLib)
 }
 
-export async function getDefaultSendLibrary(
-    epv2Contract: Contract,
-    evmAddress: string,
-    apnewSEid: eid
-): Promise<string> {
-    const sendLib = await epv2Contract.getDefaultSendLibrary(evmAddress, apnewSEid)
+export async function getDefaultSendLibrary(epv2Contract: Contract, peerEid: eid): Promise<string> {
+    const sendLib = await epv2Contract.defaultSendLibrary(peerEid)
 
     const sendLibAddress = utils.getAddress(sendLib)
 


### PR DESCRIPTION
1. Fixed bug where send and receive libraries would call getDefaultSend/ReceiveLibrary when this is not a valid endpoint v2 function
2. Handling case when using default library fetched from the endpoint and the library is not specified in the lz config
3. calldata no longer requires a private key or mneumonic. it also skips forking  