### PR TITLE
fix: indexing the transaction object on from eid instead of to eid

### DIFF
--- a/packages/devtools-move/tasks/evm/utils/types.ts
+++ b/packages/devtools-move/tasks/evm/utils/types.ts
@@ -58,6 +58,7 @@ export type OmniContractMetadataMapping = Record<eid, ContractMetadata>
 
 export type TxPool = {
     from_eid: eid
+    to_eid: eid
     raw: ethers.PopulatedTransaction
     response: Promise<providers.TransactionResponse> | undefined
 }


### PR DESCRIPTION
indexing TxPool by `fromEid` instead of `toEid`. Using `toEid` leads to overwrites on a `<n,1>` mapping of transactions.  