### PR TITLE
🚀  feat(oft-solana): debug command checks peers

### DIFF
--- a/examples/oft-solana/tasks/common/utils.ts
+++ b/examples/oft-solana/tasks/common/utils.ts
@@ -18,7 +18,7 @@ import {
     createRpcUrlFactory,
 } from '@layerzerolabs/devtools-solana'
 import { ChainType, EndpointId, endpointIdToChainType } from '@layerzerolabs/lz-definitions'
-import { Options, bytes32ToEthAddress } from '@layerzerolabs/lz-v2-utilities'
+import { Options } from '@layerzerolabs/lz-v2-utilities'
 import { IOApp } from '@layerzerolabs/ua-devtools'
 import { createOAppFactory } from '@layerzerolabs/ua-devtools-evm'
 import { createOFTFactory } from '@layerzerolabs/ua-devtools-solana'
@@ -90,15 +90,6 @@ export const createSolanaSignerFactory = (
 export function uint8ArrayToHex(uint8Array: Uint8Array, prefix = false): string {
     const hexString = Buffer.from(uint8Array).toString('hex')
     return prefix ? `0x${hexString}` : hexString
-}
-
-export function formatBytesAddressPerChainType(chainType: ChainType, uint8Array: Uint8Array) {
-    switch (chainType) {
-        case ChainType.EVM:
-            return bytes32ToEthAddress(uint8Array)
-        default:
-            throw new Error(`formatBytesAddressPerChainType not implemented yet for chain type ${chainType}`)
-    }
 }
 
 function formatBigIntForDisplay(n: bigint) {

--- a/examples/oft-solana/tasks/common/utils.ts
+++ b/examples/oft-solana/tasks/common/utils.ts
@@ -85,3 +85,21 @@ export const createSolanaSignerFactory = (
             : new OmniSignerSolana(eid, await connectionFactory(eid), wallet)
     }
 }
+
+export function uint8ArrayToHex(uint8Array: Uint8Array, prefix = false): string {
+    const hexString = Buffer.from(uint8Array).toString('hex')
+    return prefix ? `0x${hexString}` : hexString
+}
+
+export function parse32BytesArrayIntoEvmAddress(uint8Array: Uint8Array): string {
+    return uint8ArrayToHex(uint8Array.slice(12), true)
+}
+
+export function formatBytesAddressPerChainType(chainType: ChainType, uint8Array: Uint8Array) {
+    switch (chainType) {
+        case ChainType.EVM:
+            return parse32BytesArrayIntoEvmAddress(uint8Array)
+        default:
+            throw new Error(`formatBytesAddressPerChainType not implemented yet for chain type ${chainType}`)
+    }
+}

--- a/examples/oft-solana/tasks/common/utils.ts
+++ b/examples/oft-solana/tasks/common/utils.ts
@@ -18,6 +18,7 @@ import {
     createRpcUrlFactory,
 } from '@layerzerolabs/devtools-solana'
 import { ChainType, EndpointId, endpointIdToChainType } from '@layerzerolabs/lz-definitions'
+import { bytes32ToEthAddress } from '@layerzerolabs/lz-v2-utilities'
 import { IOApp } from '@layerzerolabs/ua-devtools'
 import { createOAppFactory } from '@layerzerolabs/ua-devtools-evm'
 import { createOFTFactory } from '@layerzerolabs/ua-devtools-solana'
@@ -91,14 +92,10 @@ export function uint8ArrayToHex(uint8Array: Uint8Array, prefix = false): string 
     return prefix ? `0x${hexString}` : hexString
 }
 
