### PR TITLE
🧹 clarify error message

### DIFF
--- a/.changeset/early-onions-bathe.md
+++ b/.changeset/early-onions-bathe.md
@@ -1,0 +1,5 @@
+---
+"@layerzerolabs/devtools": patch
+---
+
+Clarify missing contract error message

--- a/packages/devtools/src/omnigraph/builder.ts
+++ b/packages/devtools/src/omnigraph/builder.ts
@@ -28,7 +28,10 @@ export class OmniGraphBuilder<TNodeConfig = unknown, TEdgeConfig = unknown> {
         const from = formatOmniPoint(edge.vector.from)
 
         assert(isVectorPossible(edge.vector), `Cannot add edge ${label}: cannot connect the two endpoints`)
-        assert(this.getNodeAt(edge.vector.from), `Cannot add edge ${label}: ${from} is not in the graph`)
+        assert(
+            this.getNodeAt(edge.vector.from),
+            `Cannot add edge ${label}: ${from} is not in the graph.  Please check that it is included in the --oapp-config contracts.`
+        )
     }
 
     //   .-.-.   .-.-.   .-.-.   .-.-.   .-.-.   .-.-.   .-.-.   .-.-


### PR DESCRIPTION
Tell users how to actually fix the error instead of being unintentionally vague about what is wrong.