### PR TITLE
🚀  refactor(oft-solana): move DebugLogger from tasks/solana to tasks/common

### DIFF
--- a/examples/oft-solana/tasks/common/utils.ts
+++ b/examples/oft-solana/tasks/common/utils.ts
@@ -124,3 +124,75 @@ export async function getSolanaUlnConfigPDAs(
 
     return await Promise.all([sendConfig, receiveConfig])
 }
+
+export class DebugLogger {
+    static keyValue(key: string, value: any, indentLevel = 0) {
+        const indent = ' '.repeat(indentLevel * 2)
+        console.log(`${indent}\x1b[33m${key}:\x1b[0m ${value}`)
+    }
+
+    static keyHeader(key: string, indentLevel = 0) {
+        const indent = ' '.repeat(indentLevel * 2)
+        console.log(`${indent}\x1b[33m${key}:\x1b[0m`)
+    }
+
+    static header(text: string) {
+        console.log(`\x1b[36m${text}\x1b[0m`)
+    }
+
+    static separator() {
+        console.log('\x1b[90m----------------------------------------\x1b[0m')
+    }
+
+    /**
+     * Logs an error (in red) and corresponding fix suggestion (in blue).
+     * Uses the ERRORS_FIXES_MAP to retrieve text based on the known error type.
+     *
+     * @param type Required KnownErrors enum member
+     * @param errorMsg Optional string message to append to the error.
+     */
+    static printErrorAndFixSuggestion(type: KnownErrors, errorMsg?: string) {
+        const fixInfo = ERRORS_FIXES_MAP[type]
+        if (!fixInfo) {
+            // Fallback if the error type is not recognized
+            console.log(`\x1b[31mError:\x1b[0m Unknown error type "${type}"`)
+            return
+        }
+
+        // If errorMsg is specified, append it in parentheses
+        const errorOutput = errorMsg ? `${type}: (${errorMsg})` : type
+
+        // Print the error type in red
+        console.log(`\x1b[31mError:\x1b[0m ${errorOutput}`)
+
+        // Print the tip in green
+        console.log(`\x1b[32mFix suggestion:\x1b[0m ${fixInfo.tip}`)
+
+        // Print the info in blue
+        if (fixInfo.info) {
+            console.log(`\x1b[34mElaboration:\x1b[0m ${fixInfo.info}`)
+        }
+
+        // log empty line to separate error messages
+        console.log()
+    }
+}
+
+export enum KnownErrors {
+    // variable name format: <DOMAIN>_<REASON>
+    // e.g. If the user forgets to deploy the OFT Program, the variable name should be:
+    // FIX_SUGGESTION_OFT_PROGRAM_NOT_DEPLOYED
+    ULN_INIT_CONFIG_SKIPPED = 'ULN_INIT_CONFIG_SKIPPED',
+}
+
+interface ErrorFixInfo {
+    tip: string
+    info?: string
+}
+
+export const ERRORS_FIXES_MAP: Record<KnownErrors, ErrorFixInfo> = {
+    [KnownErrors.ULN_INIT_CONFIG_SKIPPED]: {
+        tip: 'Did you run `npx hardhat lz:oft:solana:init-config --oapp-config <LZ_CONFIG_FILE_NAME> --solana-eid <SOLANA_EID>` ?',
+        info: 'You must run lz:oft:solana:init-config once before you run lz:oapp:wire. If you have added new pathways, you must also run lz:oft:solana:init-config again.',
+    },
+}

--- a/examples/oft-solana/tasks/common/wire.ts
+++ b/examples/oft-solana/tasks/common/wire.ts
@@ -15,10 +15,11 @@ import {
 } from '@layerzerolabs/ua-devtools-evm-hardhat'
 
 import { getSolanaDeployment, useWeb3Js } from '../solana'
