### PR TITLE
🚀 feat(oft-solana): enhance debug task to print send and receive configs

### DIFF
--- a/examples/oft-solana/tasks/solana/debug.ts
+++ b/examples/oft-solana/tasks/solana/debug.ts
@@ -84,6 +84,11 @@ task('lz:oft:solana:debug', 'Manages OFTStore and OAppRegistry information')
             oAppRegistry
         )
 
+        if (!oAppRegistryInfo) {
+            console.warn('OAppRegistry info not found.')
+            return
+        }
+
         const oftDeriver = new OftPDA(oftStoreInfo.header.owner)
 
         const printOftStore = async () => {

--- a/examples/oft-solana/tasks/solana/debug.ts
+++ b/examples/oft-solana/tasks/solana/debug.ts
@@ -1,16 +1,18 @@
-import { fetchMint } from '@metaplex-foundation/mpl-toolbox' // Import fetchToken function
+import { fetchMint } from '@metaplex-foundation/mpl-toolbox'
 import { publicKey, unwrapOption } from '@metaplex-foundation/umi'
 import { toWeb3JsPublicKey } from '@metaplex-foundation/umi-web3js-adapters'
-import { PublicKey } from '@solana/web3.js'
+import { Keypair, PublicKey } from '@solana/web3.js'
 import { task } from 'hardhat/config'
 
-import { denormalizePeer } from '@layerzerolabs/devtools'
+import { OmniPoint, denormalizePeer } from '@layerzerolabs/devtools'
 import { types } from '@layerzerolabs/devtools-evm-hardhat'
 import { EndpointId, getNetworkForChainId } from '@layerzerolabs/lz-definitions'
 import { EndpointPDADeriver, EndpointProgram } from '@layerzerolabs/lz-solana-sdk-v2'
 import { OftPDA, oft } from '@layerzerolabs/oft-v2-solana-sdk'
+import { EndpointV2 } from '@layerzerolabs/protocol-devtools-solana'
 
-import { DebugLogger, decodeLzReceiveOptions, uint8ArrayToHex } from '../common/utils'
+import { getSolanaReceiveConfig, getSolanaSendConfig } from '../common/taskHelper'
+import { DebugLogger, createSolanaConnectionFactory, decodeLzReceiveOptions, uint8ArrayToHex } from '../common/utils'
 
 import { deriveConnection, getSolanaDeployment } from './index'
 
@@ -61,14 +63,22 @@ task('lz:oft:solana:debug', 'Manages OFTStore and OAppRegistry information')
         types.string
     )
     .setAction(async (taskArgs: DebugTaskArgs) => {
-        const { eid, oftStore, endpoint, dstEids, action } = taskArgs
+        const { eid, oftStore: oftStoreArg, endpoint, dstEids, action } = taskArgs
         const { umi, connection } = await deriveConnection(eid, true)
-        const store = getOftStore(eid, oftStore)
-        const oftStoreInfo = await oft.accounts.fetchOFTStore(umi, store)
+        const oftStore = getOftStore(eid, oftStoreArg)
+
+        let oftStoreInfo
+        try {
+            oftStoreInfo = await oft.accounts.fetchOFTStore(umi, oftStore)
+        } catch (e) {
+            console.error(`Failed to fetch OFTStore at ${oftStore.toString()}:`, e)
+            return
+        }
+
         const mintAccount = await fetchMint(umi, publicKey(oftStoreInfo.tokenMint))
 
         const epDeriver = new EndpointPDADeriver(new PublicKey(endpoint))
-        const [oAppRegistry] = epDeriver.oappRegistry(toWeb3JsPublicKey(store))
+        const [oAppRegistry] = epDeriver.oappRegistry(toWeb3JsPublicKey(oftStore))
         const oAppRegistryInfo = await EndpointProgram.accounts.OAppRegistry.fromAccountAddress(
             connection,
             oAppRegistry
@@ -114,23 +124,44 @@ task('lz:oft:solana:debug', 'Manages OFTStore and OAppRegistry information')
 
             DebugLogger.header('Checks')
             DebugLogger.keyValue('Admin (Owner) same as Delegate', oftStoreInfo.admin === delegate)
-            DebugLogger.keyValue('Token Mint Authority is OFT Store', unwrapOption(mintAccount.mintAuthority) === store)
+            DebugLogger.keyValue(
+                'Token Mint Authority is OFT Store',
+                unwrapOption(mintAccount.mintAuthority) === oftStore
+            )
             DebugLogger.separator()
         }
 
         const printPeerConfigs = async () => {
             const peerConfigs = dstEids.map((dstEid) => {
-                const peerConfig = oftDeriver.peer(store, dstEid)
+                const peerConfig = oftDeriver.peer(oftStore, dstEid)
                 return publicKey(peerConfig)
             })
+            const mockKeypair = new Keypair()
+            const point: OmniPoint = {
+                eid,
+                address: oftStore.toString(),
+            }
+            const endpointV2Sdk = new EndpointV2(
+                await createSolanaConnectionFactory()(eid),
+                point,
+                mockKeypair.publicKey // doesn't matter as we are not sending transactions
+            )
 
             DebugLogger.header('Peer Configurations')
+
             const peerConfigInfos = await oft.accounts.safeFetchAllPeerConfig(umi, peerConfigs)
-            dstEids.forEach((dstEid, index) => {
+            for (let index = 0; index < dstEids.length; index++) {
+                const dstEid = dstEids[index]
                 const info = peerConfigInfos[index]
                 const network = getNetworkForChainId(dstEid)
+                const oAppReceiveConfig = await getSolanaReceiveConfig(endpointV2Sdk, dstEid, oftStore)
+                const oAppSendConfig = await getSolanaSendConfig(endpointV2Sdk, dstEid, oftStore)
+
+                // Show the chain info
                 DebugLogger.header(`${dstEid} (${network.chainName})`)
+
                 if (info) {
+                    // Existing PeerConfig info
                     DebugLogger.keyValue('PeerConfig Account', peerConfigs[index].toString())
                     DebugLogger.keyValue('Peer Address', denormalizePeer(info.peerAddress, dstEid))
                     DebugLogger.keyHeader('Enforced Options')
@@ -144,13 +175,17 @@ task('lz:oft:solana:debug', 'Manages OFTStore and OAppRegistry information')
                         decodeLzReceiveOptions(uint8ArrayToHex(info.enforcedOptions.sendAndCall, true)),
                         2
                     )
+
+                    printOAppReceiveConfigs(oAppReceiveConfig, network.chainName)
+                    printOAppSendConfigs(oAppSendConfig, network.chainName)
                 } else {
+                    // No PeerConfig account
                     console.log(`No PeerConfig account found for ${dstEid} (${network.chainName}).`)
                 }
-                DebugLogger.separator()
-            })
-        }
 
+                DebugLogger.separator()
+            }
+        }
         if (action) {
             switch (action) {
                 case DEBUG_ACTIONS.OFT_STORE:
@@ -182,3 +217,60 @@ task('lz:oft:solana:debug', 'Manages OFTStore and OAppRegistry information')
             await printChecks()
         }
     })
