### PR TITLE
feat: enable `anchor keys sync` auto-replacement by removing `program_id_from_env!`

### DIFF
--- a/examples/lzapp-migration/README.md
+++ b/examples/lzapp-migration/README.md
@@ -76,6 +76,7 @@ Run
 anchor keys sync
 anchor keys list
 ```
+
 :information_source: `anchor keys sync` will replace the example programId value in `declare_id!()` and `Anchor.toml` to match the created keypair's.
 
 :information_source: `anchor keys list` will output the generated programIds (public keys). It should look something like this:

--- a/examples/lzapp-migration/README.md
+++ b/examples/lzapp-migration/README.md
@@ -68,21 +68,22 @@ pnpm compile
 ```bash
 solana-keygen new -o target/deploy/endpoint-keypair.json --force
 solana-keygen new -o target/deploy/oft-keypair.json --force
+```
 
+Run
+
+```
 anchor keys sync
 anchor keys list
 ```
+:information_source: `anchor keys sync` will replace the example programId value in `declare_id!()` and `Anchor.toml` to match the created keypair's.
 
-Copy the OFT's programId and go into [programs/oft202/lib.rs](./programs/oft202/src/lib.rs). Note the following snippet:
+:information_source: `anchor keys list` will output the generated programIds (public keys). It should look something like this:
 
-```rust
-declare_id!(Pubkey::new_from_array(program_id_from_env!(
-    "OFT_ID",
-    "3ThC8DDzimnnrt4mvJSKFpWQA3UvnbzKM3mT6SHoNQKu"
-)));
 ```
-
-Replace `3ThC8DDzimnnrt4mvJSKFpWQA3UvnbzKM3mT6SHoNQKu` with the programId that you have copied.
+endpoint: <ENDPOINT_PROGRAM_ID>
+oft: <OFT_PROGRAM_ID>
+```
 
 ### Building and Deploying the Solana OFT Program
 

--- a/examples/lzapp-migration/programs/oft202/src/lib.rs
+++ b/examples/lzapp-migration/programs/oft202/src/lib.rs
@@ -19,10 +19,7 @@ use oapp::{
 use solana_helper::program_id_from_env;
 use state::*;
 
-declare_id!(Pubkey::new_from_array(program_id_from_env!(
-    "OFT_ID",
-    "3ThC8DDzimnnrt4mvJSKFpWQA3UvnbzKM3mT6SHoNQKu"
-)));
+declare_id!("3ThC8DDzimnnrt4mvJSKFpWQA3UvnbzKM3mT6SHoNQKu");
 
 pub const OFT_SEED: &[u8] = b"OFT";
 pub const PEER_SEED: &[u8] = b"Peer";

--- a/examples/oft-solana/README.md
+++ b/examples/oft-solana/README.md
@@ -94,8 +94,6 @@ Create `programId` keypair files by running:
 ```bash
 solana-keygen new -o target/deploy/endpoint-keypair.json --force
 solana-keygen new -o target/deploy/oft-keypair.json --force
-
-anchor keys sync
 ```
 
 :warning: `--force` flag overwrites the existing keys with the ones you generate.
@@ -103,26 +101,17 @@ anchor keys sync
 Run
 
 ```
+anchor keys sync
 anchor keys list
 ```
+:information_source: `anchor keys sync` will replace the example programId value in `declare_id!()` and `Anchor.toml` to match the created keypair's.
 
-to view the generated programIds (public keys). The output should look something like this:
+:information_source: `anchor keys list` will output the generated programIds (public keys). It should look something like this:
 
 ```
 endpoint: <ENDPOINT_PROGRAM_ID>
 oft: <OFT_PROGRAM_ID>
 ```
-
-Copy the OFT's programId and go into [lib.rs](./programs/oft/src/lib.rs). Note the following snippet:
-
-```
-declare_id!(Pubkey::new_from_array(program_id_from_env!(
-    "OFT_ID",
-    "9UovNrJD8pQyBLheeHNayuG1wJSEAoxkmM14vw5gcsTT"
-)));
-```
-
-Replace `9UovNrJD8pQyBLheeHNayuG1wJSEAoxkmM14vw5gcsTT` with the programId that you have copied.
 
 ### Building and Deploying the Solana OFT Program
 

--- a/examples/oft-solana/README.md
+++ b/examples/oft-solana/README.md
@@ -104,6 +104,7 @@ Run
 anchor keys sync
 anchor keys list
 ```
+
 :information_source: `anchor keys sync` will replace the example programId value in `declare_id!()` and `Anchor.toml` to match the created keypair's.
 
 :information_source: `anchor keys list` will output the generated programIds (public keys). It should look something like this:

--- a/examples/oft-solana/programs/oft/src/lib.rs
+++ b/examples/oft-solana/programs/oft/src/lib.rs
@@ -17,10 +17,7 @@ use oapp::{
 use solana_helper::program_id_from_env;
 use state::*;
 
-declare_id!(Pubkey::new_from_array(program_id_from_env!(
-    "OFT_ID",
-    "9UovNrJD8pQyBLheeHNayuG1wJSEAoxkmM14vw5gcsTT"
-)));
+declare_id!("9UovNrJD8pQyBLheeHNayuG1wJSEAoxkmM14vw5gcsTT");
 
 pub const OFT_SEED: &[u8] = b"OFT";
 pub const PEER_SEED: &[u8] = b"Peer";


### PR DESCRIPTION
## Context

- Currently, we require developers to manually replace the program ID in the OFT's `lib.rs`. This creates an opportunity for human error. We have encountered cases where the developer has forgotten to do this. This will not result in an error during program deployment, but will come up when running the init-config/wire commands.
  - Impact: re-building and re-deployment would be required
- We already ask developers to run `anchor keys sync`, which normally would remove the need for the above manual programId replacement. However, it won't auto replace the value since we use `Pubkey::new_from_array(program_id_from_env!(XXX))`


## Motivation

If we remove the usage of `program_id_from_env!`, then we can remove the need for manual replacement of `programId`, thereby removing once opportunity for human error during development. Replacement is handled by the existing `anchor keys sync` command. Improved DevEx unlocked.

## Changes

- Removed `program_id_from_env!` from `declare_id!`