### PR TITLE
refactor(oft-solana): move to own script and update task name

### DIFF
--- a/.changeset/orange-birds-brush.md
+++ b/.changeset/orange-birds-brush.md
@@ -1,0 +1,5 @@
+---
+"@layerzerolabs/oft-solana-example": patch
+---
+
+move solana init to own script and update task name

--- a/examples/oft-solana/README.md
+++ b/examples/oft-solana/README.md
@@ -258,7 +258,7 @@ Note: If you are on testnet, consider using `MyOFTMock` to allow test token mint
 :warning: Do this only when initializing the OFT for the first time. The only exception is if a new pathway is added later. If so, run this again to properly initialize the pathway.
 
 ```bash
-npx hardhat lz:oapp:init:solana --oapp-config layerzero.config.ts --solana-secret-key <SECRET_KEY> --solana-program-id <PROGRAM_ID>
+npx hardhat lz:oft:solana:init-config --oapp-config layerzero.config.ts --solana-secret-key <SECRET_KEY> --solana-program-id <PROGRAM_ID>
 ```
 
 :information_source: `<SECRET_KEY>` should also be in base58 format.

--- a/examples/oft-solana/tasks/common/wire.ts
+++ b/examples/oft-solana/tasks/common/wire.ts
@@ -2,7 +2,7 @@ import { Keypair, PublicKey } from '@solana/web3.js'
 import { subtask, task } from 'hardhat/config'
 
 import { firstFactory } from '@layerzerolabs/devtools'
-import { SUBTASK_LZ_SIGN_AND_SEND, inheritTask, types } from '@layerzerolabs/devtools-evm-hardhat'
+import { SUBTASK_LZ_SIGN_AND_SEND, types } from '@layerzerolabs/devtools-evm-hardhat'
 import { setTransactionSizeBuffer } from '@layerzerolabs/devtools-solana'
 import { type LogLevel, createLogger } from '@layerzerolabs/io-devtools'
 import { type IOApp, type OAppConfigurator, type OAppOmniGraph, configureOwnable } from '@layerzerolabs/ua-devtools'
@@ -12,7 +12,6 @@ import {
     TASK_LZ_OAPP_WIRE,
     TASK_LZ_OWNABLE_TRANSFER_OWNERSHIP,
 } from '@layerzerolabs/ua-devtools-evm-hardhat'
-import { initOFTAccounts } from '@layerzerolabs/ua-devtools-solana'
 
 import { keyPair, publicKey } from './types'
 import { createSdkFactory, createSolanaConnectionFactory, createSolanaSignerFactory } from './utils'
@@ -172,13 +171,3 @@ task(TASK_LZ_OWNABLE_TRANSFER_OWNERSHIP)
     .setAction(async (args: Args, hre) => {
         return hre.run(TASK_LZ_OAPP_WIRE, { ...args, internalConfigurator: configureOwnable })
     })
-
-// We'll create clones of the wire task and only override the configurator argument
-const wireLikeTask = inheritTask(TASK_LZ_OAPP_WIRE)
-
-// This task will use the `initOFTAccounts` configurator that initializes the Solana accounts
-wireLikeTask('lz:oapp:init:solana')
-    .setDescription('Initialize OFT accounts for Solana')
-    .setAction(async (args: Args, hre) =>
-        hre.run(TASK_LZ_OAPP_WIRE, { ...args, internalConfigurator: initOFTAccounts })
-    )

--- a/examples/oft-solana/tasks/index.ts
+++ b/examples/oft-solana/tasks/index.ts
@@ -1,6 +1,7 @@
 import './common/config.get'
 import './common/wire'
 import './evm/send'
+import './solana/initConfig'
 import './solana/clearPayload'
 import './solana/createOFT'
 import './solana/createOFTAdapter'

--- a/examples/oft-solana/tasks/solana/initConfig.ts
+++ b/examples/oft-solana/tasks/solana/initConfig.ts
@@ -1,0 +1,32 @@
+import { Keypair, PublicKey } from '@solana/web3.js'
+import { ConfigurableTaskDefinition } from 'hardhat/types'
+
+import { inheritTask } from '@layerzerolabs/devtools-evm-hardhat'
+import { type LogLevel } from '@layerzerolabs/io-devtools'
+import { type OAppConfigurator } from '@layerzerolabs/ua-devtools'
+import { TASK_LZ_OAPP_WIRE } from '@layerzerolabs/ua-devtools-evm-hardhat'
+import { initOFTAccounts } from '@layerzerolabs/ua-devtools-solana'
+
+// We'll create clones of the wire task and only override the configurator argument
+const wireLikeTask = inheritTask(TASK_LZ_OAPP_WIRE)
+
+/**
+ * Additional CLI arguments for our custom wire task
+ */
+interface Args {
+    logLevel: LogLevel
+    solanaProgramId: PublicKey
+    solanaSecretKey?: Keypair
+    multisigKey?: PublicKey
+    internalConfigurator?: OAppConfigurator
+}
+
+// This task will use the `initOFTAccounts` configurator that initializes the Solana accounts
+const initConfigTask = wireLikeTask('lz:oft:solana:init-config') as ConfigurableTaskDefinition
+
+// TODO: currently the message for 'already done' state is "OApp is already wired." which is misleading -> should be changed to "Pathway Config already initialized"
+initConfigTask
+    .setDescription('Initialize OFT accounts for Solana')
+    .setAction(async (args: Args, hre) =>
+        hre.run(TASK_LZ_OAPP_WIRE, { ...args, internalConfigurator: initOFTAccounts })
+    )


### PR DESCRIPTION
This PR
- rename the hardhat task from `lz:oapp:init:solana` to the more accurate `lz:oft:solana:init-config`
- moves that task to under the `solana` folder and into its own file (keeping to 1 task = 1 file) 

Test transaction calling renamed task: https://solscan.io/tx/H1rJyWk4bsirsycT5cKHfrHfyhwrCSTYrZ6rFD6qs1REAewrSiCGdF6SHzVHA7VPYzNJ9ARK226ustoZVEby8vF?cluster=devnet