### PR TITLE
🧹 oft  upgradeable example deploy script

### DIFF
--- a/.changeset/dull-chairs-develop.md
+++ b/.changeset/dull-chairs-develop.md
@@ -1,0 +1,5 @@
+---
+"@layerzerolabs/oft-upgradeable-example": patch
+---
+
+fix: deploy scripts does not rely on hardhat network name being the same as layerzero network name

--- a/examples/oft-upgradeable/deploy/MyOFTAdapterUpgradeable.ts
+++ b/examples/oft-upgradeable/deploy/MyOFTAdapterUpgradeable.ts
@@ -1,6 +1,6 @@
 import { type DeployFunction } from 'hardhat-deploy/types'
 
-import { EndpointId, getNetworkForChainId } from '@layerzerolabs/lz-definitions'
+import { EndpointId, endpointIdToNetwork } from '@layerzerolabs/lz-definitions'
 import { getDeploymentAddressAndAbi } from '@layerzerolabs/lz-evm-sdk-v2'
 
 const contractName = 'MyOFTAdapterUpgradeable'
@@ -11,8 +11,7 @@ const deploy: DeployFunction = async (hre) => {
     console.log(`deploying ${contractName} on network: ${hre.network.name} with ${signer.address}`)
 
     const eid = hre.network.config.eid as EndpointId
-    const networkStage = getNetworkForChainId(eid)
-    const lzNetworkName = `${networkStage.chainName}-${networkStage.env}`
+    const lzNetworkName = endpointIdToNetwork(eid)
 
     const { address } = getDeploymentAddressAndAbi(lzNetworkName, 'EndpointV2')
 

--- a/examples/oft-upgradeable/deploy/MyOFTAdapterUpgradeable.ts
+++ b/examples/oft-upgradeable/deploy/MyOFTAdapterUpgradeable.ts
@@ -1,6 +1,6 @@
-import { Contract } from 'ethers'
 import { type DeployFunction } from 'hardhat-deploy/types'
 
+import { EndpointId, getNetworkForChainId } from '@layerzerolabs/lz-definitions'
 import { getDeploymentAddressAndAbi } from '@layerzerolabs/lz-evm-sdk-v2'
 
 const contractName = 'MyOFTAdapterUpgradeable'
@@ -10,18 +10,15 @@ const deploy: DeployFunction = async (hre) => {
     const signer = (await hre.ethers.getSigners())[0]
     console.log(`deploying ${contractName} on network: ${hre.network.name} with ${signer.address}`)
 
-    const { address, abi } = getDeploymentAddressAndAbi(hre.network.name, 'EndpointV2')
-    const endpointV2Deployment = new Contract(address, abi, signer)
-    try {
-        const proxy = await hre.ethers.getContract('MyOFTUpgradeable')
-        console.log(`Proxy: ${proxy.address}`)
-    } catch (e) {
-        console.log(`Proxy not found`)
-    }
+    const eid = hre.network.config.eid as EndpointId
+    const networkStage = getNetworkForChainId(eid)
+    const lzNetworkName = `${networkStage.chainName}-${networkStage.env}`
+
+    const { address } = getDeploymentAddressAndAbi(lzNetworkName, 'EndpointV2')
 
     await deploy(contractName, {
         from: signer.address,
-        args: ['0x', endpointV2Deployment.address], // replace '0x' with the address of the ERC-20 token
+        args: ['0x', address], // replace '0x' with the address of the ERC-20 token
         log: true,
         waitConfirmations: 1,
         skipIfAlreadyDeployed: false,

--- a/examples/oft-upgradeable/deploy/MyOFTUpgradeable.ts
+++ b/examples/oft-upgradeable/deploy/MyOFTUpgradeable.ts
@@ -1,6 +1,6 @@
-import { Contract } from 'ethers'
 import { type DeployFunction } from 'hardhat-deploy/types'
 
+import { EndpointId, getNetworkForChainId } from '@layerzerolabs/lz-definitions'
 import { getDeploymentAddressAndAbi } from '@layerzerolabs/lz-evm-sdk-v2'
 
 const contractName = 'MyOFTUpgradeable'
@@ -10,12 +10,15 @@ const deploy: DeployFunction = async (hre) => {
     const signer = (await hre.ethers.getSigners())[0]
     console.log(`deploying ${contractName} on network: ${hre.network.name} with ${signer.address}`)
 
-    const { address, abi } = getDeploymentAddressAndAbi(hre.network.name, 'EndpointV2')
-    const endpointV2Deployment = new Contract(address, abi, signer)
+    const eid = hre.network.config.eid as EndpointId
+    const networkStage = getNetworkForChainId(eid)
+    const lzNetworkName = `${networkStage.chainName}-${networkStage.env}`
+
+    const { address } = getDeploymentAddressAndAbi(lzNetworkName, 'EndpointV2')
 
     await deploy(contractName, {
         from: signer.address,
-        args: [endpointV2Deployment.address],
+        args: [address],
         log: true,
         waitConfirmations: 1,
         skipIfAlreadyDeployed: false,

--- a/examples/oft-upgradeable/deploy/MyOFTUpgradeable.ts
+++ b/examples/oft-upgradeable/deploy/MyOFTUpgradeable.ts
@@ -1,6 +1,6 @@
 import { type DeployFunction } from 'hardhat-deploy/types'
 
-import { EndpointId, getNetworkForChainId } from '@layerzerolabs/lz-definitions'
+import { EndpointId, endpointIdToNetwork } from '@layerzerolabs/lz-definitions'
 import { getDeploymentAddressAndAbi } from '@layerzerolabs/lz-evm-sdk-v2'
 
 const contractName = 'MyOFTUpgradeable'
@@ -11,8 +11,7 @@ const deploy: DeployFunction = async (hre) => {
     console.log(`deploying ${contractName} on network: ${hre.network.name} with ${signer.address}`)
 
     const eid = hre.network.config.eid as EndpointId
-    const networkStage = getNetworkForChainId(eid)
-    const lzNetworkName = `${networkStage.chainName}-${networkStage.env}`
+    const lzNetworkName = endpointIdToNetwork(eid)
 
     const { address } = getDeploymentAddressAndAbi(lzNetworkName, 'EndpointV2')
 


### PR DESCRIPTION
The old OFT Upgradeable deploy used to assume that the layerzero's internally defined network names founds under `deployments` <https://www.npmjs.com/package/@layerzerolabs/lz-evm-sdk-v2?activeTab=code>  is the same as those defined in `hardhat.config.ts`'s network config. 

This isn't the case as developers can name networks differently. 

Other examples <https://github.com/LayerZero-Labs/devtools/blob/main/examples/oapp/deploy/MyOApp.ts> use this pattern where we load the deployments (`EndpointV2` among others) and artifacts into `Hardhat` in [toolbox-hardhat](https://github.com/LayerZero-Labs/devtools/blob/main/packages/toolbox-hardhat/src/index.ts#L25-L37)
```
    // And we check the config for packages from which to import deployments as well
    const deploymentSourcePackages = layerZero?.deploymentSourcePackages ?? ['@layerzerolabs/lz-evm-sdk-v2']

    // Here we create our two config extenders, two curried functions
    // that accept hardhat user config and return a hardhat user config with external
    // artifacts and deployments configured
    const withArtifacts = withLayerZeroArtifacts(...artifactSourcePackages)
    const withDeployments = withLayerZeroDeployments(...deploymentSourcePackages)
``` 
For some reason this does not work with Upgradeable which could be due to some internal hardcoding or use of other packages. 

The solution is to unabstract the abstraction created by the above code snippet and raw fetch the `EndpointV2` information from the layerzero network name