### PR TITLE
🚀  feat(metadata-tools): allow for custom fetchMetadata implementation

### DIFF
--- a/.changeset/mean-frogs-lick.md
+++ b/.changeset/mean-frogs-lick.md
@@ -1,0 +1,5 @@
+---
+"@layerzerolabs/metadata-tools": minor
+---
+
+allow for custom fetchMetadata implementation

--- a/packages/metadata-tools/README.md
+++ b/packages/metadata-tools/README.md
@@ -28,11 +28,63 @@ npm install @layerzerolabs/metadata-tools
 
 ## Usage
 
+Without custom params:
+
 ```typescript
 import { generateConnectionsConfig } from "@layerzerolabs/metadata-tools";
 
 // [srcContract, dstContract, [requiredDVNs, [optionalDVNs, threshold]], [srcToDstConfirmations, dstToSrcConfirmations]], [enforcedOptionsSrcToDst, enforcedOptionsDstToSrc]
 const connections = await generateConnectionsConfig([
-  [avalancheContract, polygonContract, [['LayerZero'], []], [1, 1], [EVM_ENFORCED_OPTIONS, EVM_ENFORCED_OPTIONS]],
+  [avalancheContract, polygonContract, [['LayerZero Labs'], []], [1, 1], [EVM_ENFORCED_OPTIONS, EVM_ENFORCED_OPTIONS]],
 ]);
 ```
+
+With custom fetchMetadata, to add the custom DVN 'SuperCustomDVN' for Solana Devnet and Fuji:
+
+```typescript
+import { generateConnectionsConfig, defaultFetchMetadata, IMetadata, IMetadataDvns } from "@layerzerolabs/metadata-tools";
+
+// create a custom fetchMetadata implementation
+const customFetchMetadata = async (): Promise<IMetadata> => {
+    // get the default metadata
+    const defaultMetadata = await defaultFetchMetadata() 
+
+    // extend the Solana DVNs with custom DVN(s)
+    const solanaTestnetDVNsWithCustom: IMetadataDvns = {
+      ...metadata['solana-testnet']!.dvns,
+      '29EKzmCscUg8mf4f5uskwMqvu2SXM8hKF1gWi1cCBoKT': {
+          version: 2,
+          canonicalName: 'SuperCustomDVN',
+          id: 'super-custom-dvn',
+      },
+    }
+    // extend the Fuji DVNs with custom DVN(s)
+    const fujiDVNsWithCustom: IMetadataDvns = {
+        ...metadata.fuji!.dvns,
+        '0x9f0e79aeb198750f963b6f30b99d87c6ee5a0467': {
+            version: 2,
+            canonicalName: 'SuperCustomDVN',
+            id: 'super-custom-dvn',
+        },
+    }
+
+    return {
+        ...metadata,
+        'solana-testnet': {
+            ...metadata['solana-testnet']!,
+            dvns: solanaTestnetDVNsWithCustom,
+        },
+        fuji: {
+            ...metadata.fuji!,
+            dvns: fujiDVNsWithCustom,
+        },
+    }
+}
+
+// We can now pass 'SuperCustomDVN' as a DVN value
+// [srcContract, dstContract, [requiredDVNs, [optionalDVNs, threshold]], [srcToDstConfirmations, dstToSrcConfirmations]], [enforcedOptionsSrcToDst, enforcedOptionsDstToSrc]
+const connections = await generateConnectionsConfig([
+  [avalancheContract, polygonContract, [['SuperCustomDVN'], []], [1, 1], [EVM_ENFORCED_OPTIONS, EVM_ENFORCED_OPTIONS]],
+]);
+```
+

--- a/packages/metadata-tools/src/config-metadata.ts
+++ b/packages/metadata-tools/src/config-metadata.ts
@@ -216,12 +216,12 @@ export async function translatePathwayToConfig(
     return configs
 }
 
-/// allow for a custom metadataUrl
+// allow for a custom metadataUrl
 async function defaultFetchMetadata(metadataUrl = METADATA_URL): Promise<IMetadata> {
     return (await fetch(metadataUrl).then((res) => res.json())) as IMetadata
 }
 
