### PR TITLE
🧹oapp-aptos-example import path update

### DIFF
--- a/.changeset/five-drinks-visit.md
+++ b/.changeset/five-drinks-visit.md
@@ -1,0 +1,5 @@
+---
+"@layerzerolabs/oapp-aptos-example": patch
+---
+
+scripts/cli uses the changed imports

--- a/examples/oapp-aptos-move/.eslintrc.js
+++ b/examples/oapp-aptos-move/.eslintrc.js
@@ -1,10 +1,33 @@
 require('@rushstack/eslint-patch/modern-module-resolution');
 
 module.exports = {
+    root: true, // Add this line to prevent ESLint from looking up the directory tree
     extends: ['@layerzerolabs/eslint-config-next/recommended'],
     rules: {
         // @layerzerolabs/eslint-config-next defines rules for turborepo-based projects
         // that are not relevant for this particular project
         'turbo/no-undeclared-env-vars': 'off',
+        // Explicitly disable no-unresolved for LayerZero packages
+        'import/no-unresolved': [
+            'error',
+            {
+                ignore: [
+                    '@layerzerolabs/devtools-extensible-cli',
+                    '@layerzerolabs/devtools-move',
+                    '@layerzerolabs/oft-move',
+                ],
+            },
+        ],
+    },
+    settings: {
+        'import/resolver': {
+            typescript: {
+                project: './tsconfig.json',
+            },
+            node: {
+                moduleDirectory: ['node_modules', '.'],
+                extensions: ['.js', '.jsx', '.ts', '.tsx'],
+            },
+        },
     },
 };

--- a/examples/oapp-aptos-move/scripts/cli.ts
+++ b/examples/oapp-aptos-move/scripts/cli.ts
@@ -1,6 +1,6 @@
-import { sdk } from '@layerzerolabs/devtools-extensible-cli/cli/AptosEVMCli'
-import { attach_wire_evm, attach_wire_move } from '@layerzerolabs/devtools-move/cli/init'
-import { attach_oft_move } from '@layerzerolabs/oft-move/cli/init'
+import { sdk } from '@layerzerolabs/devtools-extensible-cli'
+import { attach_wire_evm, attach_wire_move } from '@layerzerolabs/devtools-move'
+import { attach_oft_move } from '@layerzerolabs/oft-move'
 
 async function lzSdk() {
     await attach_wire_move(sdk)


### PR DESCRIPTION
updating `oapp-aptos` 's `scripts/cli` which was missed in the earlier PR  <https://github.com/LayerZero-Labs/devtools/pull/1355>