### PR TITLE
🗞️ typescript sdk for hyperliquid  

### DIFF
--- a/packages/oft-hyperliquid-evm/HYPERLIQUID.README.md
+++ b/packages/oft-hyperliquid-evm/HYPERLIQUID.README.md
@@ -211,3 +211,24 @@ This will give you the spot meta data for the Hyperliquid L1. (this is an exampl
 The `tokenId` is the address of the token on the HyperLiquid L1.
 The `evmContract` is the address of the token on the HyperEVM.
 The `deployerTradingFeeShare` is the fee share for the deployer of the token.
+
+## Hyperliquid L1 Actions
+
+You need to use ethers-v6 to sign the actions - <https://docs.ethers.org/v6/api/providers/#Signer-signTypedData>
+
+```bash
+# add ethers-v6 to your project as an alias for ethers@^6.13.5
+pnpm add ethers-v6@npm:ethers@^6.13.5
+```
+
+```ts
+import { Wallet } from 'ethers' // ethers-v5 wallet
+import { Wallet as ethersV6Wallet } from 'ethers-v6' // ethers-v6 wallet
+
+const signerv6 = new ethersV6Wallet(wallet.privateKey) // where wallet is an ethers.Wallet from ethers-v5
+const signature = await signerv6.signTypedData(domain, types, message)
+```
+
+This is because in ethers-v5 EIP-712 signing is not stable. - <https://docs.ethers.org/v5/api/signer/#Signer-signTypedData>
+> Experimental feature (this method name will change)
+> This is still an experimental feature. If using it, please specify the exact version of ethers you are using (e.g. spcify "5.0.18", not "^5.0.18") as the method name will be renamed from _signTypedData to signTypedData once it has been used in the field a bit.

--- a/packages/oft-hyperliquid-evm/package.json
+++ b/packages/oft-hyperliquid-evm/package.json
@@ -19,12 +19,20 @@
   },
   "license": "MIT",
   "exports": {
-    "./package.json": "./package.json",
-    "./artifacts/*.json": {
-      "require": "./artifacts/*.json",
-      "imports": "./artifacts/*.json"
+    ".": {
+      "types": "./dist/index.d.ts",
+      "require": "./dist/index.js",
+      "import": "./dist/index.mjs"
+    },
+    "./*": {
+      "types": "./dist/*.d.ts",
+      "require": "./dist/*.js",
+      "import": "./dist/*.mjs"
     }
   },
+  "main": "./dist/index.js",
+  "module": "./dist/index.mjs",
+  "types": "./dist/index.d.ts",
   "files": [
     "artifacts/Fee.sol/Fee.json",
     "artifacts/IFee.sol/IFee.json",
@@ -35,26 +43,43 @@
     "artifacts/OFTAdapter.sol/OFTAdapter.json",
     "artifacts/OFTCore.sol/OFTCore.json",
     "contracts/**/*",
-    "test/**/*"
+    "test/**/*",
+    "./dist/index.*",
+    "./src/**/*"
   ],
   "scripts": {
-    "clean": "rimraf .turbo cache out artifacts",
+    "prebuild": "$npm_execpath tsc --noEmit",
+    "build": "$npm_execpath tsup",
+    "clean": "rimraf .turbo cache out artifacts dist",
     "compile": "$npm_execpath compile:forge",
     "compile:forge": "forge build",
+    "dev": "$npm_execpath tsup --watch",
+    "lint": "$npm_execpath eslint '**/*.{js,ts,json}'",
+    "lint:fix": "eslint --fix '**/*.{js,ts,json}'",
     "test": "$npm_execpath test:forge",
     "test:forge": "forge test"
   },
   "devDependencies": {
     "@layerzerolabs/lz-evm-protocol-v2": "^3.0.12",
     "@layerzerolabs/lz-evm-v1-0.7": "^3.0.12",
+    "@layerzerolabs/lz-utilities": "^3.0.74",
     "@layerzerolabs/oapp-evm": "^0.3.1",
     "@layerzerolabs/oft-evm": "^3.1.2",
     "@layerzerolabs/test-devtools-evm-foundry": "~6.0.2",
     "@layerzerolabs/toolbox-foundry": "^0.1.12",
+    "@msgpack/msgpack": "^3.0.0-beta2",
+    "@noble/hashes": "^1.7.1",
     "@openzeppelin/contracts": "^5.0.2",
     "@openzeppelin/contracts-upgradeable": "^5.0.2",
+    "axios": "^1.7.2",
     "depcheck": "^1.4.7",
-    "rimraf": "^5.0.5"
+    "dotenv": "^16.4.7",
+    "ethers": "^5.7.2",
+    "ethers-v6": "npm:ethers@^6.13.5",
+    "jest": "^29.7.0",
+    "rimraf": "^5.0.5",
+    "ts-node": "^10.9.2",
+    "tsup": "^8.4.0"
   },
   "peerDependencies": {
     "@layerzerolabs/lz-evm-messagelib-v2": "^3.0.12",
@@ -63,8 +88,5 @@
     "@layerzerolabs/oapp-evm": "^0.3.1",
     "@openzeppelin/contracts": "^4.8.1 || ^5.0.0",
     "@openzeppelin/contracts-upgradeable": "^4.8.1 || ^5.0.0"
-  },
-  "publishConfig": {
-    "access": "restricted"
   }
 }

