### PR TITLE
fix title in Solana examples

### DIFF
--- a/examples/lzapp-migration/README.md
+++ b/examples/lzapp-migration/README.md
@@ -283,7 +283,7 @@ const solanaContract: OmniPointHardhat = {
 };
 ```
 
-#### Initialize the Solana OFT PeerConfig Account(s)
+#### Initialize the OFT Program's SendConfig and ReceiveConfig Accounts
 
 :warning: Do this only when initializing the OFT for the first time. The only exception is if a new pathway is added later. If so, run this again to properly initialize the pathway.
 

--- a/examples/oft-solana/README.md
+++ b/examples/oft-solana/README.md
@@ -246,7 +246,7 @@ pnpm hardhat lz:deploy # follow the prompts
 
 Note: If you are on testnet, consider using `MyOFTMock` to allow test token minting. If you do use `MyOFTMock`, make sure to update the `sepoliaContract.contractName` in [layerzero.config.ts](./layerzero.config.ts) to `MyOFTMock`.
 
-### Initialize the Solana OFT Config PeerConfig Account(s)
+#### Initialize the OFT Program's SendConfig and ReceiveConfig Accounts
 
 :warning: Do this only when initializing the OFT for the first time. The only exception is if a new pathway is added later. If so, run this again to properly initialize the pathway.
 


### PR DESCRIPTION
The `oft:solana:init-config` step (hardhat task) was wrongly described as setting up the PeerConfig accounts when in fact it's setting up SendConfig and ReceiveConfig.