### PR TITLE
oft-solana: instruction uses --max-len

### DIFF
--- a/examples/oft-solana/README.md
+++ b/examples/oft-solana/README.md
@@ -157,12 +157,14 @@ Rent-exempt minimum: 3.87415872 SOL
 #### Deploy the Solana OFT
 
 ```bash
-solana program deploy --program-id target/deploy/oft-keypair.json target/verifiable/oft.so -u devnet
+solana program deploy --program-id target/deploy/oft-keypair.json target/verifiable/oft.so -u devnet --max-len $(wc -c < target/verifiable/oft.so)
 ```
 
 :information_source: the `-u` flag specifies the RPC URL that should be used. The options are `mainnet-beta, devnet, testnet, localhost`, which also have their respective shorthands: `-um, -ud, -ut, -ul`
 
-:warning: If the deployment is slow, it could be that the network is congested. If so, you can either wait it out or opt to include a `priorityFee`.
+:information_source: Regarding `--max-len $(wc -c < target/verifiable/oft.so)` - as we are using Solana CLI `v1.17.31`, the program deploy command would be allocating twice the size of the program bytecode, which leads to needing twice the amount of rent. On mainnet this can be costly. This behavior was changed in `v1.18` to require only the exact size of the program bytecode. To emulate this, we are using the `--max-len` flag and passing it the actual size of the program bytecode.
+
+:warning: If the deployment is slow, it could be that the network is congested. If so, you can either wait it out or opt to include a priority fee (see below).
 
 #### (optional) Deploying with a priority fee
 


### PR DESCRIPTION
As we are using Solana CLI `v1.17.31`, the program deploy command would be allocating twice the size of the program bytecode, which leads to needing twice the amount of rent. On mainnet this can be costly.

Currently, rent for the exact program bytecode size is around 3.8 SOL so 2x this would be 7.6 SOL. At $200 per SOL, that's $760 and $1520 respectively.

This behavior was changed in `v1.18` to require only the exact size of the program bytecode.
To emulate this, we can use the `--max-len` flag and passing it the actual size of the program bytecode.

The alternative to using this flag is to ask the dev to switch to v1.18 temporarily when deploying, which might also be beneficial in that it then allows the user to directly specify a priority fee.