### PR TITLE
feat(oft-solana): remove need to pass in solana secret key flag

### DIFF
--- a/.changeset/small-beans-ring.md
+++ b/.changeset/small-beans-ring.md
@@ -1,0 +1,5 @@
+---
+"@layerzerolabs/oft-solana-example": patch
+---
+
+feat(oft-solana): remove need to pass in solana secret key flag

--- a/examples/oft-solana/README.md
+++ b/examples/oft-solana/README.md
@@ -258,17 +258,15 @@ Note: If you are on testnet, consider using `MyOFTMock` to allow test token mint
 Run the following command to init the pathway config. This step is unique to pathways that involve Solana.
 
 ```bash
-npx hardhat lz:oft:solana:init-config --oapp-config layerzero.config.ts --solana-secret-key <SECRET_KEY> --solana-program-id <PROGRAM_ID>
+npx hardhat lz:oft:solana:init-config --oapp-config layerzero.config.ts --solana-program-id <PROGRAM_ID>
 ```
-
-:information_source: `<SECRET_KEY>` should also be in base58 format.
 
 ### Wire
 
 Run the following to wire the pathways specified in your `layerzero.config.ts`
 
 ```bash
-npx hardhat lz:oapp:wire --oapp-config layerzero.config.ts --solana-secret-key <PRIVATE_KEY> --solana-program-id <PROGRAM_ID>
+npx hardhat lz:oapp:wire --oapp-config layerzero.config.ts --solana-program-id <PROGRAM_ID>
 ```
 
 With a squads multisig, you can simply append the `--multisig-key` flag to the end of the above command.
@@ -346,7 +344,7 @@ How to set delegate: https://docs.layerzero.network/v2/developers/evm/create-lz-
 Now run
 
 ```
-npx hardhat lz:oapp:wire --oapp-config layerzero.config.ts --solana-secret-key <PRIVATE_KEY> --solana-program-id <PROGRAM_ID>
+npx hardhat lz:oapp:wire --oapp-config layerzero.config.ts --solana-program-id <PROGRAM_ID>
 ```
 
 and execute the transactions.
@@ -358,7 +356,7 @@ How to set owner: https://docs.layerzero.network/v2/developers/evm/create-lz-oap
 Now, run
 
 ```
-npx hardhat lz:ownable:transfer-ownership --oapp-config layerzero.config.ts --solana-secret-key <PRIVATE_KEY> --solana-program-id <PROGRAM_ID>
+npx hardhat lz:ownable:transfer-ownership --oapp-config layerzero.config.ts --solana-program-id <PROGRAM_ID>
 ```
 
 ### Common Errors

--- a/examples/oft-solana/tasks/common/wire.ts
+++ b/examples/oft-solana/tasks/common/wire.ts
@@ -1,4 +1,4 @@
-import { Keypair, PublicKey } from '@solana/web3.js'
+import { PublicKey } from '@solana/web3.js'
 import { subtask, task } from 'hardhat/config'
 
 import { firstFactory } from '@layerzerolabs/devtools'
@@ -13,7 +13,9 @@ import {
     TASK_LZ_OWNABLE_TRANSFER_OWNERSHIP,
 } from '@layerzerolabs/ua-devtools-evm-hardhat'
 
-import { keyPair, publicKey } from './types'
+import { useWeb3Js } from '../solana'
+
+import { publicKey } from './types'
 import { createSdkFactory, createSolanaConnectionFactory, createSolanaSignerFactory } from './utils'
 
 import type { SignAndSendTaskArgs } from '@layerzerolabs/devtools-evm-hardhat/tasks'
@@ -24,7 +26,6 @@ import type { SignAndSendTaskArgs } from '@layerzerolabs/devtools-evm-hardhat/ta
 interface Args {
     logLevel: LogLevel
     solanaProgramId: PublicKey
-    solanaSecretKey?: Keypair
     multisigKey?: PublicKey
     internalConfigurator?: OAppConfigurator
 }