-/// allow for a custom metadataFetcher
+// allow for a custom fetchMetadata
 export async function generateConnectionsConfig(
     pathways: TwoWayConfig[],
     fetchMetadata: () => Promise<IMetadata> = defaultFetchMetadata

--- a/packages/metadata-tools/src/config-metadata.ts
+++ b/packages/metadata-tools/src/config-metadata.ts
@@ -224,7 +224,7 @@ export async function defaultFetchMetadata(metadataUrl = METADATA_URL): Promise<
 // allow for a custom fetchMetadata
 export async function generateConnectionsConfig(
     pathways: TwoWayConfig[],
-    fetchMetadata: () => Promise<IMetadata> = defaultFetchMetadata
+    { fetchMetadata = defaultFetchMetadata }: { fetchMetadata?: () => Promise<IMetadata> }
 ) {
     const metadata = await fetchMetadata()
     const connections: OmniEdgeHardhat<OAppEdgeConfig | undefined>[] = []

--- a/packages/metadata-tools/src/config-metadata.ts
+++ b/packages/metadata-tools/src/config-metadata.ts
@@ -217,7 +217,7 @@ export async function translatePathwayToConfig(
 }
 
 // allow for a custom metadataUrl
-async function defaultFetchMetadata(metadataUrl = METADATA_URL): Promise<IMetadata> {
+export async function defaultFetchMetadata(metadataUrl = METADATA_URL): Promise<IMetadata> {
     return (await fetch(metadataUrl).then((res) => res.json())) as IMetadata
 }
 

--- a/packages/metadata-tools/src/config-metadata.ts
+++ b/packages/metadata-tools/src/config-metadata.ts
@@ -216,8 +216,12 @@ export async function translatePathwayToConfig(
     return configs
 }
 
+async function fetchMetadata(metadataUrl = METADATA_URL): Promise<IMetadata> {
+    return (await fetch(metadataUrl).then((res) => res.json())) as IMetadata
+}
+
 export async function generateConnectionsConfig(pathways: TwoWayConfig[]) {
-    const metadata = (await fetch(METADATA_URL).then((res) => res.json())) as IMetadata
+    const metadata = await fetchMetadata()
     const connections: OmniEdgeHardhat<OAppEdgeConfig | undefined>[] = []
 
     for (const pathway of pathways) {

--- a/packages/metadata-tools/src/config-metadata.ts
+++ b/packages/metadata-tools/src/config-metadata.ts
@@ -2,8 +2,7 @@ import type { OmniEdgeHardhat } from '@layerzerolabs/devtools-evm-hardhat'
 import type { OAppEdgeConfig } from '@layerzerolabs/ua-devtools'
 import { IMetadata } from './types'
 import { TwoWayConfig } from './types'
-
-const METADATA_URL = process.env.LZ_METADATA_URL || 'https://metadata.layerzero-api.com/v1/metadata'
+import { METADATA_URL } from './constants'
 
 function getEndpointIdDeployment(eid: number, metadata: IMetadata) {
     const srcEidString = eid.toString()

--- a/packages/metadata-tools/src/config-metadata.ts
+++ b/packages/metadata-tools/src/config-metadata.ts
@@ -216,11 +216,16 @@ export async function translatePathwayToConfig(
     return configs
 }
 
-async function fetchMetadata(metadataUrl = METADATA_URL): Promise<IMetadata> {
+/// allow for a custom metadataUrl
+async function defaultFetchMetadata(metadataUrl = METADATA_URL): Promise<IMetadata> {
     return (await fetch(metadataUrl).then((res) => res.json())) as IMetadata
 }
 
-export async function generateConnectionsConfig(pathways: TwoWayConfig[]) {
+/// allow for a custom metadataFetcher
+export async function generateConnectionsConfig(
+    pathways: TwoWayConfig[],
+    fetchMetadata: () => Promise<IMetadata> = defaultFetchMetadata
+) {
     const metadata = await fetchMetadata()
     const connections: OmniEdgeHardhat<OAppEdgeConfig | undefined>[] = []
 

--- a/packages/metadata-tools/src/constants.ts
+++ b/packages/metadata-tools/src/constants.ts
@@ -1,0 +1,1 @@
+export const METADATA_URL = process.env.LZ_METADATA_URL || 'https://metadata.layerzero-api.com/v1/metadata'

--- a/packages/metadata-tools/src/index.ts
+++ b/packages/metadata-tools/src/index.ts
@@ -1,2 +1,3 @@
 export * from './config-metadata'
 export * from './types'
+export * from './constants'

--- a/packages/metadata-tools/src/types.ts
+++ b/packages/metadata-tools/src/types.ts
@@ -10,6 +10,16 @@ export type TwoWayConfig = [
     [OAppEnforcedOption[] | undefined, OAppEnforcedOption[] | undefined], // [enforcedOptionsSrcToDst, enforcedOptionsDstToSrc]
 ]
 
+export interface IMetadataDvns {
+    [address: string]: {
+        version: number
+        canonicalName: string
+        id: string
+        deprecated?: boolean
+        lzReadCompatible?: boolean
+    }
+}
+
 export interface IMetadata {
     [key: string]: {
         created: string
@@ -53,15 +63,7 @@ export interface IMetadata {
             mainnetChainName?: string
             name?: string
         }
-        dvns?: {
-            [address: string]: {
-                version: number
-                canonicalName: string
-                id: string
-                deprecated?: boolean
-                lzReadCompatible?: boolean
-            }
-        }
+        dvns?: IMetadataDvns
         rpcs?: { url: string; weight?: number }[]
         addressToOApp?: {
             [address: string]: {

--- a/packages/metadata-tools/test/__snapshots__/config-metadata.test.ts.snap
+++ b/packages/metadata-tools/test/__snapshots__/config-metadata.test.ts.snap
@@ -1,5 +1,94 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`config-metadata generateConnectionsConfig should allow for custom DVNs in the metadata 1`] = `
+[
+  {
+    "config": {
+      "enforcedOptions": undefined,
+      "receiveConfig": {
+        "ulnConfig": {
+          "confirmations": 1n,
+          "optionalDVNThreshold": 0,
+          "optionalDVNs": [],
+          "requiredDVNs": [
+            "0x9f0e79aeb198750f963b6f30b99d87c6ee5a0467",
+          ],
+        },
+      },
+      "receiveLibraryConfig": {
+        "gracePeriod": 0n,
+        "receiveLibrary": "0x819F0FAF2cb1Fba15b9cB24c9A2BDaDb0f895daf",
+      },
+      "sendConfig": {
+        "executorConfig": {
+          "executor": "0xa7BFA9D51032F82D649A501B6a1f922FC2f7d4e3",
+          "maxMessageSize": 10000,
+        },
+        "ulnConfig": {
+          "confirmations": 1n,
+          "optionalDVNThreshold": 0,
+          "optionalDVNs": [],
+          "requiredDVNs": [
+            "0x9f0e79aeb198750f963b6f30b99d87c6ee5a0467",
+          ],
+        },
+      },
+      "sendLibrary": "0x69BF5f48d2072DfeBc670A1D19dff91D0F4E8170",
+    },
+    "from": {
+      "contractName": "MyOFT",
+      "eid": 40106,
+    },
+    "to": {
+      "address": "HBTWw2VKNLuDBjg9e5dArxo5axJRX8csCEBcCo3CFdAy",
+      "eid": 40168,
+    },
+  },
+  {
+    "config": {
+      "enforcedOptions": undefined,
+      "receiveConfig": {
+        "ulnConfig": {
+          "confirmations": 1n,
+          "optionalDVNThreshold": 0,
+          "optionalDVNs": [],
+          "requiredDVNs": [
+            "29EKzmCscUg8mf4f5uskwMqvu2SXM8hKF1gWi1cCBoKT",
+          ],
+        },
+      },
+      "receiveLibraryConfig": {
+        "gracePeriod": 0n,
+        "receiveLibrary": "7a4WjyR8VZ7yZz5XJAKm39BUGn5iT9CKcv2pmG9tdXVH",
+      },
+      "sendConfig": {
+        "executorConfig": {
+          "executor": "AwrbHeCyniXaQhiJZkLhgWdUCteeWSGaSN1sTfLiY7xK",
+          "maxMessageSize": 10000,
+        },
+        "ulnConfig": {
+          "confirmations": 1n,
+          "optionalDVNThreshold": 0,
+          "optionalDVNs": [],
+          "requiredDVNs": [
+            "29EKzmCscUg8mf4f5uskwMqvu2SXM8hKF1gWi1cCBoKT",
+          ],
+        },
+      },
+      "sendLibrary": "7a4WjyR8VZ7yZz5XJAKm39BUGn5iT9CKcv2pmG9tdXVH",
+    },
+    "from": {
+      "address": "HBTWw2VKNLuDBjg9e5dArxo5axJRX8csCEBcCo3CFdAy",
+      "eid": 40168,
+    },
+    "to": {
+      "contractName": "MyOFT",
+      "eid": 40106,
+    },
+  },
+]
+`;
+
 exports[`config-metadata generateConnectionsConfig should generate the connections config for a given set of pathways 1`] = `
 [
   {

--- a/packages/metadata-tools/test/__snapshots__/config-metadata.test.ts.snap
+++ b/packages/metadata-tools/test/__snapshots__/config-metadata.test.ts.snap
@@ -1,5 +1,94 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`config-metadata generateConnectionsConfig should generate the connections config for a given set of pathways 1`] = `
+[
+  {
+    "config": {
+      "enforcedOptions": undefined,
+      "receiveConfig": {
+        "ulnConfig": {
+          "confirmations": 1n,
+          "optionalDVNThreshold": 0,
+          "optionalDVNs": [],
+          "requiredDVNs": [
+            "0x9f0e79aeb198750f963b6f30b99d87c6ee5a0467",
+          ],
+        },
+      },
+      "receiveLibraryConfig": {
+        "gracePeriod": 0n,
+        "receiveLibrary": "0x819F0FAF2cb1Fba15b9cB24c9A2BDaDb0f895daf",
+      },
+      "sendConfig": {
+        "executorConfig": {
+          "executor": "0xa7BFA9D51032F82D649A501B6a1f922FC2f7d4e3",
+          "maxMessageSize": 10000,
+        },
+        "ulnConfig": {
+          "confirmations": 1n,
+          "optionalDVNThreshold": 0,
+          "optionalDVNs": [],
+          "requiredDVNs": [
+            "0x9f0e79aeb198750f963b6f30b99d87c6ee5a0467",
+          ],
+        },
+      },
+      "sendLibrary": "0x69BF5f48d2072DfeBc670A1D19dff91D0F4E8170",
+    },
+    "from": {
+      "contractName": "MyOFT",
+      "eid": 40106,
+    },
+    "to": {
+      "address": "HBTWw2VKNLuDBjg9e5dArxo5axJRX8csCEBcCo3CFdAy",
+      "eid": 40168,
+    },
+  },
+  {
+    "config": {
+      "enforcedOptions": undefined,
+      "receiveConfig": {
+        "ulnConfig": {
+          "confirmations": 1n,
+          "optionalDVNThreshold": 0,
+          "optionalDVNs": [],
+          "requiredDVNs": [
+            "4VDjp6XQaxoZf5RGwiPU9NR1EXSZn2TP4ATMmiSzLfhb",
+          ],
+        },
+      },
+      "receiveLibraryConfig": {
+        "gracePeriod": 0n,
+        "receiveLibrary": "7a4WjyR8VZ7yZz5XJAKm39BUGn5iT9CKcv2pmG9tdXVH",
+      },
+      "sendConfig": {
+        "executorConfig": {
+          "executor": "AwrbHeCyniXaQhiJZkLhgWdUCteeWSGaSN1sTfLiY7xK",
+          "maxMessageSize": 10000,
+        },
+        "ulnConfig": {
+          "confirmations": 1n,
+          "optionalDVNThreshold": 0,
+          "optionalDVNs": [],
+          "requiredDVNs": [
+            "4VDjp6XQaxoZf5RGwiPU9NR1EXSZn2TP4ATMmiSzLfhb",
+          ],
+        },
+      },
+      "sendLibrary": "7a4WjyR8VZ7yZz5XJAKm39BUGn5iT9CKcv2pmG9tdXVH",
+    },
+    "from": {
+      "address": "HBTWw2VKNLuDBjg9e5dArxo5axJRX8csCEBcCo3CFdAy",
+      "eid": 40168,
+    },
+    "to": {
+      "contractName": "MyOFT",
+      "eid": 40106,
+    },
+  },
+]
+`;
+
 exports[`config-metadata translatePathwayToConfig should be able to translate a pathway to a config 1`] = `
 [
   {

--- a/packages/metadata-tools/test/config-metadata.test.ts
+++ b/packages/metadata-tools/test/config-metadata.test.ts
@@ -1,5 +1,5 @@
-import { DVNsToAddresses, translatePathwayToConfig } from '@/config-metadata'
-import { IMetadata } from '@/types'
+import { DVNsToAddresses, generateConnectionsConfig, translatePathwayToConfig } from '@/config-metadata'
+import { IMetadata, TwoWayConfig } from '@/types'
 
 import fujiMetadata from './data/fuji.json'
 import polygonMainnetMetadata from './data/polygon-mainnet.json'
@@ -13,6 +13,43 @@ describe('config-metadata', () => {
         polygon: polygonMainnetMetadata,
         'solana-testnet': solanaTestnetMetadata,
     }
+
+    describe('generateConnectionsConfig', () => {
+        const metadata: IMetadata = {
+            fuji: fujiMetadata,
+            solana: solanaMainnetMetadata,
+            polygon: polygonMainnetMetadata,
+            'solana-testnet': solanaTestnetMetadata,
+        }
+
+        beforeEach(() => {
+            // Mock `fetch` to return our local metadata
+            global.fetch = jest.fn().mockResolvedValue({
+                json: jest.fn().mockResolvedValue(metadata),
+            })
+        })
+
+        it('should generate the connections config for a given set of pathways', async () => {
+            const avalancheContract = {
+                eid: 40106,
+                contractName: 'MyOFT',
+            }
+
+            const solanaContract = {
+                eid: 40168,
+                address: 'HBTWw2VKNLuDBjg9e5dArxo5axJRX8csCEBcCo3CFdAy',
+            }
+
+            // This array is your TwoWayConfig[]
+            const pathways: TwoWayConfig[] = [
+                [avalancheContract, solanaContract, [['LayerZero Labs'], []], [1, 1], [undefined, undefined]],
+            ]
+
+            const config = await generateConnectionsConfig(pathways)
+
+            expect(config).toMatchSnapshot()
+        })
+    })
 
     describe('translatePathwayToConfig', () => {
         it('should be able to translate a pathway to a config', async () => {

--- a/packages/metadata-tools/test/config-metadata.test.ts
+++ b/packages/metadata-tools/test/config-metadata.test.ts
@@ -22,13 +22,6 @@ describe('config-metadata', () => {
             'solana-testnet': solanaTestnetMetadata,
         }
 
-        beforeEach(() => {
-            // Mock `fetch` to return our local metadata
-            global.fetch = jest.fn().mockResolvedValue({
-                json: jest.fn().mockResolvedValue(metadata),
-            })
-        })
-
         it('should generate the connections config for a given set of pathways', async () => {
             const avalancheContract = {
                 eid: 40106,
@@ -45,8 +38,9 @@ describe('config-metadata', () => {
                 [avalancheContract, solanaContract, [['LayerZero Labs'], []], [1, 1], [undefined, undefined]],
             ]
 
-            const config = await generateConnectionsConfig(pathways)
+            const mockFetchMetadata = async () => metadata
 
+            const config = await generateConnectionsConfig(pathways, mockFetchMetadata)
             expect(config).toMatchSnapshot()
         })
     })

--- a/packages/metadata-tools/test/config-metadata.test.ts
+++ b/packages/metadata-tools/test/config-metadata.test.ts
@@ -40,7 +40,7 @@ describe('config-metadata', () => {
 
             const mockFetchMetadata = async () => metadata
 
-            const config = await generateConnectionsConfig(pathways, mockFetchMetadata)
+            const config = await generateConnectionsConfig(pathways, { fetchMetadata: mockFetchMetadata })
             expect(config).toMatchSnapshot()
         })
         it('should allow for custom DVNs in the metadata', async () => {
@@ -94,8 +94,7 @@ describe('config-metadata', () => {
             ]
 
             // Generate config using our custom fetchMetadata
-            const config = await generateConnectionsConfig(pathways, customFetchMetadata)
-            console.log(config)
+            const config = await generateConnectionsConfig(pathways, { fetchMetadata: customFetchMetadata })
             expect(config).toMatchSnapshot()
         })
     })


### PR DESCRIPTION
This PR

- adds a unit test for `generateConnectionsConfig` (added before function was changed)
- adds a new param to `generateConnectionsConfig` (currently only accepts `fetchMetadata` that defaults to `defaultFetchMetadata`)
- creates a `defaultFetchMetadata` function
- extract out the interface `IMetadataDvns` from `IMetadata` for better reusability
- unit test for custom `fetchMetadata` implementation