### PR TITLE
fix(oft-solana): un-lock solana oft sdk version and update imports

### DIFF
--- a/examples/oft-solana/package.json
+++ b/examples/oft-solana/package.json
@@ -38,7 +38,7 @@
     "@layerzerolabs/lz-v2-utilities": "^3.0.12",
     "@layerzerolabs/oapp-evm": "^0.3.0",
     "@layerzerolabs/oft-evm": "^3.1.0",
-    "@layerzerolabs/oft-v2-solana-sdk": "3.0.0",
+    "@layerzerolabs/oft-v2-solana-sdk": "^3.0.59",
     "@layerzerolabs/prettier-config-next": "^2.3.39",
     "@layerzerolabs/protocol-devtools": "^1.1.4",
     "@layerzerolabs/protocol-devtools-evm": "~3.0.5",

--- a/examples/oft-solana/tasks/solana/createOFTAdapter.ts
+++ b/examples/oft-solana/tasks/solana/createOFTAdapter.ts
@@ -6,7 +6,7 @@ import { task } from 'hardhat/config'
 
 import { types as devtoolsTypes } from '@layerzerolabs/devtools-evm-hardhat'
 import { EndpointId } from '@layerzerolabs/lz-definitions'
-import { OFT_DECIMALS, oft, types } from '@layerzerolabs/oft-v2-solana-sdk'
+import { OFT_DECIMALS, oft } from '@layerzerolabs/oft-v2-solana-sdk'
 
 import {
     TransactionType,
@@ -74,7 +74,7 @@ task('lz:oft-adapter:solana:create', 'Creates new OFT Adapter (OFT Store PDA)')
                         mint: mint,
                         escrow: createSignerFromKeypair({ eddsa: eddsa }, lockBox),
                     },
-                    types.OFTType.Adapter,
+                    oft.types.OFTType.Adapter,
                     OFT_DECIMALS,
                     {
                         oft: programId,

--- a/examples/oft-solana/tasks/solana/setOutboundRateLimit.ts
+++ b/examples/oft-solana/tasks/solana/setOutboundRateLimit.ts
@@ -11,7 +11,7 @@ import { task } from 'hardhat/config'
 import { types } from '@layerzerolabs/devtools-evm-hardhat'
 import { deserializeTransactionMessage } from '@layerzerolabs/devtools-solana'
 import { EndpointId } from '@layerzerolabs/lz-definitions'
-import { OftPDA, accounts } from '@layerzerolabs/oft-v2-solana-sdk'
+import { OftPDA, oft } from '@layerzerolabs/oft-v2-solana-sdk'
 import { createOFTFactory } from '@layerzerolabs/ua-devtools-solana'
 
 import { createSolanaConnectionFactory } from '../common/utils'
@@ -73,7 +73,7 @@ task(
             const txId = await sendAndConfirmTransaction(connection, tx, [keypair])
             console.log(`Transaction successful with ID: ${txId}`)
             const [peer] = new OftPDA(publicKey(taskArgs.programId)).peer(publicKey(taskArgs.oftStore), taskArgs.dstEid)
-            const peerInfo = await accounts.fetchPeerConfig({ rpc: umi.rpc }, peer)
+            const peerInfo = await oft.accounts.fetchPeerConfig({ rpc: umi.rpc }, peer)
             console.dir({ peerInfo }, { depth: null })
         } catch (error) {
             console.error(`setOutboundRateLimit failed:`, error)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -949,8 +949,8 @@ importers:
         specifier: ^3.1.0
         version: link:../../packages/oft-evm
       '@layerzerolabs/oft-v2-solana-sdk':
-        specifier: 3.0.0
-        version: 3.0.0(fastestsmallesttextencoderdecoder@1.0.22)
+        specifier: ^3.0.59
+        version: 3.0.66(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.3)
       '@layerzerolabs/prettier-config-next':
         specifier: ^2.3.39
         version: 2.3.44
@@ -7530,30 +7530,6 @@ packages:
       '@ethersproject/solidity': 5.7.0
       bs58: 5.0.0
       tiny-invariant: 1.3.3
-    dev: true
-
-  /@layerzerolabs/oft-v2-solana-sdk@3.0.0(fastestsmallesttextencoderdecoder@1.0.22):
-    resolution: {integrity: sha512-fiamhnEafuf83B45mDwj17rvp1BLFUmYGJEtzjp+nkKV6ZVwQwdtCXocq/5Kh8BbflEXmvpkHP+KxCHremFw6g==}
-    dependencies:
-      '@ethersproject/bytes': 5.7.0
-      '@layerzerolabs/lz-solana-sdk-v2': 3.0.0(fastestsmallesttextencoderdecoder@1.0.22)
-      '@layerzerolabs/lz-v2-utilities': 3.0.38
-      '@metaplex-foundation/beet': 0.7.2
-      '@metaplex-foundation/beet-solana': 0.4.1
-      '@metaplex-foundation/umi': 0.9.2
-      '@metaplex-foundation/umi-eddsa-web3js': 0.9.2(@metaplex-foundation/umi@0.9.2)(@solana/web3.js@1.95.8)
-      '@metaplex-foundation/umi-program-repository': 0.9.2(@metaplex-foundation/umi@0.9.2)
-      '@metaplex-foundation/umi-web3js-adapters': 0.9.2(@metaplex-foundation/umi@0.9.2)(@solana/web3.js@1.95.8)
-      '@solana/web3.js': 1.95.8
-      bn.js: 5.2.1
-      dotenv: 16.4.5
-    transitivePeerDependencies:
-      - bufferutil
-      - debug
-      - encoding
-      - fastestsmallesttextencoderdecoder
-      - supports-color
-      - utf-8-validate
     dev: true
 
   /@layerzerolabs/oft-v2-solana-sdk@3.0.38(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.5.3):


### PR DESCRIPTION
Currently, package.json has the following

```
"@layerzerolabs/oft-v2-solana-sdk": "3.0.0",
```

This was locking (exact versioning) the Solana OFT SDK version to 3.0.0, which led our versioning bot to not update it. This PR fixes it by using caret versioning starting from the update that has the updated exports.

this is related to https://github.com/LayerZero-Labs/devtools/pull/1252