### PR TITLE
feat(oft-solana): throw specific error if trying to send more than owned

### DIFF
--- a/.changeset/rude-snails-serve.md
+++ b/.changeset/rude-snails-serve.md
@@ -1,0 +1,5 @@
+---
+"@layerzerolabs/oft-solana-example": minor
+---
+
+oft-solana - throw if trying to send more than owned

--- a/examples/oft-solana/tasks/solana/sendOFT.ts
+++ b/examples/oft-solana/tasks/solana/sendOFT.ts
@@ -1,4 +1,4 @@
-import { findAssociatedTokenPda } from '@metaplex-foundation/mpl-toolbox'
+import { fetchToken, findAssociatedTokenPda } from '@metaplex-foundation/mpl-toolbox'
 import { publicKey, transactionBuilder } from '@metaplex-foundation/umi'
 import { fromWeb3JsPublicKey } from '@metaplex-foundation/umi-web3js-adapters'
 import { TOKEN_PROGRAM_ID } from '@solana/spl-token'
@@ -69,6 +69,15 @@ task('lz:oft:solana:send', 'Send tokens from Solana to a target EVM chain')
             if (!tokenAccount) {
                 throw new Error(
                     `No token account found for mint ${mintStr} and owner ${umiWalletSigner.publicKey} in program ${tokenProgramId}`
+                )
+            }
+
+            const tokenAccountData = await fetchToken(umi, tokenAccount)
+            const balance = Number(tokenAccountData.amount)
+
+            if (amount > balance) {
+                throw new Error(
+                    `Attempting to send ${amount}, but ${umiWalletSigner.publicKey} only has balance of ${balance}`
                 )
             }
 

--- a/examples/oft-solana/tasks/solana/sendOFT.ts
+++ b/examples/oft-solana/tasks/solana/sendOFT.ts
@@ -75,7 +75,7 @@ task('lz:oft:solana:send', 'Send tokens from Solana to a target EVM chain')
             const tokenAccountData = await fetchToken(umi, tokenAccount)
             const balance = Number(tokenAccountData.amount)
 
-            if (amount > balance) {
+            if (amount == 0 || amount > balance) {
                 throw new Error(
                     `Attempting to send ${amount}, but ${umiWalletSigner.publicKey} only has balance of ${balance}`
                 )

--- a/examples/oft-solana/tasks/solana/sendOFT.ts
+++ b/examples/oft-solana/tasks/solana/sendOFT.ts
@@ -32,7 +32,7 @@ interface Args {
 
 // Define a Hardhat task for sending OFT from Solana
 task('lz:oft:solana:send', 'Send tokens from Solana to a target EVM chain')
-    .addParam('amount', 'The amount of tokens to send', undefined, types.int)
+    .addParam('amount', 'The amount of tokens to send', undefined, types.bigint)
     .addParam('fromEid', 'The source endpoint ID', undefined, types.eid)
     .addParam('to', 'The recipient address on the destination chain')
     .addParam('toEid', 'The destination endpoint ID', undefined, types.eid)

--- a/examples/oft-solana/tasks/solana/sendOFT.ts
+++ b/examples/oft-solana/tasks/solana/sendOFT.ts
@@ -19,7 +19,7 @@ import {
 } from './index'
 
 interface Args {
-    amount: number
+    amount: bigint
     to: string
     fromEid: EndpointId
     toEid: EndpointId
@@ -73,9 +73,9 @@ task('lz:oft:solana:send', 'Send tokens from Solana to a target EVM chain')
             }
 
             const tokenAccountData = await fetchToken(umi, tokenAccount)
-            const balance = Number(tokenAccountData.amount)
+            const balance = tokenAccountData.amount
 
-            if (amount == 0 || amount > balance) {
+            if (amount == BigInt(0) || amount > balance) {
                 throw new Error(
                     `Attempting to send ${amount}, but ${umiWalletSigner.publicKey} only has balance of ${balance}`
                 )


### PR DESCRIPTION
Currently, if a dev tries to run the sendOFT.ts script with an amount greater than the balance of their deployer address, they will be faced with an error like so:

```bash
SendTransactionError: Simulation failed. 
Message: Transaction simulation failed: Error processing Instruction 2: custom program error: 0x1. 
Logs: 
[
  "Program ComputeBudget111111111111111111111111111111 success",
  "Program 13DZBdTFGrhYCcgKFx7ensYs1yBLgGwXdD7kzRA9tU2v invoke [1]",
  "Program log: Instruction: Send",
  "Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA invoke [2]",
  "Program log: Instruction: Burn",
  "Program log: Error: insufficient funds",
  "Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA consumed 4171 of 227697 compute units",
  "Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA failed: custom program error: 0x1",
  "Program 13DZBdTFGrhYCcgKFx7ensYs1yBLgGwXdD7kzRA9tU2v consumed 29174 of 252700 compute units",
  "Program 13DZBdTFGrhYCcgKFx7ensYs1yBLgGwXdD7kzRA9tU2v failed: custom program error: 0x1"
]. 

```

This is too cryptic. They will often resort to asking us for clarification. We can do better.

This PR removes this from ever being a blocker for self-service, by checking the `balance` of the deployer address and comparing it with the `amount` passed into the task.


## Testing

init a repo with the example from this branch:
```bash
LAYERZERO_EXAMPLES_REPOSITORY_REF=#nazreen/oft-solana/throw-if-sending-more LZ_ENABLE_SOLANA_OFT_EXAMPLE=1 npx create-lz-oapp@latest
```

go through the usual steps until you reach the send step for Solana to Sepolia
then, input an amount greater than what was minted

you would get an error message like so:

```
Error: Attempting to send 10000000023456788, but <ADDRESS> only has balance of 9900000000
```