### PR TITLE
🗞️ add "lz:oapp:wire" option to filter out connections from certain eids

### DIFF
--- a/.changeset/selfish-brooms-grin.md
+++ b/.changeset/selfish-brooms-grin.md
@@ -1,0 +1,6 @@
+---
+"@layerzerolabs/ua-devtools-evm-hardhat": patch
+"@layerzerolabs/devtools": patch
+---
+
+Add the ability to filter out connections from specified EndpointIds

--- a/packages/ua-devtools-evm-hardhat/src/tasks/oapp/wire/index.ts
+++ b/packages/ua-devtools-evm-hardhat/src/tasks/oapp/wire/index.ts
@@ -54,6 +54,10 @@ interface TaskArgs {
      * Output filename for the generated transactions.
      */
     outputFilename?: string
+    /**
+     * Exclude connections that originate from the specified EndpointIds.
+     */
+    skipConnectionsFromEids?: string[]
 }
 
 const action: ActionType<TaskArgs> = async (
@@ -69,6 +73,7 @@ const action: ActionType<TaskArgs> = async (
         configureSubtask = SUBTASK_LZ_OAPP_WIRE_CONFIGURE,
         signAndSendSubtask = SUBTASK_LZ_SIGN_AND_SEND,
         outputFilename,
+        skipConnectionsFromEids,
     },
     hre
 ): Promise<SignAndSendResult> => {
@@ -121,6 +126,7 @@ const action: ActionType<TaskArgs> = async (
         graph,
         assert,
         dryRun,
+        skipConnectionsFromEids,
     })
 }
 
@@ -157,3 +163,9 @@ task(TASK_LZ_OAPP_WIRE, 'Wire LayerZero OApp', action)
     .addFlag('safe', 'Use gnosis safe to sign transactions')
     .addParam('signer', 'Index or address of signer', undefined, types.signer, true)
     .addParam('outputFilename', 'Output filename for the generated transactions', undefined, types.string, true)
+    .addOptionalParam(
+        'skipConnectionsFromEids',
+        'Skip wiring connections that originate from the specified EndpointIds',
+        undefined,
+        types.csv
+    )


### PR DESCRIPTION
### Test without the flag:

`pnpm hardhat lz:oapp:wire --oapp-config ./layerzero.config.ts`

<img width="559" alt="Screenshot 2025-03-13 at 4 07 58 PM" src="https://github.com/user-attachments/assets/7a8e9411-af2e-4b44-b87a-b518c47b5013" />

Result:  2 Transactions, as is normal.

### Test excluding SEPOLIA_V2_TESTNET

`pnpm hardhat lz:oapp:wire --oapp-config ./layerzero.config.ts --skip-connections-from-eids 40161`

<img width="1414" alt="Screenshot 2025-03-13 at 4 09 20 PM" src="https://github.com/user-attachments/assets/3f162ec5-9852-470d-b058-8beb704edf77" />

Result:  Only the Fuji transaction

### Test excluding SEPOLIA_V2_TESTNET and AVALANCHE_V2_TESTNET

`pnpm hardhat lz:oapp:wire --oapp-config ./layerzero.config.ts --skip-connections-from-eids 40161,40106`

<img width="520" alt="Screenshot 2025-03-13 at 4 10 45 PM" src="https://github.com/user-attachments/assets/266a1537-072c-4159-a790-88bd4f329231" />

Result:  No transactions, all connections were filtered.

### Test some garbage input, some good

`pnpm hardhat lz:oapp:wire --oapp-config ./layerzero.config.ts --skip-connections-from-eids 40161,pizza`

<img width="1324" alt="Screenshot 2025-03-13 at 4 11 34 PM" src="https://github.com/user-attachments/assets/576d4bea-fad4-4d9b-b059-6ec6355eb519" />

Result:  Applies only valid eids in the CSV.


