### PR TITLE
chore: update workflow to match images

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -17,7 +17,7 @@ USE VS-CODE. CURSOR DOES NOT WORK.
 ### Prebuilt images (default)
 
 By default, the devcontainer will use the prebuilt base images from [GHCR](https://github.com/LayerZero-Labs/devtools/pkgs/container/devtools-dev-base).
-(temporary change: using "image": "ghcr.io/layerzero-labs/devtools-dev-base:shankar-create_images_for_both_architectures")
+(temporary change: using "image": "ghcr.io/layerzero-labs/devtools-dev-base:main")
 
 ### Local images
 

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "name": "LayerZero Devtools",
-  "image": "ghcr.io/layerzero-labs/devtools-dev-base:shankar-create_images_for_both_architectures",
+  "image": "ghcr.io/layerzero-labs/devtools-dev-base:main",
   "mounts": ["type=volume,target=${containerWorkspaceFolder}/node_modules"],
   "runArgs": ["--env-file", ".env"],
   "features": {

--- a/.github/README.md
+++ b/.github/README.md
@@ -1,4 +1,7 @@
+# GitHub Actions
+
 Since we operate with multiple architectures, we need to build and publish the images for each architecture.
+We also need to maintain architecture specific caches of the images to prevent the workflow from using the cache of the wrong architecture - notably affects hardhat cache.
 
 We use the `reusable-publish-docker.yaml` workflow to build and publish the images for each architecture.
 
@@ -6,10 +9,15 @@ We use the `reusable-test.yaml` workflow to test the images for each architectur
 
 Under each workflow, we have a matrix that includes the architecture and the runner.
 
-Runners as of the last change (2025-02-08):
+Runners as of the last change (2025-02-12):
+
 - ubuntu-latest-16xlarge for amd64
 - ubuntu-latest-16xlarge-arm for arm64
 
 This generates an entire workflow run for each architecture.
 
 This also means we need to select the right image for the user's architecture.
+
+We can do this by using the `matrix` keyword in the workflow.
+
+Original image: <https://github.com/LayerZero-Labs/devtools/pkgs/container/devtools-dev-base/304693620>

--- a/.github/README.md
+++ b/.github/README.md
@@ -9,7 +9,7 @@ We use the `reusable-test.yaml` workflow to test the images for each architectur
 
 Under each workflow, we have a matrix that includes the architecture and the runner.
 
-Runners as of the last change (2025-02-12):
+Runners as of the last change (2025-02-11):
 
 - ubuntu-latest-16xlarge for amd64
 - ubuntu-latest-16xlarge-arm for arm64

--- a/.github/workflows/actions/install-dependencies/action.yaml
+++ b/.github/workflows/actions/install-dependencies/action.yaml
@@ -4,6 +4,15 @@ runs:
   using: "composite"
   steps:
     # Clean Hardhat cache directory manually
+    # Required because certain packages or dependencies like zksolc on hardhat are architecture specific fetches during the building stage. 
+    # We don't want to use the cache of the wrong architecture, so we clean the cache manually.
+    # Running dual caches for hardhat - on amd64 and arm64 because the binaries they generate (for zksolc and hardhat's compiler) is platform dependant) and hardhat checks if the zksolc library exists
+    # 
+    # Example:
+    # ls /root/.cache/hardhat-nodejs/compilers-v2/
+    # linux-amd64  wasm  zksolc  zkvm-solc
+    # 
+    #-> it finds it -> it tries it and you get the error based on pipe Error: write EPIPE as it fetches the wrong architecture's cache
     - name: Clean Hardhat Cache
       shell: bash
       run: |

--- a/.github/workflows/actions/setup-build-cache/action.yaml
+++ b/.github/workflows/actions/setup-build-cache/action.yaml
@@ -7,6 +7,8 @@ runs:
     #
     # This step will speed up workflow runs that don't touch the whole codebase
     # (or the ones that don't touch the codebase at all)
+
+    # We build architecture specific caches for turbo builds as there can be differences in the build artifacts between architectures
     - name: Cache turbo build setup
       uses: actions/cache@v4
       with:
@@ -27,6 +29,8 @@ runs:
     # Cache hardhat compilers
     #
     # This step will speed up workflow runs that use hardhat compilation
+
+    # We build architecture specific caches for hardhat compilers as there can be differences in the build artifacts between architectures
     - name: Cache hardhat compilers
       uses: actions/cache@v4
       with:

--- a/.github/workflows/reusable-publish.yaml
+++ b/.github/workflows/reusable-publish.yaml
@@ -34,7 +34,7 @@ jobs:
 
     # We'll run the job on the prebuilt base image
     container:
-      image: ghcr.io/layerzero-labs/devtools-dev-base:shankar-create_images_for_both_architectures
+      image: ghcr.io/layerzero-labs/devtools-dev-base:main
 
     steps:
       - name: Checkout repo

--- a/.github/workflows/reusable-test.yaml
+++ b/.github/workflows/reusable-test.yaml
@@ -38,7 +38,7 @@ jobs:
     
     # We'll run the job on the prebuilt base image
     container:
-      image: ghcr.io/layerzero-labs/devtools-dev-base:shankar-create_images_for_both_architectures
+      image: ghcr.io/layerzero-labs/devtools-dev-base:main
 
     steps:
       - name: Checkout repo
@@ -107,11 +107,11 @@ jobs:
           JEST_TIMEOUT: 30000  # Increase timeout for ARM builds
           TEST_TIMEOUT: 300000 # 5 minutes timeout for long-running tests
           # We'll use the prebuilt base image
-          DEVTOOLS_BASE_IMAGE: ghcr.io/layerzero-labs/devtools-dev-base:shankar-create_images_for_both_architectures
+          DEVTOOLS_BASE_IMAGE: ghcr.io/layerzero-labs/devtools-dev-base:main
           # And the prebuilt hardhat EVM node image
-          DEVTOOLS_EVM_NODE_IMAGE: ghcr.io/layerzero-labs/devtools-dev-node-evm-hardhat:shankar-create_images_for_both_architectures
+          DEVTOOLS_EVM_NODE_IMAGE: ghcr.io/layerzero-labs/devtools-dev-node-evm-hardhat:main
           # And the prebuilt TON node image
-          DEVTOOLS_TON_NODE_IMAGE: ghcr.io/layerzero-labs/devtools-dev-node-ton-my-local-ton:shankar-create_images_for_both_architectures
+          DEVTOOLS_TON_NODE_IMAGE: ghcr.io/layerzero-labs/devtools-dev-node-ton-my-local-ton:main
           # Provided we have good quality Solana RPCs, we can enable Solana tests
           #
           # FIXME The Solana tests need to be ported to either use a stable deployment
@@ -172,15 +172,15 @@ jobs:
           LAYERZERO_EXAMPLES_REPOSITORY_URL: https://github.com/${{ github.repository }}.git
           LAYERZERO_EXAMPLES_REPOSITORY_REF: ${{ github.ref }}
           # We'll use the prebuilt base image
-          DEVTOOLS_BASE_IMAGE: ghcr.io/layerzero-labs/devtools-dev-base:shankar-create_images_for_both_architectures
+          DEVTOOLS_BASE_IMAGE: ghcr.io/layerzero-labs/devtools-dev-base:main
           # And the prebuilt hardhat EVM node image
-          DEVTOOLS_EVM_NODE_IMAGE: ghcr.io/layerzero-labs/devtools-dev-node-evm-hardhat:shankar-create_images_for_both_architectures
+          DEVTOOLS_EVM_NODE_IMAGE: ghcr.io/layerzero-labs/devtools-dev-node-evm-hardhat:main
           # Using the local Aptos testnet node
-          DEVTOOLS_APTOS_NODE_IMAGE: ghcr.io/layerzero-labs/devtools-dev-node-aptos-local-testnet:shankar-create_images_for_both_architectures
+          DEVTOOLS_APTOS_NODE_IMAGE: ghcr.io/layerzero-labs/devtools-dev-node-aptos-local-testnet:main
           # Using the local TON node - i do not know if this is working
-          DEVTOOLS_TON_NODE_IMAGE: ghcr.io/layerzero-labs/devtools-dev-node-ton-my-local-ton:shankar-create_images_for_both_architectures
+          DEVTOOLS_TON_NODE_IMAGE: ghcr.io/layerzero-labs/devtools-dev-node-ton-my-local-ton:main
           # Using the local Solana test validator - may fail due to RPC issues
-          DEVTOOLS_SOLANA_NODE_IMAGE: ghcr.io/layerzero-labs/devtools-dev-node-solana-test-validator:shankar-create_images_for_both_architectures
+          DEVTOOLS_SOLANA_NODE_IMAGE: ghcr.io/layerzero-labs/devtools-dev-node-solana-test-validator:main
 
 
       # We'll collect the docker compose logs from all containers on failure

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ ARG NODE_VERSION=20.10.0
 # and the base image is built locally
 # 
 # The CI environment will use base images from https://github.com/LayerZero-Labs/devtools/pkgs/container/devtools-dev-base
-# e.g. ghcr.io/layerzero-labs/devtools-dev-base:shankar-create_images_for_both_architectures
+# e.g. ghcr.io/layerzero-labs/devtools-dev-base:main
 ARG BASE_IMAGE=base
 
 # We will provide a way for consumers to override the default Aptos node image

--- a/Dockerfile
+++ b/Dockerfile
@@ -80,8 +80,8 @@ RUN apt-get install --yes \
     expect \
     # Parallel is a utilit we use to parallelize the BATS (user) tests
     parallel \
-    # Utilities required to build solana
-    pkg-config libudev-dev llvm libclang-dev protobuf-compiler cmake\
+    # Utilities required to build solana - and cmake is required for building platform tools used by solana
+    pkg-config libudev-dev llvm libclang-dev protobuf-compiler cmake \
     # Utilities required to build aptos CLI
     libssl-dev libdw-dev lld \
     # Required for TON to run
@@ -199,14 +199,14 @@ ENV CARGO_BUILD_JOBS=$CARGO_BUILD_JOBS
 RUN BUILD_FROM_SOURCE=true; \
     # Install Solana using a binary with a fallback to installing from source. 
     # List of machines that have prebuilt binaries:
-    # - amd64/linux - last checked on Feb 10, 2025
+    # - amd64/linux - last checked on Feb 11, 2025
     if [ "$(dpkg --print-architecture)" = "amd64" ]; then \
         curl --proto '=https' --tlsv1.2 -sSf https://release.anza.xyz/v${SOLANA_VERSION}/install | sh -s && \
         BUILD_FROM_SOURCE=false; \
     fi && \
     # If we need to build from source, we'll do it here
     # List of machines that need to be built from source:
-    # - arm64/linux - last checked on Feb 10, 2025
+    # - arm64/linux - last checked on Feb 11, 2025
     if [ "$BUILD_FROM_SOURCE" = "true" ]; then \
             git clone https://github.com/anza-xyz/agave.git --depth 1 --branch v${SOLANA_VERSION} ~/solana-v${SOLANA_VERSION} && \
             # Produces the same directory structure as the prebuilt binaries


### PR DESCRIPTION
With the devtools image workflow changed and re-published on a tag with `:main` <https://github.com/LayerZero-Labs/devtools/actions/runs/13273422696>

This PR updated the image tagging from using a specific tag from a (now deleted) branch 
`shankar-create_images_for_both_architectures` that was used during the PR for the devtools image+workflow fix - <https://github.com/LayerZero-Labs/devtools/pull/1257> 


The old image tagged `main`:
https://github.com/LayerZero-Labs/devtools/pkgs/container/devtools-dev-base/304693620


And some documentation and comments as a bonus