### PR TITLE
🪲 temporarily remove hardhat cache

### DIFF
--- a/.github/workflows/actions/setup-build-cache/action.yaml
+++ b/.github/workflows/actions/setup-build-cache/action.yaml
@@ -25,25 +25,3 @@ runs:
           ${{ runner.os }}-${{ runner.arch }}-turbo-${{ github.base_ref }}-
           ${{ runner.os }}-${{ runner.arch }}-turbo-${{ github.event.repository.default_branch }}-
           ${{ runner.os }}-${{ runner.arch }}-turbo-
-
-    # Cache hardhat compilers
-    #
-    # This step will speed up workflow runs that use hardhat compilation
-
-    # We build architecture specific caches for hardhat compilers as there can be differences in the build artifacts between architectures
-    - name: Cache hardhat compilers
-      uses: actions/cache@v4
-      with:
-        path: .cache/hardhat
-        key: ${{ runner.os }}-${{ runner.arch }}-hardhat-${{ github.ref_name }}-${{ github.sha }}
-        # The hierarchy of restoring the cache goes as follows:
-        #
-        # - First we try to match an existing cache from the same branch
-        # - Then we try to match a cache from the target branch of this PR (if this is not a PR, this cache will never exist)
-        # - Then we try to match a cache from the default branch
-        # - Then we try to match any cache
-        restore-keys: |
-          ${{ runner.os }}-${{ runner.arch }}-hardhat-${{ github.ref_name }}-
-          ${{ runner.os }}-${{ runner.arch }}-hardhat-${{ github.base_ref }}-
-          ${{ runner.os }}-${{ runner.arch }}-hardhat-${{ github.event.repository.default_branch }}-
-          ${{ runner.os }}-${{ runner.arch }}-hardhat-


### PR DESCRIPTION
This is breaking since it was made architecture-dependent. Rather than try to fix, just disable the cache right now.