--- a/packages/oft-hyperliquid-evm/src/index.ts
+++ b/packages/oft-hyperliquid-evm/src/index.ts
@@ -1,0 +1,4 @@
+export * from './operations'
+export * from './signer'
+export * from './types'
+export * from './io'

--- a/packages/oft-hyperliquid-evm/src/io/env.ts
+++ b/packages/oft-hyperliquid-evm/src/io/env.ts
@@ -1,0 +1,13 @@
+import path from 'path'
+import dotenv from 'dotenv'
+
+export function loadEnv() {
+    const envPath = path.resolve(path.join(process.cwd(), '.env'))
+    const env = dotenv.config({ path: envPath })
+    if (!env.parsed || env.error?.message !== undefined) {
+        console.error('Failed to load .env file.')
+        process.exit(1)
+    }
+
+    return env.parsed
+}

--- a/packages/oft-hyperliquid-evm/src/io/index.ts
+++ b/packages/oft-hyperliquid-evm/src/io/index.ts
@@ -1,0 +1,2 @@
+export * from './parser'
+export * from './env'

--- a/packages/oft-hyperliquid-evm/src/io/parser.ts
+++ b/packages/oft-hyperliquid-evm/src/io/parser.ts
@@ -1,0 +1,26 @@
+import { NativeSpots, NativeSpot } from '@/types'
+import fs from 'fs'
+import path from 'path'
+
+export function getNativeSpot(nativeSpots: NativeSpots, key: string): NativeSpot {
+    for (const spot of Object.values(nativeSpots)) {
+        if (spot.name === key) {
+            return spot
+        }
+    }
+
+    throw new Error(`Native spot ${key} not found`)
+}
+
+export function writeUpdatedNativeSpots(
+    nativeSpots: NativeSpots,
+    key: string,
+    tokenAddress: string,
+    tokenName: string
+) {
+    const spot = getNativeSpot(nativeSpots, key)
+    spot.evmContract = tokenAddress
+    spot.fullName = tokenName
+
+    fs.writeFileSync(path.join(process.cwd(), 'nativeSpots.ts'), JSON.stringify(nativeSpots, null, 2))
+}

--- a/packages/oft-hyperliquid-evm/src/operations/evmUserModify.ts
+++ b/packages/oft-hyperliquid-evm/src/operations/evmUserModify.ts
@@ -1,0 +1,25 @@
+import { Wallet } from 'ethers'
+import { HyperliquidClient } from '@/signer'
+import { EvmUserModifyRequest } from '@/types'
+
+export async function useBigBlock(wallet: Wallet, isTestnet: boolean) {
+    const action: EvmUserModifyRequest['action'] = {
+        type: 'evmUserModify',
+        usingBigBlocks: true,
+    }
+
+    const hyperliquidClient = new HyperliquidClient(isTestnet)
+    const response = await hyperliquidClient.submitHyperliquidAction('/exchange', wallet, action)
+    return response
+}
+
+export async function useSmallBlock(wallet: Wallet, isTestnet: boolean) {
+    const action: EvmUserModifyRequest['action'] = {
+        type: 'evmUserModify',
+        usingBigBlocks: false,
+    }
+
+    const hyperliquidClient = new HyperliquidClient(isTestnet)
+    const response = await hyperliquidClient.submitHyperliquidAction('/exchange', wallet, action)
+    return response
+}