-export function parse32BytesArrayIntoEvmAddress(uint8Array: Uint8Array): string {
-    return uint8ArrayToHex(uint8Array.slice(12), true)
-}
-
 export function formatBytesAddressPerChainType(chainType: ChainType, uint8Array: Uint8Array) {
     switch (chainType) {
         case ChainType.EVM:
-            return parse32BytesArrayIntoEvmAddress(uint8Array)
+            return bytes32ToEthAddress(uint8Array)
         default:
             throw new Error(`formatBytesAddressPerChainType not implemented yet for chain type ${chainType}`)
     }

--- a/examples/oft-solana/tasks/common/utils.ts
+++ b/examples/oft-solana/tasks/common/utils.ts
@@ -18,7 +18,7 @@ import {
     createRpcUrlFactory,
 } from '@layerzerolabs/devtools-solana'
 import { ChainType, EndpointId, endpointIdToChainType } from '@layerzerolabs/lz-definitions'
-import { bytes32ToEthAddress } from '@layerzerolabs/lz-v2-utilities'
+import { Options, bytes32ToEthAddress } from '@layerzerolabs/lz-v2-utilities'
 import { IOApp } from '@layerzerolabs/ua-devtools'
 import { createOAppFactory } from '@layerzerolabs/ua-devtools-evm'
 import { createOFTFactory } from '@layerzerolabs/ua-devtools-solana'
@@ -98,5 +98,23 @@ export function formatBytesAddressPerChainType(chainType: ChainType, uint8Array:
             return bytes32ToEthAddress(uint8Array)
         default:
             throw new Error(`formatBytesAddressPerChainType not implemented yet for chain type ${chainType}`)
+    }
+}
+
+function formatBigIntForDisplay(n: bigint) {
+    return n.toLocaleString().replace(/,/g, '_')
+}
+
+export function decodeLzReceiveOptions(hex: string): string {
+    try {
+        // Handle empty/undefined values first
+        if (!hex || hex === '0x') return 'No options set'
+        const options = Options.fromOptions(hex)
+        const lzReceiveOpt = options.decodeExecutorLzReceiveOption()
+        return lzReceiveOpt
+            ? `gas: ${formatBigIntForDisplay(lzReceiveOpt.gas)} , value: ${formatBigIntForDisplay(lzReceiveOpt.value)} wei`
+            : 'No executor options'
+    } catch (e) {
+        return `Invalid options (${hex.slice(0, 12)}...)`
     }
 }

--- a/examples/oft-solana/tasks/solana/debug.ts
+++ b/examples/oft-solana/tasks/solana/debug.ts
@@ -146,8 +146,11 @@ task('lz:oft:solana:debug', 'Manages OFTStore and OAppRegistry information')
                 if (info) {
                     Logger.keyValue('PeerConfig Account', peerConfigs[index].toString())
                     Logger.keyValue('Peer Address', formatBytesAddressPerChainType(chainType, info.peerAddress))
-                    Logger.keyValue('Enforced Options Send', bytesToHexStr(info.enforcedOptions.send))
-                    Logger.keyValue('Enforced Options SendAndCall', bytesToHexStr(info.enforcedOptions.sendAndCall))
+                    Logger.keyValue('Enforced Options Send', uint8ArrayToHex(info.enforcedOptions.send, true))
+                    Logger.keyValue(
+                        'Enforced Options SendAndCall',
+                        uint8ArrayToHex(info.enforcedOptions.sendAndCall, true)
+                    )
                 } else {
                     console.log(`No PeerConfig account found for ${dstEid} (${network.chainName}).`)
                 }
@@ -187,20 +190,13 @@ task('lz:oft:solana:debug', 'Manages OFTStore and OAppRegistry information')
         }
     })
 
