### PR TITLE
🪲 OFTAltCore reverts if non zero msg value

### DIFF
--- a/packages/oft-alt-evm/contracts/OFTAltCore.sol
+++ b/packages/oft-alt-evm/contracts/OFTAltCore.sol
@@ -44,6 +44,8 @@ abstract contract OFTAltCore is IOFT, OAppAlt, OAppPreCrimeSimulator, OAppOption
     address public msgInspector;
     event MsgInspectorSet(address inspector);
 
+    error OFTAltCore__msg_value_not_zero(uint256 _msg_value);
+
     /**
      * @dev Constructor.
      * @param _localDecimals The decimals of the token on the local chain (this chain).
@@ -174,6 +176,7 @@ abstract contract OFTAltCore is IOFT, OAppAlt, OAppPreCrimeSimulator, OAppOption
         MessagingFee calldata _fee,
         address _refundAddress
     ) external payable virtual returns (MessagingReceipt memory msgReceipt, OFTReceipt memory oftReceipt) {
+        if (msg.value > 0) revert OFTAltCore__msg_value_not_zero(msg.value);
         return _send(_sendParam, _fee, _refundAddress);
     }
 


### PR DESCRIPTION
The current `OFTAltCore::send()` was `payable` to match the interface's definition. However it did not have a revert for when `msg.value != 0`.

This means that users can send transactions to the `OFT` with `{value: msg.value}` which would simply get locked up in the OFT. This PR introduces a custom revert message for when `msg.value != 0`