--- a/packages/oft-hyperliquid-evm/src/operations/index.ts
+++ b/packages/oft-hyperliquid-evm/src/operations/index.ts
@@ -1,0 +1,2 @@
+export * from './spotDeploy'
+export * from './evmUserModify'

--- a/packages/oft-hyperliquid-evm/src/operations/spotDeploy.ts
+++ b/packages/oft-hyperliquid-evm/src/operations/spotDeploy.ts
@@ -1,0 +1,27 @@
+import { Wallet } from 'ethers'
+import { HyperliquidClient } from '@/signer'
+import { EvmSpotDeployRequest } from '@/types'
+
+export async function requestEvmContract(
+    wallet: Wallet,
+    isTestnet: boolean,
+    evmSpotTokenAddress: string,
+    evmExtraWeiDecimals: number,
+    nativeSpotTokenId: number
+) {
+    const requestEvmContract: EvmSpotDeployRequest['action']['requestEVMContract'] = {
+        type: 'requestEvmContract',
+        token: nativeSpotTokenId,
+        address: evmSpotTokenAddress,
+        evmExtraWeiDecimals: evmExtraWeiDecimals,
+    }
+
+    const action: EvmSpotDeployRequest['action'] = {
+        type: 'spotDeploy',
+        requestEVMContract: requestEvmContract,
+    }
+
+    const hyperliquidClient = new HyperliquidClient(isTestnet)
+    const response = await hyperliquidClient.submitHyperliquidAction('/exchange', wallet, action)
+    return response
+}

--- a/packages/oft-hyperliquid-evm/src/signer/index.ts
+++ b/packages/oft-hyperliquid-evm/src/signer/index.ts
@@ -1,0 +1,2 @@
+export * from './signer'
+export * from './wallet'

