### PR TITLE
using rustc 1.75.0

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -17,7 +17,7 @@ USE VS-CODE. CURSOR DOES NOT WORK.
 ### Prebuilt images (default)
 
 By default, the devcontainer will use the prebuilt base images from [GHCR](https://github.com/LayerZero-Labs/devtools/pkgs/container/devtools-dev-base).
-(temporary change: using "image": "ghcr.io/layerzero-labs/devtools-dev-base:dockerfile-default_rustup_1_75_0")
+(temporary change: using "image": "ghcr.io/layerzero-labs/devtools-dev-base:dockerfile-rustc_1_75_0")
 
 ### Local images
 

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "name": "LayerZero Devtools",
-  "image": "ghcr.io/layerzero-labs/devtools-dev-base:dockerfile-default_rustup_1_75_0",
+  "image": "ghcr.io/layerzero-labs/devtools-dev-base:dockerfile-rustc_1_75_0",
   "mounts": ["type=volume,target=${containerWorkspaceFolder}/node_modules"],
   "runArgs": ["--env-file", ".env"],
   "features": {

--- a/.github/workflows/reusable-publish.yaml
+++ b/.github/workflows/reusable-publish.yaml
@@ -31,7 +31,7 @@ jobs:
 
     # We'll run the job on the prebuilt base image
     container:
-      image: ghcr.io/layerzero-labs/devtools-dev-base:dockerfile-default_rustup_1_75_0
+      image: ghcr.io/layerzero-labs/devtools-dev-base:dockerfile-rustc_1_75_0
 
     steps:
       - name: Checkout repo

--- a/.github/workflows/reusable-test.yaml
+++ b/.github/workflows/reusable-test.yaml
@@ -38,7 +38,7 @@ jobs:
     
     # We'll run the job on the prebuilt base image
     container:
-      image: ghcr.io/layerzero-labs/devtools-dev-base:dockerfile-default_rustup_1_75_0
+      image: ghcr.io/layerzero-labs/devtools-dev-base:dockerfile-rustc_1_75_0
 
     steps:
       - name: Checkout repo
@@ -107,11 +107,11 @@ jobs:
           JEST_TIMEOUT: 30000  # Increase timeout for ARM builds
           TEST_TIMEOUT: 300000 # 5 minutes timeout for long-running tests
           # We'll use the prebuilt base image
-          DEVTOOLS_BASE_IMAGE: ghcr.io/layerzero-labs/devtools-dev-base:dockerfile-default_rustup_1_75_0
+          DEVTOOLS_BASE_IMAGE: ghcr.io/layerzero-labs/devtools-dev-base:dockerfile-rustc_1_75_0
           # And the prebuilt hardhat EVM node image
-          DEVTOOLS_EVM_NODE_IMAGE: ghcr.io/layerzero-labs/devtools-dev-node-evm-hardhat:dockerfile-default_rustup_1_75_0
+          DEVTOOLS_EVM_NODE_IMAGE: ghcr.io/layerzero-labs/devtools-dev-node-evm-hardhat:dockerfile-rustc_1_75_0
           # And the prebuilt TON node image
-          DEVTOOLS_TON_NODE_IMAGE: ghcr.io/layerzero-labs/devtools-dev-node-ton-my-local-ton:dockerfile-default_rustup_1_75_0
+          DEVTOOLS_TON_NODE_IMAGE: ghcr.io/layerzero-labs/devtools-dev-node-ton-my-local-ton:dockerfile-rustc_1_75_0
           # Provided we have good quality Solana RPCs, we can enable Solana tests
           #
           # FIXME The Solana tests need to be ported to either use a stable deployment
@@ -172,15 +172,15 @@ jobs:
           LAYERZERO_EXAMPLES_REPOSITORY_URL: https://github.com/${{ github.repository }}.git
           LAYERZERO_EXAMPLES_REPOSITORY_REF: ${{ github.ref }}
           # We'll use the prebuilt base image
-          DEVTOOLS_BASE_IMAGE: ghcr.io/layerzero-labs/devtools-dev-base:dockerfile-default_rustup_1_75_0
+          DEVTOOLS_BASE_IMAGE: ghcr.io/layerzero-labs/devtools-dev-base:dockerfile-rustc_1_75_0
           # And the prebuilt hardhat EVM node image
-          DEVTOOLS_EVM_NODE_IMAGE: ghcr.io/layerzero-labs/devtools-dev-node-evm-hardhat:dockerfile-default_rustup_1_75_0
+          DEVTOOLS_EVM_NODE_IMAGE: ghcr.io/layerzero-labs/devtools-dev-node-evm-hardhat:dockerfile-rustc_1_75_0
           # Using the local Aptos testnet node
-          DEVTOOLS_APTOS_NODE_IMAGE: ghcr.io/layerzero-labs/devtools-dev-node-aptos-local-testnet:dockerfile-default_rustup_1_75_0
+          DEVTOOLS_APTOS_NODE_IMAGE: ghcr.io/layerzero-labs/devtools-dev-node-aptos-local-testnet:dockerfile-rustc_1_75_0
           # Using the local TON node - i do not know if this is working
-          DEVTOOLS_TON_NODE_IMAGE: ghcr.io/layerzero-labs/devtools-dev-node-ton-my-local-ton:dockerfile-default_rustup_1_75_0
+          DEVTOOLS_TON_NODE_IMAGE: ghcr.io/layerzero-labs/devtools-dev-node-ton-my-local-ton:dockerfile-rustc_1_75_0
           # Using the local Solana test validator - may fail due to RPC issues
-          DEVTOOLS_SOLANA_NODE_IMAGE: ghcr.io/layerzero-labs/devtools-dev-node-solana-test-validator:dockerfile-default_rustup_1_75_0
+          DEVTOOLS_SOLANA_NODE_IMAGE: ghcr.io/layerzero-labs/devtools-dev-node-solana-test-validator:dockerfile-rustc_1_75_0
 
 
       # We'll collect the docker compose logs from all containers on failure

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ ARG NODE_VERSION=20.10.0
 # and the base image is built locally
 # 
 # The CI environment will use base images from https://github.com/LayerZero-Labs/devtools/pkgs/container/devtools-dev-base
-# e.g. ghcr.io/layerzero-labs/devtools-dev-base:main
+# e.g. ghcr.io/layerzero-labs/devtools-dev-base:dockerfile-rustc_1_75_0
 ARG BASE_IMAGE=base
 
 # We will provide a way for consumers to override the default Aptos node image

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ ARG NODE_VERSION=20.10.0
 # and the base image is built locally
 # 
 # The CI environment will use base images from https://github.com/LayerZero-Labs/devtools/pkgs/container/devtools-dev-base
-# e.g. ghcr.io/layerzero-labs/devtools-dev-base:dockerfile-default_rustup_1_75_0
+# e.g. ghcr.io/layerzero-labs/devtools-dev-base:main
 ARG BASE_IMAGE=base
 
 # We will provide a way for consumers to override the default Aptos node image
@@ -92,8 +92,8 @@ RUN apt-get install --yes \
     ninja-build
 
 
-# Install rust and set the default toolchain to 1.83.0
-ARG RUST_TOOLCHAIN_VERSION=1.83.0
+# Install rust and set the default toolchain to 1.75.0
+ARG RUST_TOOLCHAIN_VERSION=1.75.0
 ENV RUSTUP_VERSION=${RUST_TOOLCHAIN_VERSION}
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain ${RUST_TOOLCHAIN_VERSION}
 
@@ -114,6 +114,8 @@ FROM machine AS aptos
 WORKDIR /app/aptos
 
 ARG APTOS_VERSION=6.0.1
+ENV RUST_TOOLCHAIN_VERSION_APTOS=1.83.0
+RUN rustup default ${RUST_TOOLCHAIN_VERSION_APTOS}
 
 # We download the source code and extract the archive
 RUN curl -s -L https://github.com/aptos-labs/aptos-core/archive/refs/tags/aptos-cli-v${APTOS_VERSION}.tar.gz | tar -xz


### PR DESCRIPTION
New base image sets the `default rustup` toolchain version to `1.75.0`

This cleans up some ugly code introduced in the anchor-solana race condition resolution PR https://github.com/LayerZero-Labs/devtools/commit/1edf6d7ec45ce45c996ab2e8ada162f45eda7287 where we manually install `rustc v1.75.0` in a `github action` and `docker-compose.yaml`