-function bytesToHexStr(data: Uint8Array): string {
-    return '0x' + Buffer.from(data).toString('hex')
-}
-
-export function uint8ArrayToHex(uint8Array: Uint8Array): string {
-    return Array.from(uint8Array)
-        .map((byte) => byte.toString(16).padStart(2, '0')) // Convert each byte to a 2-character hex string
-        .join('') // Join all hex strings into a single string
+export function uint8ArrayToHex(uint8Array: Uint8Array, prefix = false): string {
+    const hexString = Buffer.from(uint8Array).toString('hex')
+    return prefix ? `0x${hexString}` : hexString
 }
 
 export function parse32BytesArrayIntoEvmAddress(uint8Array: Uint8Array): string {
-    const hexString: string = uint8ArrayToHex(uint8Array)
-    const zeroesRemoved = hexString.substring(24)
-    return `0x${zeroesRemoved}`
+    return uint8ArrayToHex(uint8Array.slice(12), true)
 }
 
 export function formatBytesAddressPerChainType(chainType: ChainType, uint8Array: Uint8Array) {
@@ -209,6 +205,5 @@ export function formatBytesAddressPerChainType(chainType: ChainType, uint8Array:
             return parse32BytesArrayIntoEvmAddress(uint8Array)
         default:
             throw new Error(`formatBytesAddressPerChainType not implemented yet for chain type ${chainType}`)
-            break
     }
 }

--- a/examples/oft-solana/tasks/solana/debug.ts
+++ b/examples/oft-solana/tasks/solana/debug.ts
@@ -15,8 +15,14 @@ import { deriveConnection, getSolanaDeployment } from './index'
 
 // Logger class for better logging
 class Logger {
-    static keyValue(key: string, value: any) {
-        console.log(`\x1b[33m${key}:\x1b[0m ${value}`)
+    static keyValue(key: string, value: any, indentLevel = 0) {
+        const indent = ' '.repeat(indentLevel * 2)
+        console.log(`${indent}\x1b[33m${key}:\x1b[0m ${value}`)
+    }
+
+    static keyHeader(key: string, indentLevel = 0) {
+        const indent = ' '.repeat(indentLevel * 2)
+        console.log(`${indent}\x1b[33m${key}:\x1b[0m`)
     }
 
     static header(text: string) {
@@ -148,11 +154,9 @@ task('lz:oft:solana:debug', 'Manages OFTStore and OAppRegistry information')
                 if (info) {
                     Logger.keyValue('PeerConfig Account', peerConfigs[index].toString())
                     Logger.keyValue('Peer Address', formatBytesAddressPerChainType(chainType, info.peerAddress))
-                    Logger.keyValue('Enforced Options Send', uint8ArrayToHex(info.enforcedOptions.send, true))
-                    Logger.keyValue(
-                        'Enforced Options SendAndCall',
-                        uint8ArrayToHex(info.enforcedOptions.sendAndCall, true)
-                    )
+                    Logger.keyHeader('Enforced Options')
+                    Logger.keyValue('Send', uint8ArrayToHex(info.enforcedOptions.send, true), 2)
+                    Logger.keyValue('SendAndCall', uint8ArrayToHex(info.enforcedOptions.sendAndCall, true), 2)
                 } else {
                     console.log(`No PeerConfig account found for ${dstEid} (${network.chainName}).`)
                 }

--- a/examples/oft-solana/tasks/solana/debug.ts
+++ b/examples/oft-solana/tasks/solana/debug.ts
@@ -4,12 +4,13 @@ import { toWeb3JsPublicKey } from '@metaplex-foundation/umi-web3js-adapters'
 import { PublicKey } from '@solana/web3.js'
 import { task } from 'hardhat/config'
 
+import { denormalizePeer } from '@layerzerolabs/devtools'
 import { types } from '@layerzerolabs/devtools-evm-hardhat'
-import { EndpointId, endpointIdToChainType, getNetworkForChainId } from '@layerzerolabs/lz-definitions'
+import { EndpointId, getNetworkForChainId } from '@layerzerolabs/lz-definitions'
 import { EndpointPDADeriver, EndpointProgram } from '@layerzerolabs/lz-solana-sdk-v2'
 import { OftPDA, oft } from '@layerzerolabs/oft-v2-solana-sdk'
 
-import { decodeLzReceiveOptions, formatBytesAddressPerChainType, uint8ArrayToHex } from '../common/utils'
+import { decodeLzReceiveOptions, uint8ArrayToHex } from '../common/utils'
 
 import { deriveConnection, getSolanaDeployment } from './index'
 
@@ -149,11 +150,10 @@ task('lz:oft:solana:debug', 'Manages OFTStore and OAppRegistry information')
             dstEids.forEach((dstEid, index) => {
                 const info = peerConfigInfos[index]
                 const network = getNetworkForChainId(dstEid)
-                const chainType = endpointIdToChainType(dstEid)
                 Logger.header(`${dstEid} (${network.chainName})`)
                 if (info) {
                     Logger.keyValue('PeerConfig Account', peerConfigs[index].toString())
-                    Logger.keyValue('Peer Address', formatBytesAddressPerChainType(chainType, info.peerAddress))
+                    Logger.keyValue('Peer Address', denormalizePeer(info.peerAddress, dstEid))
                     Logger.keyHeader('Enforced Options')
                     Logger.keyValue('Send', decodeLzReceiveOptions(uint8ArrayToHex(info.enforcedOptions.send, true)), 2)
                     Logger.keyValue(
@@ -164,8 +164,8 @@ task('lz:oft:solana:debug', 'Manages OFTStore and OAppRegistry information')
                 } else {
                     console.log(`No PeerConfig account found for ${dstEid} (${network.chainName}).`)
                 }
+                Logger.separator()
             })
-            Logger.separator()
         }
 
         if (action) {

--- a/examples/oft-solana/tasks/solana/debug.ts
+++ b/examples/oft-solana/tasks/solana/debug.ts
@@ -164,8 +164,8 @@ task('lz:oft:solana:debug', 'Manages OFTStore and OAppRegistry information')
                 } else {
                     console.log(`No PeerConfig account found for ${dstEid} (${network.chainName}).`)
                 }
-                Logger.separator()
             })
+            Logger.separator()
         }
 
         if (action) {

--- a/examples/oft-solana/tasks/solana/debug.ts
+++ b/examples/oft-solana/tasks/solana/debug.ts
@@ -5,9 +5,11 @@ import { PublicKey } from '@solana/web3.js'
 import { task } from 'hardhat/config'
 
 import { types } from '@layerzerolabs/devtools-evm-hardhat'
-import { ChainType, EndpointId, endpointIdToChainType, getNetworkForChainId } from '@layerzerolabs/lz-definitions'
+import { EndpointId, endpointIdToChainType, getNetworkForChainId } from '@layerzerolabs/lz-definitions'
 import { EndpointPDADeriver, EndpointProgram } from '@layerzerolabs/lz-solana-sdk-v2'
 import { OftPDA, oft } from '@layerzerolabs/oft-v2-solana-sdk'
+
+import { formatBytesAddressPerChainType, uint8ArrayToHex } from '../common/utils'
 
 import { deriveConnection, getSolanaDeployment } from './index'
 
@@ -189,21 +191,3 @@ task('lz:oft:solana:debug', 'Manages OFTStore and OAppRegistry information')
             await printChecks()
         }
     })