--- a/packages/oft-hyperliquid-evm/src/signer/signer.ts
+++ b/packages/oft-hyperliquid-evm/src/signer/signer.ts
@@ -1,0 +1,162 @@
+import { encode } from '@msgpack/msgpack'
+import { Hex } from '@layerzerolabs/lz-utilities'
+
+import { loadEnv } from '@/io'
+import { Wallet } from 'ethers'
+import { Wallet as ethersV6Wallet } from 'ethers-v6'
+
+import type { ValueType } from '@/types'
+import { isAbstractEthersV5Signer } from './utils'
+import { keccak256 } from 'ethers/lib/utils'
+
+/**
+ * Converts a hex string address to a Buffer.
+ * Removes the "0x" prefix if present.
+ *
+ * @param address - The vault address as a hex string.
+ * @returns The address as a Buffer.
+ */
+function addressToBytes(address: string): Buffer {
+    // Remove '0x' prefix if it exists.
+    if (address.startsWith('0x')) {
+        address = address.slice(2)
+    }
+    return Buffer.from(address, 'hex')
+}
+
+/**
+ * Creates a keccak hash based on the packed action, nonce, and vault address.
+ *
+ * @param action - The action data to be packed with MessagePack.
+ * @param vaultAddress - The vault address as a hex string or null.
+ * @param nonce - A numeric nonce.
+ * @returns The keccak hash as a hex string.
+ */
+export function computeL1ActionHash(action: any, nonce: number, vaultAddress: string | null): string {
+    /*
+        with nonce 0 and msg.sender = 0xa3824BFfc05178b1eD611117e5b900adCb189b94
+        v1 decoded to 0x0863c99fb68fcfbcb1761ba7638e70b0adc64940
+        v2 decoded to 0x0863c99fb68fcfbcb1761ba7638e70b0adc64940
+        v3 decoded to 0x0863c99fb68fcfbcb1761ba7638e70b0adc64940
+    */
+    const actionPacked = encode(action)
+
+    const nonceBuffer: Buffer = Buffer.alloc(8)
+    nonceBuffer.writeBigUInt64BE(BigInt(nonce))
+
+    let vaultBuffer: Buffer
+    if (vaultAddress === null) {
+        vaultBuffer = Buffer.from([0x00])
+    } else {
+        vaultBuffer = Buffer.concat([Buffer.from([0x01]), addressToBytes(vaultAddress)])
+    }
+
+    const data = Buffer.concat([actionPacked, nonceBuffer, vaultBuffer])
+
+    const hash = keccak256(data)
+    return hash
+}
+
+/**
+ * Sign an L1 action.
+ *
+ * Note: Signature generation depends on the order of the action keys.
+ * @param args.wallet - Wallet to sign the action.
+ * @param args.action - The action to be signed.
+ * @param args.nonce - Unique request identifier (recommended current timestamp in ms).
+ * @param args.isTestnet - Indicates if the action is for the testnet. Default is `false`.
+ * @param args.vaultAddress - Optional vault address used in the action.
+ * @returns The signature components r, s, and v.
+ */
+export async function signL1Action(args: {
+    wallet: Wallet
+    action: ValueType
+    nonce: number
+    isTestnet?: boolean
+    vaultAddress: Hex | null
+}): Promise<{ r: Hex; s: Hex; v: number }> {
+    const { wallet, action, nonce, isTestnet = false, vaultAddress } = args
+
+    const domain = {
+        name: 'Exchange',
+        version: '1',
+        chainId: 1337,
+        verifyingContract: '0x0000000000000000000000000000000000000000',
+    } as const
+    const types = {
+        Agent: [
+            { name: 'source', type: 'string' },
+            { name: 'connectionId', type: 'bytes32' },
+        ],
+    }
+
+    const actionHash = computeL1ActionHash(action, nonce, vaultAddress)
+    const message = {
+        source: isTestnet ? 'b' : 'a',
+        connectionId: actionHash,
+    }
+    const signature = await abstractSignTypedData({ wallet, domain, types, message })
+    return splitSignature(signature)
+}
+
+/** Signs typed data with the provided wallet using EIP-712. */
+async function abstractSignTypedData(args: {
+    wallet: Wallet
+    domain: {
+        name: string
+        version: string
+        chainId: number
+        verifyingContract: Hex
+    }
+    types: {
+        [key: string]: {
+            name: string
+            type: string
+        }[]
+    }
+    message: { [key: string]: unknown }
+}): Promise<Hex> {
+    const { wallet, domain, types, message } = args
+
+    if (isAbstractEthersV5Signer(wallet)) {
+        // Note we need ethers-v6 to sign typed data - this is because ethers-v5 EIP-712 signing is not stable.
+        const signerv6 = new ethersV6Wallet(wallet.privateKey)
+        const signature = await signerv6.signTypedData(domain, types, message)
+        return signature as Hex
+    } else {
+        throw new Error('Unsupported wallet for signing typed data')
+    }
+}
+
+/** Splits a signature hexadecimal string into its components. */
+function splitSignature(signature: Hex): { r: Hex; s: Hex; v: number } {
+    const r = `0x${signature.slice(2, 66)}` as const
+    const s = `0x${signature.slice(66, 130)}` as const
+    const v = parseInt(signature.slice(130, 132), 16)
+    return { r, s, v }
+}
+
+export function getTimestampMs(): number {
+    return Date.now()
+}
+
+export async function getHyperliquidWallet() {
+    const env = loadEnv()
+
+    const privateKey = env.PRIVATE_KEY_HYPERLIQUID
+    if (!privateKey) {
+        console.error('PRIVATE_KEY_HYPERLIQUID is not set in .env file')
+        process.exit(1)
+    }
+
+    return new Wallet(privateKey)
+}
+
+/*
+with nonce 0 and msg.sender = 0xa3824BFfc05178b1eD611117e5b900adCb189b94
+v1 decoded to 0x0863c99fb68fcfbcb1761ba7638e70b0adc64940
+
+
+
+
+*/

