### PR TITLE
🧹audit reviews 

### DIFF
--- a/examples/oft-alt/test/foundry/MyOFTAlt.t.sol
+++ b/examples/oft-alt/test/foundry/MyOFTAlt.t.sol
@@ -221,7 +221,7 @@ contract MyOFTAltTest is TestHelperOz5 {
         vm.startPrank(userA);
         nativeTokenMock_A.mint(userA, quoteFee.nativeFee);
         IERC20(nativeTokenMock_A).approve(address(aOFT), quoteFee.nativeFee);
-        (MessagingReceipt memory msgReceipt, OFTReceipt memory oftReceipt) = aOFT.send{ value: quoteFee.nativeFee }(
+        (MessagingReceipt memory msgReceipt, OFTReceipt memory oftReceipt) = aOFT.send(
             sendParam,
             quoteFee,
             payable(address(this))

--- a/packages/oapp-alt-evm/contracts/oapp/OAppSenderAlt.sol
+++ b/packages/oapp-alt-evm/contracts/oapp/OAppSenderAlt.sol
@@ -15,6 +15,12 @@ abstract contract OAppSenderAlt is OAppSender {
     // Additional error messages for the OAppSenderAlt contract.
     error NativeTokenUnavailable();
 
+    address public immutable nativeToken;
+
+    constructor() {
+        nativeToken = endpoint.nativeToken();
+    }
+
     /**
      * @dev Internal function to interact with the LayerZero EndpointV2.send() for sending a message.
      * @param _dstEid The destination endpoint ID.
@@ -59,8 +65,6 @@ abstract contract OAppSenderAlt is OAppSender {
      * @dev The endpoint is EITHER/OR, ie. it will NOT support both types of native payment at a time.
      */
     function _payNative(uint256 _nativeFee) internal override returns (uint256 nativeFee) {
-        // @dev Cannot cache the token because it is not immutable in the endpoint.
-        address nativeToken = endpoint.nativeToken();
         if (nativeToken == address(0)) revert NativeTokenUnavailable();
 
         // Pay Native token fee by sending tokens to the endpoint.

--- a/packages/oft-alt-evm/contracts/OFTAltCore.sol
+++ b/packages/oft-alt-evm/contracts/OFTAltCore.sol
@@ -173,7 +173,11 @@ abstract contract OFTAltCore is IOFT, OAppAlt, OAppPreCrimeSimulator, OAppOption
         SendParam calldata _sendParam,
         MessagingFee calldata _fee,
         address _refundAddress
-    ) external payable virtual returns (MessagingReceipt memory msgReceipt, OFTReceipt memory oftReceipt) {
+    ) external payable virtual override returns (MessagingReceipt memory msgReceipt, OFTReceipt memory oftReceipt) {
+        if (msg.value > 0) {
+            revert("OFTAltCore::send does not take msg.value. msg.value should be 0");
+        }
+
         return _send(_sendParam, _fee, _refundAddress);
     }
 

--- a/packages/oft-alt-evm/test/OFTAlt.t.sol
+++ b/packages/oft-alt-evm/test/OFTAlt.t.sol
@@ -102,8 +102,6 @@ contract OFTAltTest is TestHelperOz5 {
             )
         );
 
-
-
         // config and wire the ofts
         address[] memory ofts = new address[](3);
         ofts[0] = address(aOFT);
@@ -224,7 +222,7 @@ contract OFTAltTest is TestHelperOz5 {
         vm.startPrank(userA);
         nativeTokenMock_A.mint(userA, quoteFee.nativeFee);
         IERC20(nativeTokenMock_A).approve(address(aOFT), quoteFee.nativeFee);
-        (MessagingReceipt memory msgReceipt, OFTReceipt memory oftReceipt) = aOFT.send{ value: quoteFee.nativeFee }(
+        (MessagingReceipt memory msgReceipt, OFTReceipt memory oftReceipt) = aOFT.send(
             sendParam,
             quoteFee,
             payable(address(this))
@@ -267,7 +265,8 @@ contract OFTAltTest is TestHelperOz5 {
             amountCreditLD,
             abi.encodePacked(addressToBytes32(msg.sender), composeMsg)
         );
-        (uint64 nonce_, uint32 srcEid_, uint256 amountCreditLD_, bytes32 composeFrom_, bytes memory composeMsg_) = this.decodeOFTComposeMsgCodec(message);
+        (uint64 nonce_, uint32 srcEid_, uint256 amountCreditLD_, bytes32 composeFrom_, bytes memory composeMsg_) = this
+            .decodeOFTComposeMsgCodec(message);
 
         assertEq(nonce_, nonce);
         assertEq(srcEid_, srcEid);
@@ -318,7 +317,10 @@ contract OFTAltTest is TestHelperOz5 {
     }
 
     function test_toLD(uint64 amountSD) public {
-        assertEq(amountSD * OFTAltMock(address(aOFT)).decimalConversionRate(), aOFT.asOFTAltMock().toLD(uint64(amountSD)));
+        assertEq(
+            amountSD * OFTAltMock(address(aOFT)).decimalConversionRate(),
+            aOFT.asOFTAltMock().toLD(uint64(amountSD))
+        );
     }
 
     function test_toSD(uint256 amountLD) public {


### PR DESCRIPTION
1. `OFTAltCore` rejects transactions where `msg.value > 0`
+ this is because in an `alt variant` we use ERC20 tokens instead of native tokens and you can't pass ERC20 tokens via `msg.value`
+ updates `OFTAltCore` and tests - `MyOFTAlt.t.sol` and `OFTAlt.t.sol` 

2. Caching endpoint's native token:
+ to save gas by reducing a call on every transaction since the token is immutable at the endpoint <https://github.com/LayerZero-Labs/LayerZero-v2/blob/main/packages/layerzero-v2/evm/protocol/contracts/EndpointV2Alt.sol#L16-L20>