-
-export function uint8ArrayToHex(uint8Array: Uint8Array, prefix = false): string {
-    const hexString = Buffer.from(uint8Array).toString('hex')
-    return prefix ? `0x${hexString}` : hexString
-}
-
-export function parse32BytesArrayIntoEvmAddress(uint8Array: Uint8Array): string {
-    return uint8ArrayToHex(uint8Array.slice(12), true)
-}
-
-export function formatBytesAddressPerChainType(chainType: ChainType, uint8Array: Uint8Array) {
-    switch (chainType) {
-        case ChainType.EVM:
-            return parse32BytesArrayIntoEvmAddress(uint8Array)
-        default:
-            throw new Error(`formatBytesAddressPerChainType not implemented yet for chain type ${chainType}`)
-    }
-}

--- a/examples/oft-solana/tasks/solana/debug.ts
+++ b/examples/oft-solana/tasks/solana/debug.ts
@@ -9,7 +9,7 @@ import { EndpointId, endpointIdToChainType, getNetworkForChainId } from '@layerz
 import { EndpointPDADeriver, EndpointProgram } from '@layerzerolabs/lz-solana-sdk-v2'
 import { OftPDA, oft } from '@layerzerolabs/oft-v2-solana-sdk'
 
-import { formatBytesAddressPerChainType, uint8ArrayToHex } from '../common/utils'
+import { decodeLzReceiveOptions, formatBytesAddressPerChainType, uint8ArrayToHex } from '../common/utils'
 
 import { deriveConnection, getSolanaDeployment } from './index'
 