--- a/packages/oft-hyperliquid-evm/src/signer/utils.ts
+++ b/packages/oft-hyperliquid-evm/src/signer/utils.ts
@@ -1,0 +1,47 @@
+import type { ValueType } from '@/types'
+import { Wallet } from 'ethers'
+
+export function encodeHex(data: Uint8Array): string {
+    return Buffer.from(data).toString('hex')
+}
+
+export function decodeHex(hexString: string): Uint8Array {
+    return new Uint8Array(Buffer.from(hexString, 'hex'))
+}
+
+/** Layer to make {@link https://jsr.io/@std/msgpack | @std/msgpack} compatible with {@link https://github.com/msgpack/msgpack-javascript | @msgpack/msgpack}. */
+export function normalizeIntegersForMsgPack(obj: ValueType): ValueType {
+    const THIRTY_ONE_BITS = 2147483648
+    const THIRTY_TWO_BITS = 4294967296
+
+    if (
+        typeof obj === 'number' &&
+        Number.isInteger(obj) &&
+        obj <= Number.MAX_SAFE_INTEGER &&
+        obj >= Number.MIN_SAFE_INTEGER &&
+        (obj >= THIRTY_TWO_BITS || obj < -THIRTY_ONE_BITS)
+    ) {
+        return BigInt(obj)
+    }
+
+    if (Array.isArray(obj)) {
+        return obj.map(normalizeIntegersForMsgPack)
+    }
+
+    if (obj && typeof obj === 'object' && obj !== null) {
+        return Object.fromEntries(Object.entries(obj).map(([key, value]) => [key, normalizeIntegersForMsgPack(value)]))
+    }
+
+    return obj
+}
+
+/** Checks if the given value is an abstract ethers v5 signer. */
+export function isAbstractEthersV5Signer(client: unknown): client is Wallet {
+    return (
+        typeof client === 'object' &&
+        client !== null &&
+        '_signTypedData' in client &&
+        typeof client._signTypedData === 'function' &&
+        client._signTypedData.length === 3
+    )
+}

--- a/packages/oft-hyperliquid-evm/src/signer/wallet.ts
+++ b/packages/oft-hyperliquid-evm/src/signer/wallet.ts
@@ -1,0 +1,64 @@
+import { Wallet } from 'ethers'
+import axios, { AxiosInstance } from 'axios'
+import { HYPERLIQUID_URLS } from '@/types'
+
+import { getTimestampMs, signL1Action } from '@/signer'
+
+export class HyperliquidClient {
+    private readonly client: AxiosInstance
+    private readonly baseUrl: string
+    private readonly isTestnet: boolean
+
+    constructor(isTestnet: boolean) {
+        this.baseUrl = isTestnet ? HYPERLIQUID_URLS.TESTNET : HYPERLIQUID_URLS.MAINNET
+        this.isTestnet = isTestnet
+        this.client = axios.create({
+            baseURL: this.baseUrl,
+            headers: {
+                'Content-Type': 'application/json',
+            },
+        })
+    }
+
+    async submitHyperliquidAction(endpoint: string, wallet: Wallet, action: any) {
+        const nonce = getTimestampMs()
+
+        const signature = await signL1Action({
+            wallet,
+            action,
+            nonce,
+            isTestnet: this.isTestnet,
+            vaultAddress: null,
+        })
+
+        // Format the payload exactly as shown in the working example
+        const payload = {
+            action,
+            nonce,
+            signature,
+            vaultAddress: null,
+        }
+
+        try {
+            console.log('Sending payload:', JSON.stringify(payload, null, 2))
+            console.log(`Sending to: ${this.baseUrl}${endpoint}`)
+
+            // Direct POST to the full endpoint
+            const response = await this.client.post(endpoint, payload)
+            return response.data
+        } catch (error) {
+            console.error(error)
+            if (axios.isAxiosError(error) && error.response) {
+                console.error('API Error:', {
+                    status: error.response.status,
+                    statusText: error.response.statusText,
+                    data: error.response.data,
+                    url: `${this.baseUrl}${endpoint}`,
+                    payload: JSON.stringify(payload),
+                })
+                throw new Error(`Hyperliquid API error: ${JSON.stringify(error.response.data)}`)
+            }
+            throw new Error(`Failed to submit Hyperliquid action: ${error}`)
+        }
+    }
+}

--- a/packages/oft-hyperliquid-evm/src/types/constants.ts
+++ b/packages/oft-hyperliquid-evm/src/types/constants.ts
@@ -1,0 +1,9 @@
+export const HYPERLIQUID_URLS = {
+    MAINNET: 'https://api.hyperliquid.xyz',
+    TESTNET: 'https://api.hyperliquid-testnet.xyz',
+}
+
+export const ENDPOINTS = {
+    INFO: '/info',
+    EXCHANGE: '/exchange',
+}

