### PR TITLE
fix: anchor build has a race condition where it tries building the rust toolchain concurrently across different anchor builds

### DIFF
--- a/.github/workflows/actions/install-dependencies/action.yaml
+++ b/.github/workflows/actions/install-dependencies/action.yaml
@@ -34,3 +34,11 @@ runs:
     - name: Rebuild NPM packages
       shell: bash
       run: pnpm rebuild --recursive
+
+    # Install Rustup
+    - name: Install Rustup
+      shell: bash
+      run: |
+        export CARGO_HOME=/root/.cargo
+        export RUSTUP_HOME=/root/.rustup
+        rustup default 1.75.0

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -99,4 +99,10 @@ services:
       # as a cache directory for hardhat so that the permissions
       # don't clash
       - ./.cache/hardhat:/root/.cache/hardhat-nodejs
-    command: "pnpm test"
+      # This is required because anchor build tries to rebuild rustup. 
+      # We build stuff in parallel to be fast.
+      # This would normally be fine, but if we have more than 1 solana examples anchor tries building them in parallel.
+      # Anchor does not respect file locks on the rustup directory, so the builds fail as it can't overwrite the other example's rustup.
+      # Running rustup default before pnpm test ensures that the rustup directory is present and up to date.
+    command: >
+        sh -c "rustup default 1.75.0 && pnpm test"

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "start": "docker compose -f docker-compose.yaml -f docker-compose.local.yaml up network-britney network-vengaboys network-tango network-ton --wait $DOCKER_COMPOSE_ARGS",
     "stop": "docker compose down",
     "test": "$npm_execpath turbo run test $DOCKER_COMPOSE_RUN_TESTS_TURBO_ARGS",
-    "test:ci": "docker compose run --build --rm $DOCKER_COMPOSE_ARGS tests pnpm turbo run test --verbosity=3",
+    "test:ci": "docker compose run --build --rm $DOCKER_COMPOSE_ARGS tests",
     "test:jest": "$npm_execpath turbo run test:jest $DOCKER_COMPOSE_RUN_TESTS_TURBO_ARGS",
     "test:local": ". bin/env && $npm_execpath start && $npm_execpath test",
     "test:local:jest": ". bin/env && $npm_execpath start && $npm_execpath test:jest",


### PR DESCRIPTION
`anchor build` runs a rust toolchain build process when run, this creates temp files that it later tries copying in. 
The issue is that we run `pnpm turbo compile` in parallel - this makes it so that we have more than 1 `anchor build` running at the same time. 

These `anchor builds` end up in a state where they each create temporary files (`/root/.rustup/downloads/`) that they want to copy into the "main" rust directory (`/root/.rustup/toolchains/`). This breaks because the first `anchor build` that completes building locks the rustup file as it is now building the solana contracts. During this time the other `anchor build` completes and tries copying its new files into `/root/.rustup/toolchains/` which fails because of the original `anchor build` process. 

This PR pre-builds the rust toolchain that results in `anchor builds` skipping the "build rust toolchain step"

- the original PR that had this issue and fails at the compile step `@layerzerolabs/lzapp-migration-example#compile`<https://github.com/LayerZero-Labs/devtools/actions/runs/13282282114/job/37117263197?pr=1202> 
- my test branch that incorporates these changes locally that now fails with `@layerzerolabs/lzapp-migration-example#test` due to a logic issue `Stack offset of 4608 exceeded max offset of 4096 by 512 bytes` <https://github.com/LayerZero-Labs/devtools/actions/runs/13296998189/job/37131714610?pr=1272>

note: this might be fixed by simply setting the default toolchain in `Dockerfile` to 1.75.0. let us use this patch for the time being