### PR TITLE
Upgradable OFT contract with custom token & access control

### DIFF
--- a/packages/oapp-evm-upgradeable/contracts/OnlyLZAdmin.sol
+++ b/packages/oapp-evm-upgradeable/contracts/OnlyLZAdmin.sol
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.20;
+
+/**
+ * @title OnlyLZAdmin
+ * @dev Abstract contract that restricts access of functions to only the LayerZero admin.
+ * @dev The contract implementer is responsible for deciding how that role is defined and managed.
+ */
+abstract contract OnlyLZAdmin {
+    /**
+     * @dev Modifier to restrict access to only the LayerZero admin.
+     */
+    modifier onlyLZAdmin() virtual;
+}

--- a/packages/oapp-evm-upgradeable/contracts/oapp/OAppCoreUpgradeable.sol
+++ b/packages/oapp-evm-upgradeable/contracts/oapp/OAppCoreUpgradeable.sol
@@ -2,14 +2,15 @@
 
 pragma solidity ^0.8.20;
 
-import { OwnableUpgradeable } from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
-import { IOAppCore, ILayerZeroEndpointV2 } from "@layerzerolabs/oapp-evm/contracts/oapp/interfaces/IOAppCore.sol";
+import {OnlyLZAdmin} from "../OnlyLZAdmin.sol";
+import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+import {IOAppCore, ILayerZeroEndpointV2} from "@layerzerolabs/oapp-evm/contracts/oapp/interfaces/IOAppCore.sol";
 
 /**
  * @title OAppCore
  * @dev Abstract contract implementing the IOAppCore interface with basic OApp configurations.
  */
