### PR TITLE
fix(lzapp-migration): add missing value

### DIFF
--- a/examples/lzapp-migration/layerzero.config.ts
+++ b/examples/lzapp-migration/layerzero.config.ts
@@ -35,6 +35,7 @@ const config: OAppOmniGraphHardhat = {
                 },
                 sendConfig: {
                     executorConfig: {
+                        maxMessageSize: 10000,
                         executor: '0x718B92b5CB0a5552039B593faF724D182A881eDA',
                     },
                     ulnConfig: {

--- a/examples/lzapp-migration/layerzero.config.ts
+++ b/examples/lzapp-migration/layerzero.config.ts
@@ -35,7 +35,7 @@ const config: OAppOmniGraphHardhat = {
                 },
                 sendConfig: {
                     executorConfig: {
-                        maxMessageSize: 10000,
+                        maxMessageSize: 200,
                         executor: '0x718B92b5CB0a5552039B593faF724D182A881eDA',
                     },
                     ulnConfig: {


### PR DESCRIPTION
without a value for `maxMessageSize`, the following error appears when running `init-config`:

```
An unexpected error occurred:

Error: Config from file 'layerzero.config.ts' is malformed. Please fix the following errors:

Property 'connections.0.config.sendConfig.executorConfig.maxMessageSize': Expected number, received nan
```