### PR TITLE
🪲 Fix to allow move OFTs to wire a Solana peer

### DIFF
--- a/.changeset/unlucky-jeans-eat.md
+++ b/.changeset/unlucky-jeans-eat.md
@@ -1,0 +1,5 @@
+---
+"@layerzerolabs/devtools-move": patch
+---
+
+fix to allow move OFTs to be wired to a Solana peer


### PR DESCRIPTION
Prior to this fix, it was impossible to wire a Solana peer.  This change makes determining the contractAddress more flexible, by reading it from hardhat-deploy deployments for EVM peers and taking it directly from the configuration for Solana peers.  Supporting other blockchains is future work and considered out of scope for this PR.