@@ -155,8 +155,12 @@ task('lz:oft:solana:debug', 'Manages OFTStore and OAppRegistry information')
                     Logger.keyValue('PeerConfig Account', peerConfigs[index].toString())
                     Logger.keyValue('Peer Address', formatBytesAddressPerChainType(chainType, info.peerAddress))
                     Logger.keyHeader('Enforced Options')
-                    Logger.keyValue('Send', uint8ArrayToHex(info.enforcedOptions.send, true), 2)
-                    Logger.keyValue('SendAndCall', uint8ArrayToHex(info.enforcedOptions.sendAndCall, true), 2)
+                    Logger.keyValue('Send', decodeLzReceiveOptions(uint8ArrayToHex(info.enforcedOptions.send, true)), 2)
+                    Logger.keyValue(
+                        'SendAndCall',
+                        decodeLzReceiveOptions(uint8ArrayToHex(info.enforcedOptions.sendAndCall, true)),
+                        2
+                    )
                 } else {
                     console.log(`No PeerConfig account found for ${dstEid} (${network.chainName}).`)
                 }


### PR DESCRIPTION
## Changes
- `lz:oft:solana:debug` now takes in a new param, `dstEids` (csv of dstEid)
- `lz:oft:solana:debug` now recognizes a new action, DEBUG_ACTIONS.GET_PEERS which uses dstEids to fetch the PeerConfig accounts
- PeerConfig Account info are printed

## Testing

```
LAYERZERO_EXAMPLES_REPOSITORY_REF=#nazreen/oft-solana-debug-dst-eid LZ_ENABLE_SOLANA_OFT_EXAMPLE=1 npx create-lz-oapp@latest
```

Either do an (1) end to end deployment first or (2) use the `--oft-store` param to debug an existing deployment.

(1)

```
npx hardhat lz:oft:solana:debug --eid 40168 --dst-eids 40161,40231     
 ```

(2)

```
npx hardhat lz:oft:solana:debug --eid 40168 --oft-store HRxaPR51cxfjaCvKQAvkkbYbahu5fbeWMEEJLHFSmNpN --dst-eids 40161,40231     
 ```



## Example output:

```
OFT Store Information
Owner: 8yQ1LVN632bdqmrdwVJeLZ4Hu4AYcbUxAmvPMGBQRduD
OFT Type: Native
Admin: EKXXXF8kzh4Bnq1HBHVwZgA5egJJWLDYqXmJTQtbbd5D
Token Mint: 6bGQtSh7JJLsfFArFMfFJjqitjzSUtMcb3RLeQsiKm68
Token Escrow: EP1UWADJRm7NLh93pQ9gH96JE4i3Aakvf3p7NnDFNEmj
Endpoint Program: 76y77prsiCMvXMjuoZ5VRrhG5qYBrUMYTE5WgHqgjEn6
----------------------------------------
OApp Registry Information
Delegate: EKXXXF8kzh4Bnq1HBHVwZgA5egJJWLDYqXmJTQtbbd5D
----------------------------------------
Token Information
Mint Authority: HRxaPR51cxfjaCvKQAvkkbYbahu5fbeWMEEJLHFSmNpN
Freeze Authority: None
----------------------------------------
Peer Configurations
40161 (sepolia)
PeerConfig Account: 1eXAQVWf7xW1oPQNxmCED43qSLg1YGcdRKnktqbSUWi
Peer Address: 0xC0941A758e86669FAD70Fe7AE75ec40995B443da
Enforced Options:
    Send: gas: 80_000 , value: 0 wei
    SendAndCall: gas: 80_000 , value: 0 wei
----------------------------------------
40231 (arbsep)
No PeerConfig account found for 40231 (arbsep).
----------------------------------------
Checks
Admin (Owner) same as Delegate: true
Token Mint Authority is OFT Store: true
```