--- a/packages/oft-hyperliquid-evm/src/types/index.ts
+++ b/packages/oft-hyperliquid-evm/src/types/index.ts
@@ -1,0 +1,2 @@
+export * from './constants'
+export * from './types'

--- a/packages/oft-hyperliquid-evm/src/types/types.ts
+++ b/packages/oft-hyperliquid-evm/src/types/types.ts
@@ -1,0 +1,98 @@
+import { Hex } from '@layerzerolabs/lz-utilities'
+
+export interface Signature {
+    r: string
+    s: string
+    v: number
+}
+
+export interface NativeSpot {
+    name: string
+    szDecimals: number
+    weiDecimals: number
+    index: number
+    tokenId: string
+    isCanonical: boolean
+    evmContract: string | null
+    fullName: string | null
+    deployerTradingFeeShare: string
+}
+
+export interface NativeSpots {
+    [key: string]: NativeSpot
+}
+
+/** Base structure for exchange requests. */
+export interface BaseExchangeRequest {
+    /** Action to perform. */
+    action: {
+        /** Type of action. */
+        type: string
+        /** Additional action parameters. */
+        [key: string]: unknown
+    }
+    /** Unique request identifier (recommended current timestamp in ms). */
+    nonce: number
+    /** Cryptographic signature. */
+    signature: { r: Hex; s: Hex; v: number }
+}
+
+/**
+ * Configure block type for EVM transactions.
+ * @returns {SuccessResponse}
+ * @see https://hyperliquid.gitbook.io/hyperliquid-docs/for-developers/evm/dual-block-architecture
+ */
+export interface EvmUserModifyRequest extends BaseExchangeRequest {
+    /** Action to be performed. */
+    action: {
+        /** Type of action. */
+        type: 'evmUserModify'
+        /** `true` for large blocks, `false` for small blocks. */
+        usingBigBlocks: boolean
+    }
+}
+
+export interface EvmSpotDeployRequest extends BaseExchangeRequest {
+    /** Action to be performed. */
+    action: {
+        type: 'spotDeploy'
+        requestEVMContract: {
+            type: 'requestEvmContract'
+            token: number
+            address: string
+            evmExtraWeiDecimals: number
+        }
+    }
+}
+
+/** Base structure for exchange responses. */
+export interface BaseExchangeResponse {
+    /** Response status */
+    status: 'ok' | 'err'
+    /** Error message or success data */
+    response:
+        | string
+        | {
+              /** Type of response. */
+              type: string
+              /** Specific data for the operation. */
+              data?: unknown
+          }
+}
+
+/** Successful response without specific data. */
+export interface SuccessResponse extends BaseExchangeResponse {
+    /** Successful status. */
+    status: 'ok'
+    /** Response details. */
+    response: {
+        /** Type of response. */
+        type: 'default'
+    }
+}
+
+export type ValueType = number | bigint | string | boolean | null | Uint8Array | readonly ValueType[] | ValueMap
+
+export interface ValueMap {
+    [key: string]: ValueType
+}

--- a/packages/oft-hyperliquid-evm/tsconfig.json
+++ b/packages/oft-hyperliquid-evm/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.json",
+  "exclude": ["dist", "node_modules"],
+  "include": ["src", "test", "*.config.ts"],
+  "compilerOptions": {
+    "types": ["node", "jest"],
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  }
+}

--- a/packages/oft-hyperliquid-evm/tsup.config.ts
+++ b/packages/oft-hyperliquid-evm/tsup.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from 'tsup'
+
+export default defineConfig([
+    {
+        entry: ['src/index.ts'],
+        outDir: './dist',
+        clean: true,
+        dts: true,
+        sourcemap: true,
+        splitting: false,
+        treeshake: true,
+        format: ['esm', 'cjs'],
+    },
+])


### PR DESCRIPTION
Hyperliquid does not have an official ts-sdk and the community built ones don't support all the L1 actions that we need.
This PR is performs 2x L1 actions that we need 
1. [evmUserModify](https://hyperliquid.gitbook.io/hyperliquid-docs/for-developers/evm/dual-block-architecture) to toggle between big and smol blocks 
2. [requestEvmContract](https://hyperliquid.gitbook.io/hyperliquid-docs/for-developers/evm/native-transfers) to link a evm spot with a native spot