### PR TITLE
Remove Solana from CI

### DIFF
--- a/.github/workflows/reusable-publish-docker.yaml
+++ b/.github/workflows/reusable-publish-docker.yaml
@@ -133,47 +133,6 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
   #
-  # Build the Solana node image and push it as digests
-  #
-  # We build the node images after we're done with the base so that we can use the docker layer cache
-  # instead of rebuilding the whole thing from scratch
-  #
-  build-node-solana:
-    name: Build Solana node image
-    runs-on: ubuntu-latest-16xlarge
-    needs:
-      - build-base
-
-    permissions:
-      contents: read
-      packages: write
-
-    strategy:
-      fail-fast: false
-      matrix:
-        platform:
-          - linux/amd64
-          - linux/arm64
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Build image & push the digest
-        uses: ./.github/workflows/actions/docker-build-image
-        with:
-          # The name of the image
-          image: devtools-dev-node-solana-test-validator
-          # The target stage of the Dockerfile
-          target: node-solana-test-validator
-          # Since the digests will be shared across jobs as artifacts,
-          # we need a unique name (per workflow) for these artifacts
-          digest-name: node-solana-test-validator
-          platform: ${{ matrix.platform }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-  #
   # Build the TON node image and push it as digests
   #
   # We build the node images after we're done with the base so that we can use the docker layer cache
@@ -289,32 +248,6 @@ jobs:
           #
           # This needs to match the digest name of the build stage
           digest-name: node-evm-hardhat
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-  #
-  # Collect the Solana node image digests and push them to GHCR
-  #
-  push-node-solana:
-    name: Push Solana node image
-    runs-on: ubuntu-latest-4xlarge
-    needs:
-      - build-node-solana
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Push image
-        uses: ./.github/workflows/actions/docker-push-image
-        with:
-          # The name of the image
-          image: devtools-dev-node-solana-test-validator
-          # Since the digests will be shared across jobs as artifacts,
-          # we need a unique name (per workflow) for these artifacts
-          #
-          # This needs to match the digest name of the build stage
-          digest-name: node-solana-test-validator
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/reusable-test.yaml
+++ b/.github/workflows/reusable-test.yaml
@@ -88,13 +88,6 @@ jobs:
           DEVTOOLS_EVM_NODE_IMAGE: ghcr.io/layerzero-labs/devtools-dev-node-evm-hardhat:main
           # And the prebuilt TON node image
           DEVTOOLS_TON_NODE_IMAGE: ghcr.io/layerzero-labs/devtools-dev-node-ton-my-local-ton:main
-          # Provided we have good quality Solana RPCs, we can enable Solana tests
-          #
-          # FIXME The Solana tests need to be ported to either use a stable deployment
-          # or a local node. Until then, we disable the tests
-          # LZ_DEVTOOLS_ENABLE_SOLANA_TESTS: 1
-          RPC_URL_SOLANA_MAINNET: ${{ secrets.RPC_URL_SOLANA_MAINNET || 'https://rpc.ankr.com/solana' }}
-          RPC_URL_SOLANA_TESTNET: ${{ secrets.RPC_URL_SOLANA_TESTNET || 'https://api.devnet.solana.com' }}
 
       # We'll collect the docker compose logs from all containers on failure
       - name: Collect docker logs on failure

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -86,11 +86,6 @@ services:
       - NETWORK_URL_TANGO=http://network-tango:8545
       - NETWORK_URL_TON=http://network-ton:8081/jsonRPC
       - DOCKER_COMPOSE_RUN_TESTS_TURBO_ARGS=$DOCKER_COMPOSE_RUN_TESTS_TURBO_ARGS
-      # Passing environment variables that control the solana tests
-      - RPC_URL_SOLANA_MAINNET=${RPC_URL_SOLANA_MAINNET}
-      - RPC_URL_SOLANA_TESTNET=${RPC_URL_SOLANA_TESTNET}
-      - LZ_DEVTOOLS_ENABLE_SOLANA_TESTS=${LZ_DEVTOOLS_ENABLE_SOLANA_TESTS}
-    volumes:
       - ./node_modules/.cache/turbo:/app/node_modules/.cache/turbo
       # Hardhat has an issue with caching compilers inside a docker container,
       # failing with EACCES -13 error, pointing to a permissions issue with the cache folder.


### PR DESCRIPTION
Removes Solana from CI because currently build is broken and works only due to caching.

Tests were disabled before anyway:
```
# FIXME The Solana tests need to be ported to either use a stable deployment
# or a local node. Until then, we disable the tests
# LZ_DEVTOOLS_ENABLE_SOLANA_TESTS: 1
```