### PR TITLE
fix(eslint): add `root: true` to example directories

### DIFF
--- a/examples/lzapp-migration/.eslintrc.js
+++ b/examples/lzapp-migration/.eslintrc.js
@@ -1,4 +1,5 @@
 module.exports = {
+    root: true,
     extends: ['@layerzerolabs/eslint-config-next/recommended'],
     settings: {
         'import/resolver': {

--- a/examples/mint-burn-oft-adapter/.eslintrc.js
+++ b/examples/mint-burn-oft-adapter/.eslintrc.js
@@ -1,6 +1,7 @@
 require('@rushstack/eslint-patch/modern-module-resolution');
 
 module.exports = {
+    root: true,
     extends: ['@layerzerolabs/eslint-config-next/recommended'],
     rules: {
         // @layerzerolabs/eslint-config-next defines rules for turborepo-based projects

--- a/examples/native-oft-adapter/.eslintrc.js
+++ b/examples/native-oft-adapter/.eslintrc.js
@@ -1,6 +1,7 @@
 require('@rushstack/eslint-patch/modern-module-resolution');
 
 module.exports = {
+    root: true,
     extends: ['@layerzerolabs/eslint-config-next/recommended'],
     rules: {
         // @layerzerolabs/eslint-config-next defines rules for turborepo-based projects

--- a/examples/oapp-read/.eslintrc.js
+++ b/examples/oapp-read/.eslintrc.js
@@ -1,6 +1,7 @@
 require('@rushstack/eslint-patch/modern-module-resolution');
 
 module.exports = {
+    root: true,
     extends: ['@layerzerolabs/eslint-config-next/recommended'],
     rules: {
         // @layerzerolabs/eslint-config-next defines rules for turborepo-based projects

--- a/examples/oapp/.eslintrc.js
+++ b/examples/oapp/.eslintrc.js
@@ -1,6 +1,7 @@
 require('@rushstack/eslint-patch/modern-module-resolution');
 
 module.exports = {
+    root: true,
     extends: ['@layerzerolabs/eslint-config-next/recommended'],
     rules: {
         // @layerzerolabs/eslint-config-next defines rules for turborepo-based projects

--- a/examples/oft-adapter/.eslintrc.js
+++ b/examples/oft-adapter/.eslintrc.js
@@ -1,6 +1,7 @@
 require('@rushstack/eslint-patch/modern-module-resolution');
 
 module.exports = {
+    root: true,
     extends: ['@layerzerolabs/eslint-config-next/recommended'],
     rules: {
         // @layerzerolabs/eslint-config-next defines rules for turborepo-based projects

--- a/examples/oft-solana/.eslintrc.js
+++ b/examples/oft-solana/.eslintrc.js
@@ -1,6 +1,7 @@
 require('@rushstack/eslint-patch/modern-module-resolution');
 
 module.exports = {
+    root: true,
     extends: ['@layerzerolabs/eslint-config-next/recommended'],
     rules: {
         // @layerzerolabs/eslint-config-next defines rules for turborepo-based projects

--- a/examples/oft-upgradeable/.eslintrc.js
+++ b/examples/oft-upgradeable/.eslintrc.js
@@ -1,6 +1,7 @@
 require('@rushstack/eslint-patch/modern-module-resolution');
 
 module.exports = {
+    root: true,
     extends: ['@layerzerolabs/eslint-config-next/recommended'],
     rules: {
         // @layerzerolabs/eslint-config-next defines rules for turborepo-based projects

--- a/examples/oft/.eslintrc.js
+++ b/examples/oft/.eslintrc.js
@@ -1,6 +1,7 @@
 require('@rushstack/eslint-patch/modern-module-resolution');
 
 module.exports = {
+    root: true,
     extends: ['@layerzerolabs/eslint-config-next/recommended'],
     rules: {
         // @layerzerolabs/eslint-config-next defines rules for turborepo-based projects

--- a/examples/onft721-zksync/.eslintrc.js
+++ b/examples/onft721-zksync/.eslintrc.js
@@ -1,6 +1,7 @@
 require('@rushstack/eslint-patch/modern-module-resolution');
 
 module.exports = {
+    root: true,
     extends: ['@layerzerolabs/eslint-config-next/recommended'],
     rules: {
         // @layerzerolabs/eslint-config-next defines rules for turborepo-based projects

--- a/examples/onft721/.eslintrc.js
+++ b/examples/onft721/.eslintrc.js
@@ -1,6 +1,7 @@
 require('@rushstack/eslint-patch/modern-module-resolution');
 
 module.exports = {
+    root: true,
     extends: ['@layerzerolabs/eslint-config-next/recommended'],
     rules: {
         // @layerzerolabs/eslint-config-next defines rules for turborepo-based projects

--- a/examples/uniswap-read/.eslintrc.js
+++ b/examples/uniswap-read/.eslintrc.js
@@ -1,6 +1,7 @@
 require('@rushstack/eslint-patch/modern-module-resolution');
 
 module.exports = {
+    root: true,
     extends: ['@layerzerolabs/eslint-config-next/recommended'],
     rules: {
         // @layerzerolabs/eslint-config-next defines rules for turborepo-based projects


### PR DESCRIPTION
Currently, sometimes in feature branches, the following error may appear in one of the example repos:

```
ESLint: 8.57.1
  
  ESLint couldn't determine the plugin "@typescript-eslint" uniquely.
  
  - /__w/devtools/devtools/node_modules/.pnpm/@typescript-eslint+eslint-plugin@7.7.1_@typescript-eslint+parser@7.7.1_eslint@8.57.1_typescript@5.5.3/node_modules/@typescript-eslint/eslint-plugin/dist/index.js (loaded in ".eslintrc.js » @layerzerolabs/eslint-config-next/recommended")
  - /__w/devtools/devtools/node_modules/.pnpm/@typescript-eslint+eslint-plugin@7.7.1_@typescript-eslint+parser@7.7.1_eslint@8.57.1_typescript@5.7.3/node_modules/@typescript-eslint/eslint-plugin/dist/index.js (loaded in "../../.eslintrc.json")
  
  Please remove the "plugins" setting from either config or remove either plugin installation.
  
  If you still can't figure out the problem, please stop by https://eslint.org/chat/help to chat with the team.
  ```
  
  Even when the feature branches changes are not related to the example folder that the error appears in.
  
  It's due to conflicting versions caused by the fact that in the root `.eslintrc.json` there's
  
  ```
  "plugins": ["@typescript-eslint", "prettier", "turbo"],
  ```
  
and then in the subdir (examples/uniswap-read/.eslintrc.js) there's

```
    extends: ['@layerzerolabs/eslint-config-next/recommended'],
```

and the thing is '@layerzerolabs/eslint-config-next/recommended' already includes "@typescript-eslint

I have no idea why this only errors intermittently, but the fact is that the example repo should not be looking for eslint config files in parent directories. It should only care about what's defined in its own ESLint config file. 

Fortunately there's a param for that: 

```
root: true
```

Reference: https://archive.eslint.org/docs/7.0.0/user-guide/configuring (Find mentions of `root`)