-import { DebugLogger, KnownErrors } from '../solana/debug'
 
 import { publicKey as publicKeyType } from './types'
 import {
+    DebugLogger,
+    KnownErrors,
     createSdkFactory,
     createSolanaConnectionFactory,
     createSolanaSignerFactory,

--- a/examples/oft-solana/tasks/solana/debug.ts
+++ b/examples/oft-solana/tasks/solana/debug.ts
@@ -10,86 +10,9 @@ import { EndpointId, getNetworkForChainId } from '@layerzerolabs/lz-definitions'
 import { EndpointPDADeriver, EndpointProgram } from '@layerzerolabs/lz-solana-sdk-v2'
 import { OftPDA, oft } from '@layerzerolabs/oft-v2-solana-sdk'
 
-import { decodeLzReceiveOptions, uint8ArrayToHex } from '../common/utils'
+import { DebugLogger, decodeLzReceiveOptions, uint8ArrayToHex } from '../common/utils'
 
 import { deriveConnection, getSolanaDeployment } from './index'
-
-// TODO: move this to tasks/common since it's not Solana-specific
-export enum KnownErrors {
-    // variable name format: <DOMAIN>_<REASON>
-    // e.g. If the user forgets to deploy the OFT Program, the variable name should be:
-    // FIX_SUGGESTION_OFT_PROGRAM_NOT_DEPLOYED
-    ULN_INIT_CONFIG_SKIPPED = 'ULN_INIT_CONFIG_SKIPPED',
-}
-
-// TODO: move this to tasks/common since it's not Solana-specific
-interface ErrorFixInfo {
-    tip: string
-    info?: string
-}
-
-// TODO: move this to tasks/common since it's not Solana-specific
-const ERRORS_FIXES_MAP: Record<KnownErrors, ErrorFixInfo> = {
-    [KnownErrors.ULN_INIT_CONFIG_SKIPPED]: {
-        tip: 'Did you run `npx hardhat lz:oft:solana:init-config --oapp-config <LZ_CONFIG_FILE_NAME> --solana-eid <SOLANA_EID>` ?',
-        info: 'You must run lz:oft:solana:init-config once before you run lz:oapp:wire. If you have added new pathways, you must also run lz:oft:solana:init-config again.',
-    },
-}
-
-// TODO: move this to tasks/common since it's not Solana-specific
-// Logger class for better loggin
-export class DebugLogger {
-    static keyValue(key: string, value: any, indentLevel = 0) {
-        const indent = ' '.repeat(indentLevel * 2)
-        console.log(`${indent}\x1b[33m${key}:\x1b[0m ${value}`)
-    }
-
-    static keyHeader(key: string, indentLevel = 0) {
-        const indent = ' '.repeat(indentLevel * 2)
-        console.log(`${indent}\x1b[33m${key}:\x1b[0m`)
-    }
-
-    static header(text: string) {
-        console.log(`\x1b[36m${text}\x1b[0m`)
-    }
-
-    static separator() {
-        console.log('\x1b[90m----------------------------------------\x1b[0m')
-    }
-
-    /**
-     * Logs an error (in red) and corresponding fix suggestion (in blue).
-     * Uses the ERRORS_FIXES_MAP to retrieve text based on the known error type.
-     *
-     * @param type Required KnownErrors enum member
-     * @param errorMsg Optional string message to append to the error.
-     */
-    static printErrorAndFixSuggestion(type: KnownErrors, errorMsg?: string) {
-        const fixInfo = ERRORS_FIXES_MAP[type]
-        if (!fixInfo) {
-            // Fallback if the error type is not recognized
-            console.log(`\x1b[31mError:\x1b[0m Unknown error type "${type}"`)
-            return
-        }
-
-        // If errorMsg is specified, append it in parentheses
-        const errorOutput = errorMsg ? `${type}: (${errorMsg})` : type
-
-        // Print the error type in red
-        console.log(`\x1b[31mError:\x1b[0m ${errorOutput}`)
-
-        // Print the tip in green
-        console.log(`\x1b[32mFix suggestion:\x1b[0m ${fixInfo.tip}`)
-
-        // Print the info in blue
-        if (fixInfo.info) {
-            console.log(`\x1b[34mElaboration:\x1b[0m ${fixInfo.info}`)
-        }
-
-        // log empty line to separate error messages
-        console.log()
-    }
-}
 
 const DEBUG_ACTIONS = {
     OFT_STORE: 'oft-store',


### PR DESCRIPTION
# Motivation

DebugLogger is not specific to Solana.


# Testing

To test, run:
```
LAYERZERO_EXAMPLES_REPOSITORY_REF=#refactor-debug-logger-move LZ_ENABLE_SOLANA_OFT_EXAMPLE=1 npx create-lz-oapp@latest
```
Select OFT (Solana)

Then, without needing to deploy anything, you can run the following, to verify that the imports are working.

```
npx hardhat lz:oft:solana:debug --eid 40168 --oft-store 9Ccpw8khitczfmj7ThadPVsrwuvNzSPMeCCrApsXYqBU      
```

If you also want to test for when the logger should output something, then, 
- deploy OFT program
- deploy EVM OFT
- run wire script (deliberately skip init-config)