+
+function printOAppReceiveConfigs(
+    oAppReceiveConfig: Awaited<ReturnType<typeof getSolanaReceiveConfig>>,
+    peerChainName: string
+) {
+    const oAppReceiveConfigIndexesToKeys: Record<number, string> = {
+        0: 'receiveLibrary',
+        1: 'receiveUlnConfig',
+        2: 'receiveLibraryTimeoutConfig',
+    }
+
+    if (!oAppReceiveConfig) {
+        console.log('No receive configs found.')
+        return
+    }
+
+    DebugLogger.keyValue(`Receive Configs (${peerChainName} to solana)`, '')
+    for (let i = 0; i < oAppReceiveConfig.length; i++) {
+        const item = oAppReceiveConfig[i]
+        if (typeof item === 'object' && item !== null) {
+            // Print each property in the object
+            DebugLogger.keyValue(`${oAppReceiveConfigIndexesToKeys[i]}`, '', 2)
+            for (const [propKey, propVal] of Object.entries(item)) {
+                DebugLogger.keyValue(`${propKey}`, String(propVal), 3)
+            }
+        } else {
+            // Print a primitive (string, number, etc.)
+            DebugLogger.keyValue(`${oAppReceiveConfigIndexesToKeys[i]}`, String(item), 2)
+        }
+    }
+}
+
+function printOAppSendConfigs(oAppSendConfig: Awaited<ReturnType<typeof getSolanaSendConfig>>, peerChainName: string) {
+    const sendOappConfigIndexesToKeys: Record<number, string> = {
+        0: 'sendLibrary',
+        1: 'sendUlnConfig',
+        2: 'sendExecutorConfig',
+    }
+
+    if (!oAppSendConfig) {
+        console.log('No send configs found.')
+        return
+    }
+
+    DebugLogger.keyValue(`Send Configs (solana to ${peerChainName})`, '')
+    for (let i = 0; i < oAppSendConfig.length; i++) {
+        const item = oAppSendConfig[i]
+        if (typeof item === 'object' && item !== null) {
+            DebugLogger.keyValue(`${sendOappConfigIndexesToKeys[i]}`, '', 2)
+            for (const [propKey, propVal] of Object.entries(item)) {
+                DebugLogger.keyValue(`${propKey}`, String(propVal), 3)
+            }
+        } else {
+            DebugLogger.keyValue(`${sendOappConfigIndexesToKeys[i]}`, String(item), 2)
+        }
+    }
+}


### PR DESCRIPTION
Example output:

```
npx hardhat lz:oft:solana:debug --eid 40168 --oft-store HRxaPR51cxfjaCvKQAvkkbYbahu5fbeWMEEJLHFSmNpN --dst-eids 40161,40231 --action peers

Peer Configurations
send library not initialized, return empty array
40161 (sepolia)
PeerConfig Account: 1eXAQVWf7xW1oPQNxmCED43qSLg1YGcdRKnktqbSUWi
Peer Address: 0xc0941a758e86669fad70fe7ae75ec40995b443da
Enforced Options:
    Send: gas: 80_000 , value: 0 wei
    SendAndCall: gas: 80_000 , value: 0 wei
Receive Configs (sepolia to solana): 
    receiveLibrary: 7a4WjyR8VZ7yZz5XJAKm39BUGn5iT9CKcv2pmG9tdXVH
    receiveUlnConfig: 
      confirmations: 15
      optionalDVNThreshold: 0
      requiredDVNs: 4VDjp6XQaxoZf5RGwiPU9NR1EXSZn2TP4ATMmiSzLfhb
      optionalDVNs: 
    receiveLibraryTimeoutConfig: 
      lib: 7a4WjyR8VZ7yZz5XJAKm39BUGn5iT9CKcv2pmG9tdXVH
      expiry: 0
Send Configs (solana to sepolia): 
    sendLibrary: 7a4WjyR8VZ7yZz5XJAKm39BUGn5iT9CKcv2pmG9tdXVH
    sendUlnConfig: 
      confirmations: 32
      optionalDVNThreshold: 0
      requiredDVNs: 4VDjp6XQaxoZf5RGwiPU9NR1EXSZn2TP4ATMmiSzLfhb
      optionalDVNs: 
    sendExecutorConfig: 
      maxMessageSize: 10000
      executor: AwrbHeCyniXaQhiJZkLhgWdUCteeWSGaSN1sTfLiY7xK
```