### PR TITLE
chore:  explicitly enable foundry optimizer

### DIFF
--- a/.changeset/real-bears-judge.md
+++ b/.changeset/real-bears-judge.md
@@ -1,0 +1,16 @@
+---
+"@layerzerolabs/test-devtools-evm-foundry": patch
+"@layerzerolabs/mint-burn-oft-adapter-example": patch
+"@layerzerolabs/lzapp-migration-example": patch
+"@layerzerolabs/oft-upgradeable-example": patch
+"@layerzerolabs/onft721-zksync-example": patch
+"@layerzerolabs/uniswap-read-example": patch
+"@layerzerolabs/oft-adapter-example": patch
+"@layerzerolabs/oft-solana-example": patch
+"@layerzerolabs/oapp-read-example": patch
+"@layerzerolabs/onft-evm": patch
+"@layerzerolabs/onft721-example": patch
+"@layerzerolabs/oft-example": patch
+---
+
+Enable optimizer explicitly

--- a/examples/lzapp-migration/foundry.toml
+++ b/examples/lzapp-migration/foundry.toml
@@ -5,6 +5,9 @@ out = 'out'
 test = 'test/foundry'
 cache_path = 'cache/foundry'
 verbosity = 3
+optimizer = true
+optimizer_runs = 20_000
+
 libs = [
     # We provide a set of useful contract utilities
     # in the lib directory of @layerzerolabs/toolbox-foundry:

--- a/examples/mint-burn-oft-adapter/foundry.toml
+++ b/examples/mint-burn-oft-adapter/foundry.toml
@@ -5,6 +5,9 @@ out = 'out'
 test = 'test/foundry'
 cache_path = 'cache/foundry'
 verbosity = 3
+optimizer = true
+optimizer_runs = 20_000
+
 libs = [
     # We provide a set of useful contract utilities
     # in the lib directory of @layerzerolabs/toolbox-foundry:

--- a/examples/oapp-read/foundry.toml
+++ b/examples/oapp-read/foundry.toml
@@ -4,6 +4,9 @@ src = 'contracts'
 out = 'out'
 test = 'test/foundry'
 cache_path = 'cache/foundry'
+optimizer = true
+optimizer_runs = 20_000
+
 libs = [
     # We provide a set of useful contract utilities
     # in the lib directory of @layerzerolabs/toolbox-foundry:

--- a/examples/oft-adapter/foundry.toml
+++ b/examples/oft-adapter/foundry.toml
@@ -5,6 +5,9 @@ out = 'out'
 test = 'test/foundry'
 cache_path = 'cache/foundry'
 verbosity = 3
+optimizer = true
+optimizer_runs = 20_000
+
 libs = [
     # We provide a set of useful contract utilities
     # in the lib directory of @layerzerolabs/toolbox-foundry:

--- a/examples/oft-solana/foundry.toml
+++ b/examples/oft-solana/foundry.toml
@@ -4,6 +4,9 @@ src = 'contracts'
 out = 'out'
 test = 'test/foundry'
 cache_path = 'cache/foundry'
+optimizer = true
+optimizer_runs = 20_000
+
 libs = [
     # We provide a set of useful contract utilities
     # in the lib directory of @layerzerolabs/toolbox-foundry:

--- a/examples/oft-upgradeable/foundry.toml
+++ b/examples/oft-upgradeable/foundry.toml
@@ -4,6 +4,9 @@ src = 'contracts'
 out = 'out'
 test = 'test/foundry'
 cache_path = 'cache/foundry'
+optimizer = true
+optimizer_runs = 20_000
+
 libs = [
     # We provide a set of useful contract utilities
     # in the lib directory of @layerzerolabs/toolbox-foundry:

--- a/examples/oft/foundry.toml
+++ b/examples/oft/foundry.toml
@@ -5,6 +5,9 @@ out = 'out'
 test = 'test/foundry'
 cache_path = 'cache/foundry'
 verbosity = 3
+optimizer = true
+optimizer_runs = 20_000
+
 libs = [
     # We provide a set of useful contract utilities
     # in the lib directory of @layerzerolabs/toolbox-foundry:

--- a/examples/onft721-zksync/foundry.toml
+++ b/examples/onft721-zksync/foundry.toml
@@ -5,6 +5,9 @@ out = 'out'
 test = 'test/foundry'
 cache_path = 'cache/foundry'
 verbosity = 3
+optimizer = true
+optimizer_runs = 20_000
+
 libs = [
     # We provide a set of useful contract utilities
     # in the lib directory of @layerzerolabs/toolbox-foundry:

--- a/examples/onft721/foundry.toml
+++ b/examples/onft721/foundry.toml
@@ -5,6 +5,9 @@ out = 'out'
 test = 'test/foundry'
 cache_path = 'cache/foundry'
 verbosity = 3
+optimizer = true
+optimizer_runs = 20_000
+
 libs = [
     # We provide a set of useful contract utilities
     # in the lib directory of @layerzerolabs/toolbox-foundry:

--- a/examples/uniswap-read/foundry.toml
+++ b/examples/uniswap-read/foundry.toml
@@ -4,6 +4,9 @@ src = 'contracts'
 out = 'out'
 test = 'test/foundry'
 cache_path = 'cache/foundry'
+optimizer = true
+optimizer_runs = 20_000
+
 libs = [
     # We provide a set of useful contract utilities
     # in the lib directory of @layerzerolabs/toolbox-foundry:

--- a/packages/onft-evm/foundry.toml
+++ b/packages/onft-evm/foundry.toml
@@ -5,6 +5,9 @@ test = 'test'
 out = 'artifacts'
 cache_path = 'cache'
 verbosity = 3
+optimizer = true
+optimizer_runs = 20_000
+
 libs = [
     # We provide a set of useful contract utilities
     # in the lib directory of @layerzerolabs/toolbox-foundry:

--- a/packages/test-devtools-evm-foundry/foundry.toml
+++ b/packages/test-devtools-evm-foundry/foundry.toml
@@ -4,6 +4,9 @@ src = 'contracts'
 out = 'artifacts'
 test = 'test/foundry'
 cache_path = 'cache'
+optimizer = true
+optimizer_runs = 20_000
+
 libs = [
     # We provide a set of useful contract utilities
     # in the lib directory of @layerzerolabs/toolbox-foundry:


### PR DESCRIPTION
The foundry team disabled the optimizer by default:

https://github.com/foundry-rs/foundry/pull/9657

Most of our contracts require optimization to avoid hitting StackTooDeep.