### PR TITLE
🪲 (temporary patch) - skip gnosis safe test 

### DIFF
--- a/.changeset/polite-experts-jog.md
+++ b/.changeset/polite-experts-jog.md
@@ -1,0 +1,5 @@
+---
+"@layerzerolabs/devtools-evm-hardhat-test": patch
+---
+
+skip test that validates valid safe config

--- a/tests/devtools-evm-hardhat-test/test/task/validate.safe.configs.test.ts
+++ b/tests/devtools-evm-hardhat-test/test/task/validate.safe.configs.test.ts
@@ -21,7 +21,15 @@ describe(`task ${TASK_LZ_VALIDATE_SAFE_CONFIGS}`, () => {
             expect(result.status).toBe(0)
         })
 
-        it('should validate valid safe configs', async () => {
+        /* 
+            SKIP TEST because of Safe UI hack on Feb 21, 2025
+            Safe's API was turned off to prevent future hacks.
+            https://safe-transaction-mainnet.safe.global/ - returns 404
+            Information about the hack - https://twitter.com/senamakel/status/1893001991971905542
+            TODO: remove skip when the hack is fixed
+        */
+        // eslint-disable-next-line jest/no-disabled-tests
+        it.skip('should validate valid safe configs', async () => {
             const result = runExpect('validate-valid-safe-configs')
 
             expect(result.status).toBe(0)


### PR DESCRIPTION
Gnosis Safe's url <https://safe-transaction-mainnet.safe.global/> is down.

The url can be found at: 
<https://github.com/safe-global/safe-core-sdk/tree/main/packages/api-kit>

This will be brought back once gnosis safe's apis are live