### PR TITLE
Add custom oft contract

### DIFF
--- a/packages/oft-evm-upgradeable/contracts/oft/OFTCustomUpgradeable.sol
+++ b/packages/oft-evm-upgradeable/contracts/oft/OFTCustomUpgradeable.sol
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.20;
+
+import {IOFT, OFTCoreUpgradeable} from "./OFTCoreUpgradeable.sol";
+
+/**
+ * @title OFT Contract
+ * @dev OFT is an ERC-20 token that extends the functionality of the OFTCore contract.
+ */
+abstract contract OFTCustomUpgradeable is OFTCoreUpgradeable {
+    /**
+     * @dev Constructor for the OFT contract.
+     * @param _lzEndpoint The LayerZero endpoint address.
+     */
+    constructor(uint8 decimals, address _lzEndpoint) OFTCoreUpgradeable(decimals, _lzEndpoint) {}
+
+    /**
+     * @dev Initializes the OFT with the provided name, symbol, and delegate.
+     * @param _delegate The delegate capable of making OApp configurations inside of the endpoint.
+     *
+     * @dev The delegate typically should be set as the owner of the contract.
+     * @dev Ownable is not initialized here on purpose. It should be initialized in the child contract to
+     * accommodate the different version of Ownable.
+     */
+    function __OFT_init(address _delegate) internal onlyInitializing {
+        __OFTCore_init(_delegate);
+    }
+
+    function __OFT_init_unchained() internal onlyInitializing {}
+
+    /**
+     * @dev Retrieves the address of the underlying ERC20 implementation.
+     * @return The address of the OFT token.
+     *
+     * @dev In the case of OFT, address(this) and erc20 are the same contract.
+     */
+    function token() public view returns (address) {
+        return address(this);
+    }
+
+    /**
+     * @notice Indicates whether the OFT contract requires approval of the 'token()' to send.
+     * @return requiresApproval Needs approval of the underlying token implementation.
+     *
+     * @dev In the case of OFT where the contract IS the token, approval is NOT required.
+     */
+    function approvalRequired() external pure virtual returns (bool) {
+        return false;
+    }
+
+    /**
+     * @dev Burns tokens from the sender's specified balance.
+     * @param _from The address to debit the tokens from.
+     * @param _amountLD The amount of tokens to send in local decimals.
+     * @param _minAmountLD The minimum amount to send in local decimals.
+     * @param _dstEid The destination chain ID.
+     * @return amountSentLD The amount sent in local decimals.
+     * @return amountReceivedLD The amount received in local decimals on the remote.
+     */
+    function _debit(address _from, uint256 _amountLD, uint256 _minAmountLD, uint32 _dstEid)
+        internal
+        virtual
+        override
+        returns (uint256 amountSentLD, uint256 amountReceivedLD)
+    {
+        (amountSentLD, amountReceivedLD) = _debitView(_amountLD, _minAmountLD, _dstEid);
+
+        // @dev In NON-default OFT, amountSentLD could be 100, with a 10% fee, the amountReceivedLD amount is 90,
+        // therefore amountSentLD CAN differ from amountReceivedLD.
+
+        // @dev Default OFT burns on src.
+        _oftBurn(_from, amountSentLD);
+    }
+
+    /**
+     * @dev Credits tokens to the specified address.
+     * @param _to The address to credit the tokens to.
+     * @param _amountLD The amount of tokens to credit in local decimals.
+     * @dev _srcEid The source chain ID.
+     * @return amountReceivedLD The amount of tokens ACTUALLY received in local decimals.
+     */
+    function _credit(address _to, uint256 _amountLD, uint32 /*_srcEid*/ )
+        internal
+        virtual
+        override
+        returns (uint256 amountReceivedLD)
+    {
+        if (_to == address(0x0)) _to = address(0xdead); // _mint(...) does not support address(0x0)
+        // @dev Default OFT mints on dst.
+        _oftMint(_to, _amountLD);
+        // @dev In the case of NON-default OFT, the _amountLD MIGHT not be == amountReceivedLD.
+        return _amountLD;
+    }
+
+    /**
+     * @dev Custom hook to call into token's burn function.
+     * @param _from The address to debit the tokens from.
+     * @param _amountLD The amount of tokens to send in local decimals.
+     */
+    function _oftBurn(address _from, uint256 _amountLD) internal virtual;
+
+    /**
+     * @dev Custom hook to call into token's mint function.
+     * @param _to The address to credit the tokens to.
+     * @param _amountLD The amount of tokens to credit in local decimals.
+     */
+    function _oftMint(address _to, uint256 _amountLD) internal virtual;
+}


### PR DESCRIPTION
This contract removes the hard dependency on OZ's ERC20Upgradable, and instead allows the token builder to "BYO" token. I added two new functions that the implementer has to fulfill: `_oftBurn()` and `_oftMint()`. In most cases, these can be simple passthroughs to the OZ token `_burn()` and `_mint()` functions (like they were before).

The nice thing about organizing the code this way, is that now the token implementer is free to use any type of ERC20 base they prefer (ex you could use [solady's](https://github.com/Vectorized/solady/blob/main/src/tokens/ERC20.sol) implementation if you want) as long as it's burnable/mintable.

This PR is just an example of a change I'd love to see. It's not a full fix; there are no tests.