### PR TITLE
🪲no longer push npm packages per architecture

### DIFF
--- a/.github/workflows/reusable-publish.yaml
+++ b/.github/workflows/reusable-publish.yaml
@@ -28,9 +28,6 @@ jobs:
           - platform: linux/amd64
             runner: ubuntu-latest-16xlarge
             arch: amd64
-          - platform: linux/arm64
-            runner: ubuntu-latest-16xlarge-arm
-            arch: arm64
 
     # We'll run the job on the prebuilt base image
     container:


### PR DESCRIPTION
publishing npm packages per architecture does not make sense.
<https://github.com/LayerZero-Labs/devtools/actions/runs/13397572520> tries publishing packages for every architecture