### PR TITLE
🗞️ Dockerfile + GitHub Workflow - initiad and initia node (2/2)

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -17,7 +17,7 @@ USE VS-CODE. CURSOR DOES NOT WORK.
 ### Prebuilt images (default)
 
 By default, the devcontainer will use the prebuilt base images from [GHCR](https://github.com/LayerZero-Labs/devtools/pkgs/container/devtools-dev-base).
-(temporary change: using "image": "ghcr.io/layerzero-labs/devtools-dev-base:feat-image_initia")
+(temporary change: using "image": "ghcr.io/layerzero-labs/devtools-dev-base:main")
 
 ### Local images
 

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "name": "LayerZero Devtools",
-  "image": "ghcr.io/layerzero-labs/devtools-dev-base:feat-image_initia",
+  "image": "ghcr.io/layerzero-labs/devtools-dev-base:main",
   "mounts": ["type=volume,target=${containerWorkspaceFolder}/node_modules"],
   "runArgs": ["--env-file", ".env"],
   "features": {

--- a/.github/workflows/reusable-publish.yaml
+++ b/.github/workflows/reusable-publish.yaml
@@ -31,7 +31,7 @@ jobs:
 
     # We'll run the job on the prebuilt base image
     container:
-      image: ghcr.io/layerzero-labs/devtools-dev-base:feat-image_initia
+      image: ghcr.io/layerzero-labs/devtools-dev-base:main
 
     steps:
       - name: Checkout repo

--- a/.github/workflows/reusable-test.yaml
+++ b/.github/workflows/reusable-test.yaml
@@ -38,7 +38,7 @@ jobs:
     
     # We'll run the job on the prebuilt base image
     container:
-      image: ghcr.io/layerzero-labs/devtools-dev-base:feat-image_initia
+      image: ghcr.io/layerzero-labs/devtools-dev-base:main
 
     steps:
       - name: Checkout repo
@@ -107,11 +107,11 @@ jobs:
           JEST_TIMEOUT: 30000  # Increase timeout for ARM builds
           TEST_TIMEOUT: 300000 # 5 minutes timeout for long-running tests
           # We'll use the prebuilt base image
-          DEVTOOLS_BASE_IMAGE: ghcr.io/layerzero-labs/devtools-dev-base:feat-image_initia
+          DEVTOOLS_BASE_IMAGE: ghcr.io/layerzero-labs/devtools-dev-base:main
           # And the prebuilt hardhat EVM node image
-          DEVTOOLS_EVM_NODE_IMAGE: ghcr.io/layerzero-labs/devtools-dev-node-evm-hardhat:feat-image_initia
+          DEVTOOLS_EVM_NODE_IMAGE: ghcr.io/layerzero-labs/devtools-dev-node-evm-hardhat:main
           # And the prebuilt TON node image
-          DEVTOOLS_TON_NODE_IMAGE: ghcr.io/layerzero-labs/devtools-dev-node-ton-my-local-ton:feat-image_initia
+          DEVTOOLS_TON_NODE_IMAGE: ghcr.io/layerzero-labs/devtools-dev-node-ton-my-local-ton:main
           # Provided we have good quality Solana RPCs, we can enable Solana tests
           #
           # FIXME The Solana tests need to be ported to either use a stable deployment
@@ -172,17 +172,17 @@ jobs:
           LAYERZERO_EXAMPLES_REPOSITORY_URL: https://github.com/${{ github.repository }}.git
           LAYERZERO_EXAMPLES_REPOSITORY_REF: ${{ github.ref }}
           # We'll use the prebuilt base image
-          DEVTOOLS_BASE_IMAGE: ghcr.io/layerzero-labs/devtools-dev-base:feat-image_initia
+          DEVTOOLS_BASE_IMAGE: ghcr.io/layerzero-labs/devtools-dev-base:main
           # And the prebuilt hardhat EVM node image
-          DEVTOOLS_EVM_NODE_IMAGE: ghcr.io/layerzero-labs/devtools-dev-node-evm-hardhat:feat-image_initia
+          DEVTOOLS_EVM_NODE_IMAGE: ghcr.io/layerzero-labs/devtools-dev-node-evm-hardhat:main
           # Using the local Aptos testnet node
-          DEVTOOLS_APTOS_NODE_IMAGE: ghcr.io/layerzero-labs/devtools-dev-node-aptos-local-testnet:feat-image_initia
+          DEVTOOLS_APTOS_NODE_IMAGE: ghcr.io/layerzero-labs/devtools-dev-node-aptos-local-testnet:main
           # Using the local TON node - i do not know if this is working
-          DEVTOOLS_TON_NODE_IMAGE: ghcr.io/layerzero-labs/devtools-dev-node-ton-my-local-ton:feat-image_initia
+          DEVTOOLS_TON_NODE_IMAGE: ghcr.io/layerzero-labs/devtools-dev-node-ton-my-local-ton:main
           # Using the local Initia node
-          DEVTOOLS_INITIA_NODE_IMAGE: ghcr.io/layerzero-labs/devtools-dev-node-initia-localnet:feat-image_initia
+          DEVTOOLS_INITIA_NODE_IMAGE: ghcr.io/layerzero-labs/devtools-dev-node-initia-localnet:main
           # Using the local Solana test validator - may fail due to RPC issues
-          DEVTOOLS_SOLANA_NODE_IMAGE: ghcr.io/layerzero-labs/devtools-dev-node-solana-test-validator:feat-image_initia
+          DEVTOOLS_SOLANA_NODE_IMAGE: ghcr.io/layerzero-labs/devtools-dev-node-solana-test-validator:main
 
 
       # We'll collect the docker compose logs from all containers on failure

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ ARG NODE_VERSION=20.10.0
 # and the base image is built locally
 # 
 # The CI environment will use base images from https://github.com/LayerZero-Labs/devtools/pkgs/container/devtools-dev-base
-# e.g. ghcr.io/layerzero-labs/devtools-dev-base:feat-image_initia
+# e.g. ghcr.io/layerzero-labs/devtools-dev-base:main
 ARG BASE_IMAGE=base
 
 # We will provide a way for consumers to override the default Aptos node image


### PR DESCRIPTION
Successor PR to <https://github.com/LayerZero-Labs/devtools/pull/1307>. This is the final PR 2/2 of the set of PRs to include `initia` and sets the image tagging to `:main` from `:feat-image_initia`. 

+ For this to work we also run the `Build base development images` job that publishes new images tagged at `:main` for which the run can be found [here](https://github.com/LayerZero-Labs/devtools/actions/runs/13440929537)
+ These images created with the `:main` tag are equivalent to those created by <https://github.com/LayerZero-Labs/devtools/actions/runs/13428552457/job/37515905734> with the tag-hash `: b0c4585cfe86ec57bfec2d28fdd27e4342fcb76a4d634ff60798c8fa0f400903` found [here](https://github.com/LayerZero-Labs/devtools/pkgs/container/devtools-dev-base/359196425?tag=feat-image_initia) 
+ The old images tagged with `:main` use the hash `8d0959accc0e13823a3a0c460cb4ce286bb7e8c8` - ex: [devtools-dev-base @ 8d0959accc0e13823a3a0c460cb4ce286bb7e8c8](https://github.com/LayerZero-Labs/devtools/pkgs/container/devtools-dev-base/358325594?tag=8d0959accc0e13823a3a0c460cb4ce286bb7e8c8)
+ The newly added image to devtools image set is `[devtools-dev-node-initia-localnet](https://github.com/orgs/LayerZero-Labs/packages/container/package/devtools-dev-node-initia-localnet)` which does not have a pre-existing `:main` tag