### PR TITLE
🪲 exports from devtools-extensible-cli are fixed

### DIFF
--- a/.changeset/shy-monkeys-deny.md
+++ b/.changeset/shy-monkeys-deny.md
@@ -1,0 +1,5 @@
+---
+"@layerzerolabs/devtools-extensible-cli": patch
+---
+
+Fix exports from devtools-extensible-cli

--- a/packages/devtools-extensible-cli/cli/index.ts
+++ b/packages/devtools-extensible-cli/cli/index.ts
@@ -1,2 +1,0 @@
-export * from './AptosEVMCli'
-export * from './types/NewOperation'

--- a/packages/devtools-extensible-cli/index.ts
+++ b/packages/devtools-extensible-cli/index.ts
@@ -1,0 +1,2 @@
+export * from './cli/AptosEVMCli'
+export * from './cli/types/NewOperation'

--- a/packages/devtools-extensible-cli/tsup.config.ts
+++ b/packages/devtools-extensible-cli/tsup.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from 'tsup'
 
 export default defineConfig({
-    entry: ['cli/index.ts'],
+    entry: ['index.ts'],
     outDir: './dist',
     clean: true,
     dts: true,


### PR DESCRIPTION
Otherwise, we would need to import as @layerzerolabs/devtools-extensible-cli/cli in all clients.