### PR TITLE
chore: update eslint-plugin-turbo

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-prettier": "^5.1.3",
     "eslint-plugin-promise": "^6.1.1",
-    "eslint-plugin-turbo": "^1.12.3",
+    "eslint-plugin-turbo": "^2.4.0",
     "husky": "^8.0.3",
     "lint-staged": "^15.2.2",
     "prettier": "^3.2.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -57,8 +57,8 @@ importers:
         specifier: ^6.1.1
         version: 6.1.1(eslint@8.57.1)
       eslint-plugin-turbo:
-        specifier: ^1.12.3
-        version: 1.12.3(eslint@8.57.1)
+        specifier: ^2.4.0
+        version: 2.4.0(eslint@8.57.1)(turbo@1.11.0)
       husky:
         specifier: ^8.0.3
         version: 8.0.3
@@ -12763,13 +12763,15 @@ packages:
       string.prototype.matchall: 4.0.10
     dev: true
 
-  /eslint-plugin-turbo@1.12.3(eslint@8.57.1):
-    resolution: {integrity: sha512-7hEyxa+oP898EFNoxVenHlH8jtBwV1hbbIkdQWgqDcB0EmVNGVEZkYRo5Hm6BuMAjR433B+NISBJdj0bQo4/Lg==}
+  /eslint-plugin-turbo@2.4.0(eslint@8.57.1)(turbo@1.11.0):
+    resolution: {integrity: sha512-qCgoRi/OTc1VMxab7+sdKiV1xlkY4qjK9sM+kS7+WogrB1DxLguJSQXvk4HA13SD5VmJsq+8FYOw5q4EUk6Ixg==}
     peerDependencies:
       eslint: '>6.6.0'
+      turbo: '>2.0.0'
     dependencies:
       dotenv: 16.0.3
       eslint: 8.57.1
+      turbo: 1.11.0
     dev: true
 
   /eslint-plugin-unused-imports@3.2.0(@typescript-eslint/eslint-plugin@7.7.1)(eslint@8.57.1):


### PR DESCRIPTION
Continuing the work of #1234 

This plugin being outdated is the source of this intermittent error in feature branches:

```
TypeError: Failed to load plugin 'turbo' declared in '.eslintrc.json » ../../.eslintrc.json': Cannot convert undefined or null to object
      at Function.entries (<anonymous>)
      at /__w/devtools/devtools/node_modules/.pnpm/eslint-plugin-turbo@1.12.3_eslint@8.57.1/node_modules/eslint-plugin-turbo/dist/index.js:74:6699
      at Array.forEach (<anonymous>)
      at Ii.generateKey (/__w/devtools/devtools/node_modules/.pnpm/eslint-plugin-turbo@1.12.3_eslint@8.57.1/node_modules/eslint-plugin-turbo/dist/index.js:74:6665)
      at new Ii (/__w/devtools/devtools/node_modules/.pnpm/eslint-plugin-turbo@1.12.3_eslint@8.57.1/node_modules/eslint-plugin-turbo/dist/index.js:74:6088)
      at Object.<anonymous> (/__w/devtools/devtools/node_modules/.pnpm/eslint-plugin-turbo@1.12.3_eslint@8.57.1/node_modules/eslint-plugin-turbo/dist/index.js:74:9924)
      at Module._compile (node:internal/modules/cjs/loader:1376:14)
      at Module._extensions..js (node:internal/modules/cjs/loader:1435:10)
      at Module.load (node:internal/modules/cjs/loader:1207:32)
      at Module._load (node:internal/modules/cjs/loader:1023:12)
   ELIFECYCLE  Command failed with exit code 2.
 ```
 
 See example lint run: https://github.com/LayerZero-Labs/devtools/actions/runs/13149540223/job/36694411868?pr=1229
 
 I suspect that it pops up when the pnpm lockfile is updated.
 
Here is the `peerDependencies` section of `eslint-plugin-turbo@2.4.0` which mentions the version of `eslint` required:

```
  "peerDependencies": {
    "eslint": ">6.6.0",
    "turbo": ">2.0.0"
  },
```

We are in the clear.

Source: https://github.com/vercel/turborepo/blob/v2.4.0/packages/eslint-plugin-turbo/package.json