-abstract contract OAppCoreUpgradeable is IOAppCore, OwnableUpgradeable {
+abstract contract OAppCoreUpgradeable is IOAppCore, Initializable, OnlyLZAdmin {
     struct OAppCoreStorage {
         mapping(uint32 => bytes32) peers;
     }
@@ -72,7 +73,7 @@ abstract contract OAppCoreUpgradeable is IOAppCore, OwnableUpgradeable {
      * @dev Set this to bytes32(0) to remove the peer address.
      * @dev Peer is a bytes32 to accommodate non-evm chains.
      */
-    function setPeer(uint32 _eid, bytes32 _peer) public virtual onlyOwner {
+    function setPeer(uint32 _eid, bytes32 _peer) public virtual onlyLZAdmin {
         OAppCoreStorage storage $ = _getOAppCoreStorage();
         $.peers[_eid] = _peer;
         emit PeerSet(_eid, _peer);
@@ -98,7 +99,7 @@ abstract contract OAppCoreUpgradeable is IOAppCore, OwnableUpgradeable {
      * @dev Only the owner/admin of the OApp can call this function.
      * @dev Provides the ability for a delegate to set configs, on behalf of the OApp, directly on the Endpoint contract.
      */
-    function setDelegate(address _delegate) public onlyOwner {
+    function setDelegate(address _delegate) public onlyLZAdmin {
         endpoint.setDelegate(_delegate);
     }
 }

--- a/packages/oapp-evm-upgradeable/contracts/oapp/libs/OAppOptionsType3Upgradeable.sol
+++ b/packages/oapp-evm-upgradeable/contracts/oapp/libs/OAppOptionsType3Upgradeable.sol
@@ -2,14 +2,15 @@
 
 pragma solidity ^0.8.20;
 
-import { OwnableUpgradeable } from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
+import { OnlyLZAdmin } from "../../OnlyLZAdmin.sol";
+import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 import { IOAppOptionsType3, EnforcedOptionParam } from "@layerzerolabs/oapp-evm/contracts/oapp/interfaces/IOAppOptionsType3.sol";
 
 /**
  * @title OAppOptionsType3
  * @dev Abstract contract implementing the IOAppOptionsType3 interface with type 3 options.
  */
-abstract contract OAppOptionsType3Upgradeable is IOAppOptionsType3, OwnableUpgradeable {
+abstract contract OAppOptionsType3Upgradeable is IOAppOptionsType3, Initializable, OnlyLZAdmin {
     struct OAppOptionsType3Storage {
         // @dev The "msgType" should be defined in the child contract.
         mapping(uint32 => mapping(uint16 => bytes)) enforcedOptions;
@@ -50,7 +51,7 @@ abstract contract OAppOptionsType3Upgradeable is IOAppOptionsType3, OwnableUpgra
      * eg. Amount of lzReceive() gas necessary to deliver a lzCompose() message adds overhead you dont want to pay
      * if you are only making a standard LayerZero message ie. lzReceive() WITHOUT sendCompose().
      */
-    function setEnforcedOptions(EnforcedOptionParam[] calldata _enforcedOptions) public virtual onlyOwner {
+    function setEnforcedOptions(EnforcedOptionParam[] calldata _enforcedOptions) public virtual onlyLZAdmin {
         OAppOptionsType3Storage storage $ = _getOAppOptionsType3Storage();
         for (uint256 i = 0; i < _enforcedOptions.length; i++) {
             // @dev Enforced options are only available for optionType 3, as type 1 and 2 dont support combining.

--- a/packages/oapp-evm-upgradeable/contracts/precrime/OAppPreCrimeSimulatorUpgradeable.sol
+++ b/packages/oapp-evm-upgradeable/contracts/precrime/OAppPreCrimeSimulatorUpgradeable.sol
@@ -2,7 +2,8 @@
 
 pragma solidity ^0.8.20;
 
-import { OwnableUpgradeable } from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
+import { OnlyLZAdmin } from "../OnlyLZAdmin.sol";
+import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 import { IPreCrime } from "@layerzerolabs/oapp-evm/contracts/precrime/interfaces/IPreCrime.sol";
 import { IOAppPreCrimeSimulator, InboundPacket, Origin } from "@layerzerolabs/oapp-evm/contracts/precrime/interfaces/IOAppPreCrimeSimulator.sol";
 
@@ -10,7 +11,7 @@ import { IOAppPreCrimeSimulator, InboundPacket, Origin } from "@layerzerolabs/oa
  * @title OAppPreCrimeSimulator
  * @dev Abstract contract serving as the base for preCrime simulation functionality in an OApp.
  */
-abstract contract OAppPreCrimeSimulatorUpgradeable is IOAppPreCrimeSimulator, OwnableUpgradeable {
+abstract contract OAppPreCrimeSimulatorUpgradeable is IOAppPreCrimeSimulator, Initializable, OnlyLZAdmin {
     struct OAppPreCrimeSimulatorStorage {
         // The address of the preCrime implementation.
         address preCrime;
@@ -54,7 +55,7 @@ abstract contract OAppPreCrimeSimulatorUpgradeable is IOAppPreCrimeSimulator, Ow
      * @dev Sets the preCrime contract address.
      * @param _preCrime The address of the preCrime contract.
      */
-    function setPreCrime(address _preCrime) public virtual onlyOwner {
+    function setPreCrime(address _preCrime) public virtual onlyLZAdmin {
         OAppPreCrimeSimulatorStorage storage $ = _getOAppPreCrimeSimulatorStorage();
         $.preCrime = _preCrime;
         emit PreCrimeSet(_preCrime);

--- a/packages/oft-evm-upgradeable/contracts/oft/OFTCoreUpgradeable.sol
+++ b/packages/oft-evm-upgradeable/contracts/oft/OFTCoreUpgradeable.sol
@@ -129,7 +129,7 @@ abstract contract OFTCoreUpgradeable is
      * @dev This is an optional contract that can be used to inspect both 'message' and 'options'.
      * @dev Set it to address(0) to disable it, or set it to a contract address to enable it.
      */
-    function setMsgInspector(address _msgInspector) public virtual onlyOwner {
+    function setMsgInspector(address _msgInspector) public virtual onlyLZAdmin {
         OFTCoreStorage storage $ = _getOFTCoreStorage();
         $.msgInspector = _msgInspector;
         emit MsgInspectorSet(_msgInspector);

--- a/packages/oft-evm-upgradeable/contracts/oft/OFTCustomUpgradeable.sol
+++ b/packages/oft-evm-upgradeable/contracts/oft/OFTCustomUpgradeable.sol
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.20;
+
+import {IOFT, OFTCoreUpgradeable} from "./OFTCoreUpgradeable.sol";
+
+/**
+ * @title OFT Contract
+ * @dev OFT is an ERC-20 token that extends the functionality of the OFTCore contract.
+ */
+abstract contract OFTCustomUpgradeable is OFTCoreUpgradeable {
+    /**
+     * @dev Constructor for the OFT contract.
+     * @param _lzEndpoint The LayerZero endpoint address.
+     */
+    constructor(uint8 decimals, address _lzEndpoint) OFTCoreUpgradeable(decimals, _lzEndpoint) {}
+
+    /**
+     * @dev Initializes the OFT with the provided name, symbol, and delegate.
+     * @param _delegate The delegate capable of making OApp configurations inside of the endpoint.
+     *
+     * @dev The delegate typically should be set as the owner of the contract.
+     * @dev Ownable is not initialized here on purpose. It should be initialized in the child contract to
+     * accommodate the different version of Ownable.
+     */
+    function __OFT_init(address _delegate) internal onlyInitializing {
+        __OFTCore_init(_delegate);
+    }
+
+    function __OFT_init_unchained() internal onlyInitializing {}
+
+    /**
+     * @dev Retrieves the address of the underlying ERC20 implementation.
+     * @return The address of the OFT token.
+     *
+     * @dev In the case of OFT, address(this) and erc20 are the same contract.
+     */
+    function token() public view returns (address) {
+        return address(this);
+    }
+
+    /**
+     * @notice Indicates whether the OFT contract requires approval of the 'token()' to send.
+     * @return requiresApproval Needs approval of the underlying token implementation.
+     *
+     * @dev In the case of OFT where the contract IS the token, approval is NOT required.
+     */
+    function approvalRequired() external pure virtual returns (bool) {
+        return false;
+    }
+
+    /**
+     * @dev Burns tokens from the sender's specified balance.
+     * @param _from The address to debit the tokens from.
+     * @param _amountLD The amount of tokens to send in local decimals.
+     * @param _minAmountLD The minimum amount to send in local decimals.
+     * @param _dstEid The destination chain ID.
+     * @return amountSentLD The amount sent in local decimals.
+     * @return amountReceivedLD The amount received in local decimals on the remote.
+     */
+    function _debit(address _from, uint256 _amountLD, uint256 _minAmountLD, uint32 _dstEid)
+        internal
+        virtual
+        override
+        returns (uint256 amountSentLD, uint256 amountReceivedLD)
+    {
+        (amountSentLD, amountReceivedLD) = _debitView(_amountLD, _minAmountLD, _dstEid);
+
+        // @dev In NON-default OFT, amountSentLD could be 100, with a 10% fee, the amountReceivedLD amount is 90,
+        // therefore amountSentLD CAN differ from amountReceivedLD.
+
+        // @dev Default OFT burns on src.
+        _oftBurn(_from, amountSentLD);
+    }
+
+    /**
+     * @dev Credits tokens to the specified address.
+     * @param _to The address to credit the tokens to.
+     * @param _amountLD The amount of tokens to credit in local decimals.
+     * @dev _srcEid The source chain ID.
+     * @return amountReceivedLD The amount of tokens ACTUALLY received in local decimals.
+     */
+    function _credit(address _to, uint256 _amountLD, uint32 /*_srcEid*/ )
+        internal
+        virtual
+        override
+        returns (uint256 amountReceivedLD)
+    {
+        if (_to == address(0x0)) _to = address(0xdead); // _mint(...) does not support address(0x0)
+        // @dev Default OFT mints on dst.
+        _oftMint(_to, _amountLD);
+        // @dev In the case of NON-default OFT, the _amountLD MIGHT not be == amountReceivedLD.
+        return _amountLD;
+    }
+
+    /**
+     * @dev Custom hook to call into token's burn function.
+     * @param _from The address to debit the tokens from.
+     * @param _amountLD The amount of tokens to send in local decimals.
+     */
+    function _oftBurn(address _from, uint256 _amountLD) internal virtual;
+
+    /**
+     * @dev Custom hook to call into token's mint function.
+     * @param _to The address to credit the tokens to.
+     * @param _amountLD The amount of tokens to credit in local decimals.
+     */
+    function _oftMint(address _to, uint256 _amountLD) internal virtual;
+}


### PR DESCRIPTION
This PR demonstrates some potential changes to the OFT token implementation that allow the token builder to "BYO" token and access control. This should support any burnable/mintable ERC20 implementation and any kind of access control, rather than forcing the token builder to use OZ's ERC20 and OZ's Ownable.

This PR does not have tests, nor is it complete (I only tinkered with the upgradable contracts).