### PR TITLE
helper function to filter through large transaction objects

### DIFF
--- a/examples/oft-aptos-move/package.json
+++ b/examples/oft-aptos-move/package.json
@@ -15,6 +15,7 @@
     "lint:sol": "solhint 'contracts/**/*.sol'",
     "lz:sdk:evm:quote-send-evm": "ts-node scripts/cli.ts --vm evm --op quote-send",
     "lz:sdk:evm:send-evm": "ts-node scripts/cli.ts --vm evm --op send",
+    "lz:sdk:evm:transaction-parser": "ts-node scripts/cli.ts --vm evm --op transaction-parser",
     "lz:sdk:evm:wire": "ts-node scripts/cli.ts --vm evm --op wire",
     "lz:sdk:help": "ts-node scripts/cli.ts --op help --filter all",
     "lz:sdk:move:build": "ts-node scripts/cli.ts --vm move --op build",

--- a/packages/devtools-move/cli/init.ts
+++ b/packages/devtools-move/cli/init.ts
@@ -14,4 +14,5 @@ export async function attach_wire_evm(sdk: AptosEVMCLI) {
     await sdk.extendOperationFromPath(path.join(__dirname, './operations/evm-wire'))
     await sdk.extendOperationFromPath(path.join(__dirname, './operations/evm-quote-send'))
     await sdk.extendOperationFromPath(path.join(__dirname, './operations/evm-send'))
+    await sdk.extendOperationFromPath(path.join(__dirname, './operations/evm-transaction-parser'))
 }

--- a/packages/devtools-move/cli/operations/evm-transaction-parser.ts
+++ b/packages/devtools-move/cli/operations/evm-transaction-parser.ts
@@ -1,0 +1,79 @@
+import { INewOperation } from '@layerzerolabs/devtools-extensible-cli'
+import type { TxReceiptJson } from '../../tasks/evm/utils/types'
+import path from 'path'
+import fs from 'fs'
+
+class EVMTransactionParserOperation implements INewOperation {
+    vm = 'evm'
+    operation = 'transaction-parser'
+    description = 'Parse EVM transactions'
+    reqArgs = ['oapp_config', 'id', 'mode', 'src_eid', 'dst_eid']
+    addArgs = [
+        {
+            name: '--id',
+            arg: {
+                help: 'Transaction ID',
+                required: false,
+            },
+        },
+        {
+            name: '--mode',
+            arg: {
+                help: 'Execution mode - broadcast, dry-run, or calldata',
+                required: false,
+            },
+        },
+        {
+            name: '--src-eid',
+            arg: {
+                help: 'Source EID',
+                required: false,
+            },
+        },
+        {
+            name: '--dst-eid',
+            arg: {
+                help: 'Destination EID',
+                required: false,
+            },
+        },
+    ]
+
+    async impl(args: any): Promise<void> {
+        const oappConfig = args.oapp_config
+        const executionMode = args.mode
+        const transactionId = args.id
+        const srcEid = args.src_eid
+        const dstEid = args.dst_eid
+
+        const transactionFile = path.resolve(
+            path.join(args.rootDir, 'transactions', oappConfig, executionMode, `${transactionId}.json`)
+        )
+        const transactionFileContent = fs.readFileSync(transactionFile, 'utf8')
+        const transactionFileJson: TxReceiptJson = JSON.parse(transactionFileContent)
+        console.log(`Parsing transactions file ${transactionFile} \nWith srcEid ${srcEid} and dstEid ${dstEid}`)
+        const listOfNoLengthTransactions: string[] = []
+        for (const [txType, txReceipts] of Object.entries(transactionFileJson)) {
+            if (txReceipts.length === 0) {
+                listOfNoLengthTransactions.push(txType)
+                continue
+            }
+            console.log(`\n${txType}:`)
+            for (const txReceipt of txReceipts) {
+                if (txReceipt.dst_eid === dstEid && txReceipt.src_eid === srcEid) {
+                    console.log(txReceipt.data)
+                    continue
+                }
+                console.log(`No matching transaction found for ${txType} with srcEid ${srcEid} and dstEid ${dstEid}`)
+            }
+        }
+        if (listOfNoLengthTransactions.length > 0) {
+            console.log('\n========================================')
+            console.log('List of operations that do not have transactions:', listOfNoLengthTransactions.join(', '))
+            console.log('========================================')
+        }
+    }
+}
+
+const NewOperation = new EVMTransactionParserOperation()
+export { NewOperation }


### PR DESCRIPTION
Since transaction objects may contain 100+ transactions for several eid mappings. This operation was added to make it easier to filter through such massive objects.

`pnpm run lz:sdk:evm:transaction-parser  --oapp-config <value>  --mode <value> --id <value> --src-eid <value> --dst-eid <value>`

where 
1. `--oapp-config` is your layerzero config file
2. `--mode` is either `broadcast`, `dry-run`, or `calldata`
3. `--id` is your the run id 

these are required because of how the transaction folder is structured. it is 
`transactions/oappconfig/mode/runid.json`

