### PR TITLE
fix(solana oft examples): wrong eid value

### DIFF
--- a/examples/lzapp-migration/tasks/solana/clearPayload.ts
+++ b/examples/lzapp-migration/tasks/solana/clearPayload.ts
@@ -28,7 +28,7 @@ task('lz:oft:solana:clear', 'Clear a stored payload on Solana')
     .addParam('srcEid', 'The source EndpointId', undefined, types.eid)
     .addParam('nonce', 'The nonce of the payload', undefined, types.bigint)
     .addParam('sender', 'The source OApp address (hex)', undefined, types.string)
-    .addParam('dstEid', 'The destination EndpointId', undefined, types.eid)
+    .addParam('dstEid', 'The destination EndpointId (Solana chain)', undefined, types.eid)
     .addParam('receiver', 'The receiver address on the destination Solana chain (bytes58)', undefined, types.string)
     .addParam('guid', 'The GUID of the message (hex)', undefined, types.string)
     .addParam('payload', 'The message payload (hex)', undefined, types.string)
@@ -52,7 +52,7 @@ task('lz:oft:solana:clear', 'Clear a stored payload on Solana')
                 throw new Error('SOLANA_PRIVATE_KEY is not defined in the environment variables.')
             }
 
-            const { connection, umiWalletKeyPair } = await deriveConnection(srcEid)
+            const { connection, umiWalletKeyPair } = await deriveConnection(dstEid)
             const signer = toWeb3JsKeypair(umiWalletKeyPair)
             const { blockhash, lastValidBlockHeight } = await connection.getLatestBlockhash()
             const tx = new web3.Transaction({
@@ -89,7 +89,7 @@ task('lz:oft:solana:clear', 'Clear a stored payload on Solana')
             tx.add(instruction)
             tx.recentBlockhash = blockhash
 
-            const keypair = Keypair.fromSecretKey(bs58.decode(process.env.SOLANA_PRIVATE_KEY!))
+            const keypair = Keypair.fromSecretKey(bs58.decode(process.env.SOLANA_PRIVATE_KEY))
             tx.sign(keypair)
 
             const signature = await sendAndConfirmTransaction(connection, tx, [keypair], { skipPreflight: true })

--- a/examples/oft-solana/tasks/solana/clearPayload.ts
+++ b/examples/oft-solana/tasks/solana/clearPayload.ts
@@ -28,7 +28,7 @@ task('lz:oft:solana:clear', 'Clear a stored payload on Solana')
     .addParam('srcEid', 'The source EndpointId', undefined, types.eid)
     .addParam('nonce', 'The nonce of the payload', undefined, types.bigint)
     .addParam('sender', 'The source OApp address (hex)', undefined, types.string)
-    .addParam('dstEid', 'The destination EndpointId', undefined, types.eid)
+    .addParam('dstEid', 'The destination EndpointId (Solana chain)', undefined, types.eid)
     .addParam('receiver', 'The receiver address on the destination Solana chain (bytes58)', undefined, types.string)
     .addParam('guid', 'The GUID of the message (hex)', undefined, types.string)
     .addParam('payload', 'The message payload (hex)', undefined, types.string)
@@ -52,7 +52,7 @@ task('lz:oft:solana:clear', 'Clear a stored payload on Solana')
                 throw new Error('SOLANA_PRIVATE_KEY is not defined in the environment variables.')
             }
 
-            const { connection, umiWalletKeyPair } = await deriveConnection(srcEid)
+            const { connection, umiWalletKeyPair } = await deriveConnection(dstEid)
             const signer = toWeb3JsKeypair(umiWalletKeyPair)
             const { blockhash, lastValidBlockHeight } = await connection.getLatestBlockhash()
             const tx = new web3.Transaction({
@@ -89,7 +89,7 @@ task('lz:oft:solana:clear', 'Clear a stored payload on Solana')
             tx.add(instruction)
             tx.recentBlockhash = blockhash
 
-            const keypair = Keypair.fromSecretKey(bs58.decode(process.env.SOLANA_PRIVATE_KEY!))
+            const keypair = Keypair.fromSecretKey(bs58.decode(process.env.SOLANA_PRIVATE_KEY))
             tx.sign(keypair)
 
             const signature = await sendAndConfirmTransaction(connection, tx, [keypair], { skipPreflight: true })


### PR DESCRIPTION
## Currently

- to retry a message from Sepolia (v2) to Solana devnet, the srcEid would be 40161 an dstEid 40168
- calling below

```
npx hardhat lz:oft:solana:clear --src-eid 40161 --nonce 1 --sender 0xe1eED933016cC1beC850293CBAb5C24C32593C1a --dst-eid 40168 --receiver CRrcjPei8nh4K3rt9F4shJDA93JvceBygTxcVFdvfqgY --guid 0x1e8bc9911c2cba4fbd7c0cbc9d2fa7fdc0f112ded2ccd32d12ab9236432f301e --payload 0xc5e6e695fea2780025efd3d9211876ab08ca14af52d8bc3fac40034da287901400000000000003e8 --lamports 2500000 --compute-units 200000 --with-priority-fee 400000
```

would result in 

```
Error: Could not find a default Solana RPC URL for eid 40161 (SEPOLIA_V2_TESTNET)
```

due to

```
const { connection, umiWalletKeyPair } = await deriveConnection(srcEid)
```

## Changes
- replace `srcEid` with `dstEid` since the script is for retrying `lzReceive` on Solana chains
- remove redundant non null assertion since we already have on line 51:

```
  if (!process.env.SOLANA_PRIVATE_KEY) {
      throw new Error('SOLANA_PRIVATE_KEY is not defined in the environment variables.')
  }
```