@@ -33,16 +34,6 @@ interface Args {
  * We extend the default wiring task to add functionality required by Solana
  */
 task(TASK_LZ_OAPP_WIRE)
-    // The first thing we add is the solana secret key, used to create a signer
-    //
-    // This secret key will also be used as the user account, required to use the OFT SDK
-    .addParam(
-        'solanaSecretKey',
-        'Secret key of the user account that will be used to send transactions',
-        undefined,
-        keyPair,
-        true
-    )
     .addParam('solanaProgramId', 'The OFT program ID to use', undefined, publicKey, true)
     .addParam('multisigKey', 'The MultiSig key', undefined, publicKey, true)
     // We use this argument to get around the fact that we want to both override the task action for the wiring task
@@ -69,15 +60,9 @@ task(TASK_LZ_OAPP_WIRE)
         //
         //
 
-        if (args.solanaSecretKey == null) {
-            logger.warn(
-                `Missing --solana-secret-key CLI argument. A random keypair will be generated and interaction with solana programs will not be possible`
-            )
-        }
-
-        // The first step is to create the user Keypair from the secret passed in
-        const wallet = args.solanaSecretKey ?? Keypair.generate()
-        const userAccount = wallet.publicKey
+        // construct the user's keypair via the SOLANA_PRIVATE_KEY env var
+        const keypair = useWeb3Js().web3JsKeypair
+        const userAccount = keypair.publicKey
 
         // Then we grab the programId from the args
         const programId = args.solanaProgramId
@@ -105,7 +90,7 @@ task(TASK_LZ_OAPP_WIRE)
         const sdkFactory = createSdkFactory(userAccount, programId, connectionFactory)
 
         // We'll also need a signer factory
-        const solanaSignerFactory = createSolanaSignerFactory(wallet, connectionFactory, args.multisigKey)
+        const solanaSignerFactory = createSolanaSignerFactory(keypair, connectionFactory, args.multisigKey)
 
         //
         //
@@ -152,16 +137,6 @@ task(TASK_LZ_OAPP_WIRE)
 // The two tasks are identical and the only drawback of this approach is the fact
 // that the logs will say "Wiring OApp" instead of "Transferring ownership"
 task(TASK_LZ_OWNABLE_TRANSFER_OWNERSHIP)
-    // The first thing we add is the solana secret key, used to create a signer
-    //
-    // This secret key will also be used as the user account, required to use the OFT SDK
-    .addParam(
-        'solanaSecretKey',
-        'Secret key of the user account that will be used to send transactions',
-        undefined,
-        keyPair,
-        true
-    )
     // The next (optional) parameter is the OFT program ID
     //
     // Only pass this if you deployed a new OFT program, if you are using the default

--- a/examples/oft-solana/tasks/solana/index.ts
+++ b/examples/oft-solana/tasks/solana/index.ts
@@ -23,7 +23,7 @@ import {
 import { createUmi } from '@metaplex-foundation/umi-bundle-defaults'
 import { createWeb3JsEddsa } from '@metaplex-foundation/umi-eddsa-web3js'
 import { toWeb3JsInstruction, toWeb3JsPublicKey } from '@metaplex-foundation/umi-web3js-adapters'
-import { AddressLookupTableAccount, Connection } from '@solana/web3.js'
+import { AddressLookupTableAccount, Connection, Keypair } from '@solana/web3.js'
 import { getSimulationComputeUnits } from '@solana-developers/helpers'
 import bs58 from 'bs58'
 import { backOff } from 'exponential-backoff'
@@ -71,6 +71,15 @@ export const deriveConnection = async (eid: EndpointId) => {
         umi,
         umiWalletKeyPair,
         umiWalletSigner,
+    }
+}
+
+export const useWeb3Js = () => {
+    const privateKey = getSolanaPrivateKeyFromEnv()
+    const secretKeyBytes = bs58.decode(privateKey)
+    const keypair = Keypair.fromSecretKey(secretKeyBytes)
+    return {
+        web3JsKeypair: keypair,
     }
 }
 

--- a/examples/oft-solana/tasks/solana/initConfig.ts
+++ b/examples/oft-solana/tasks/solana/initConfig.ts
@@ -1,4 +1,4 @@
-import { Keypair, PublicKey } from '@solana/web3.js'
+import { PublicKey } from '@solana/web3.js'
 import { ConfigurableTaskDefinition } from 'hardhat/types'
 
 import { inheritTask } from '@layerzerolabs/devtools-evm-hardhat'
@@ -16,7 +16,6 @@ const wireLikeTask = inheritTask(TASK_LZ_OAPP_WIRE)
 interface Args {
     logLevel: LogLevel
     solanaProgramId: PublicKey
-    solanaSecretKey?: Keypair
     multisigKey?: PublicKey
     internalConfigurator?: OAppConfigurator
 }


### PR DESCRIPTION
lzapp-migration-example will be updated in a separate PR (it also needs its init task to be renamed/refactored)


## Testing

```
LAYERZERO_EXAMPLES_REPOSITORY_REF=#nazreen/solana-rm-secret-key-flag LZ_ENABLE_SOLANA_OFT_EXAMPLE=1 npx create-lz-oapp@latest
```