### PR TITLE
🧹hyperliquid sdk: decompose register-token into request and finalize

### DIFF
--- a/examples/oft-hyperliquid/deploy/MyHyperliquidComposer.ts
+++ b/examples/oft-hyperliquid/deploy/MyHyperliquidComposer.ts
@@ -4,7 +4,7 @@ import { Wallet } from 'ethers'
 import { type DeployFunction } from 'hardhat-deploy/types'
 import inquirer from 'inquirer'
 
-import { getCoreSpotDeployment, useBigBlock, useSmallBlock } from '@layerzerolabs/hyperliquid-composer'
+import { CHAIN_IDS, getCoreSpotDeployment, useBigBlock, useSmallBlock } from '@layerzerolabs/hyperliquid-composer'
 
 const contractName_oft = 'MyHyperLiquidOFT'
 const contractName_composer = 'MyHyperLiquidComposer'
@@ -31,13 +31,14 @@ const deploy: DeployFunction = async (hre) => {
     const loglevel = hre.hardhatArguments.verbose ? 'debug' : 'error'
 
     const wallet = new Wallet(privateKey)
-    const isHyperliquid = hre.network.name === 'hyperliquid-mainnet' || hre.network.name === 'hyperliquid-testnet'
-    const isTestnet = hre.network.name === 'hyperliquid-testnet'
+    const chainId = (await hre.ethers.provider.getNetwork()).chainId
+    const isHyperliquid = chainId === CHAIN_IDS.MAINNET || chainId === CHAIN_IDS.TESTNET
+    const isTestnet = chainId === CHAIN_IDS.TESTNET
 
     console.log(`Network: ${hre.network.name}`)
     console.log(`Deployer: ${deployer}`)
 
-    assert(isHyperliquid, 'This deploys to hyperliquid networks')
+    assert(isHyperliquid, 'The hyperliquid composer is only supported on hyperliquid networks')
 
     // Validates and returns the native spot
     const hip1Token = getCoreSpotDeployment(coreSpotIndex, isTestnet)

--- a/examples/oft-hyperliquid/test/foundry/ComposerCodec/ComposeMessage.t.sol
+++ b/examples/oft-hyperliquid/test/foundry/ComposerCodec/ComposeMessage.t.sol
@@ -1,0 +1,135 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.20;
+
+import { OFTComposeMsgCodec } from "@layerzerolabs/oft-evm/contracts/libs/OFTComposeMsgCodec.sol";
+
+import { HyperLiquidComposerCodec } from "@layerzerolabs/hyperliquid-composer/contracts/library/HyperLiquidComposerCodec.sol";
+
+import { IHyperLiquidComposerErrors, ErrorMessagePayload } from "@layerzerolabs/hyperliquid-composer/contracts/interfaces/IHyperLiquidComposerErrors.sol";
+import { IHyperAsset, IHyperLiquidComposerCore } from "@layerzerolabs/hyperliquid-composer/contracts/interfaces/IHyperLiquidComposerCore.sol";
+
+import { HyperLiquidComposer } from "@layerzerolabs/hyperliquid-composer/contracts/HyperLiquidComposer.sol";
+import { MyHyperLiquidOFT } from "../../../contracts/MyHyperLiquidOFT.sol";
+
+import { Test, console } from "forge-std/Test.sol";
+
+contract ComposeMessageTest is Test {
+    using HyperLiquidComposerCodec for bytes;
+
+    uint256 public constant DEFAULT_AMOUNT = 1e18;
+
+    IHyperAsset public ALICE;
+    IHyperAsset public HYPE;
+    address public constant HL_LZ_ENDPOINT_V2 = 0xf9e1815F151024bDE4B7C10BAC10e8Ba9F6b53E1;
+
+    MyHyperLiquidOFT public oft;
+    HyperLiquidComposer public hyperLiquidComposer;
+
+    address public sender;
+
+    function setUp() public {
+        vm.createSelectFork("https://rpc.hyperliquid-testnet.xyz/evm");
+        sender = makeAddr("sender");
+
+        ALICE = IHyperAsset({
+            assetBridgeAddress: HyperLiquidComposerCodec.into_assetBridgeAddress(1231),
+            coreIndexId: 1231,
+            decimalDiff: 18 - 6
+        });
+
+        HYPE = IHyperAsset({
+            assetBridgeAddress: 0x2222222222222222222222222222222222222222,
+            coreIndexId: 1105,
+            decimalDiff: 18 - 10
+        });
+
+        oft = new MyHyperLiquidOFT("test", "test", HL_LZ_ENDPOINT_V2, msg.sender);
+
+        hyperLiquidComposer = new HyperLiquidComposer(
+            HL_LZ_ENDPOINT_V2,
+            address(oft),
+            ALICE.coreIndexId,
+            ALICE.decimalDiff
+        );
+    }
+
+    function test_validateAndDecodeMessage_EncodingVariants(address _receiver, bool _useEncodePacked) public view {
+        vm.assume(_receiver != address(0));
+
+        bytes memory encodedReceiver = _useEncodePacked ? abi.encodePacked(_receiver) : abi.encode(_receiver);
+
+        bytes memory message = _createMessage(encodedReceiver, DEFAULT_AMOUNT, "");
+
+        (address decodedReceiver, uint256 decodedAmount) = this.validateAndDecodeMessage(message);
+        assertEq(decodedReceiver, _receiver);
+        assertEq(decodedAmount, DEFAULT_AMOUNT);
+    }
+
+    function test_validateAndDecodeMessage_InvalidLength(
+        address _receiver,
+        bytes memory _noise,
+        bool _useEncodePacked
+    ) public {
+        vm.assume(_receiver != address(0));
+        vm.assume(_noise.length > 0);
+
+        // When the noise length is 12, abi.encodePacked (20 bytes) + 12 bytes = 32 bytes
+        // 32 bytes is the length of the message when we use abi.encode
+        // This causes the abi.decode to fail as the 32 byte "address" is not valid
+        bool isNoiseLengthNot12 = _noise.length != 12;
+
+        bytes memory encodedReceiver = _useEncodePacked ? abi.encodePacked(_receiver) : abi.encode(_receiver);
+
+        bytes memory message = _createMessage(encodedReceiver, DEFAULT_AMOUNT, _noise);
+
+        if (isNoiseLengthNot12 && _useEncodePacked) {
+            bytes memory expectedRevertMessage = this.composeMsg(message);
+            address expectedRevertTo = sender;
+            uint256 expectedRevertAmount = DEFAULT_AMOUNT;
+            bytes memory expectedRevertReason = abi.encodeWithSelector(
+                IHyperLiquidComposerErrors.HyperLiquidComposer_Codec_InvalidMessage_UnexpectedLength.selector,
+                expectedRevertMessage,
+                expectedRevertMessage.length
+            );
+            vm.expectRevert(createErrorMessage(expectedRevertTo, expectedRevertAmount, expectedRevertReason));
+        } else {
+            vm.expectRevert();
+        }
+        this.validateAndDecodeMessage(message);
+    }
+
+    function _createMessage(
+        bytes memory _receiver,
+        uint256 _amount,
+        bytes memory _noise
+    ) internal view returns (bytes memory) {
+        bytes memory payload = bytes.concat(addressToBytes32(sender), _receiver, _noise);
+        return OFTComposeMsgCodec.encode(0, 0, _amount, payload);
+    }
+
+    function validateAndDecodeMessage(
+        bytes calldata _message
+    ) public view returns (address _receiver, uint256 _amountLD) {
+        bytes memory maybeReceiver = OFTComposeMsgCodec.composeMsg(_message);
+        bytes32 senderBytes32 = OFTComposeMsgCodec.composeFrom(_message);
+
+        _amountLD = OFTComposeMsgCodec.amountLD(_message);
+        _receiver = hyperLiquidComposer.validate_addresses_or_refund(maybeReceiver, senderBytes32, _amountLD);
+    }
+
+    function composeMsg(bytes calldata _message) public pure returns (bytes memory) {
+        return OFTComposeMsgCodec.composeMsg(_message);
+    }
+
+    function addressToBytes32(address _addr) internal pure returns (bytes32) {
+        return bytes32(uint256(uint160(_addr)));
+    }
+
+    function createErrorMessage(address _to, uint256 _amount, bytes memory _reason) public pure returns (bytes memory) {
+        return
+            abi.encodeWithSelector(
+                IHyperLiquidComposerErrors.ErrorMsg.selector,
+                _reason.createErrorMessage(_to, _amount)
+            );
+    }
+}

--- a/examples/oft-hyperliquid/test/foundry/ComposerCodec/TypeConversion.t.sol
+++ b/examples/oft-hyperliquid/test/foundry/ComposerCodec/TypeConversion.t.sol
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.20;
+
+import { HyperLiquidComposerCodec } from "@layerzerolabs/hyperliquid-composer/contracts/library/HyperLiquidComposerCodec.sol";
+import { IHyperAsset, IHyperAssetAmount } from "@layerzerolabs/hyperliquid-composer/contracts/interfaces/IHyperLiquidComposerCore.sol";
+
+import { Test, console } from "forge-std/Test.sol";
+
+contract TypeConversionTest is Test {
+    int8 MIN_DECIMAL_DIFF = -2;
+    int8 MAX_DECIMAL_DIFF = 8;
+
+    function setUp() public {}
+
+    function test_into_assetBridgeAddress() public pure {
+        uint256 coreIndexId = 1;
+        address assetBridgeAddress = HyperLiquidComposerCodec.into_assetBridgeAddress(coreIndexId);
+        assertEq(assetBridgeAddress, 0x2000000000000000000000000000000000000001);
+    }
+
+    function test_into_tokenId() public pure {
+        address assetBridgeAddress = 0x2000000000000000000000000000000000000001;
+        uint256 tokenId = HyperLiquidComposerCodec.into_tokenId(assetBridgeAddress);
+        assertEq(tokenId, 1);
+    }
+
+    function test_tokenId_assetBridgeAddress_equivalence(uint64 _coreIndexId) public pure {
+        address assetBridgeAddress = HyperLiquidComposerCodec.into_assetBridgeAddress(_coreIndexId);
+        uint256 tokenId = HyperLiquidComposerCodec.into_tokenId(assetBridgeAddress);
+        assertEq(tokenId, _coreIndexId);
+    }
+
+    function test_into_hyperAssetAmount_decimal_diff_leq_zero(
+        uint256 amount,
+        uint64 maxAmountTransferable,
+        int8 evmExtraWeiDecimals
+    ) public view {
+        // Skip condition based on the decimal count
+        evmExtraWeiDecimals = int8(bound(evmExtraWeiDecimals, MIN_DECIMAL_DIFF, 0));
+        uint256 scale = 10 ** uint8(-1 * evmExtraWeiDecimals);
+        console.log(scale);
+        vm.assume(maxAmountTransferable >= scale);
+
+        IHyperAsset memory oftAsset = IHyperAsset({
+            assetBridgeAddress: HyperLiquidComposerCodec.into_assetBridgeAddress(1),
+            coreIndexId: 1,
+            decimalDiff: evmExtraWeiDecimals
+        });
+
+        IHyperAssetAmount memory amounts = HyperLiquidComposerCodec.into_hyperAssetAmount(
+            amount,
+            maxAmountTransferable,
+            oftAsset
+        );
+
+        console.log(amounts.dust);
+        console.log(amounts.evm);
+        console.log(amounts.core);
+
+        assertEq(amounts.dust + amounts.evm, amount, "dust + evm is not equal to the input amount");
+        assertEq(amounts.evm, amounts.core / scale, "evm and core amounts should differ by a factor of scale");
+    }
+    function test_into_hyperAssetAmount_decimal_diff_gt_zero(
+        uint64 amount,
+        uint64 maxAmountTransferable,
+        int8 evmExtraWeiDecimals
+    ) public view {
+        // Skip condition based on the decimal count
+        evmExtraWeiDecimals = int8(bound(evmExtraWeiDecimals, 1, MAX_DECIMAL_DIFF));
+        uint256 scale = 10 ** uint8(evmExtraWeiDecimals);
+
+        // Skip condition for when we are:
+        // 1. under 1 core token
+        // 2. over 2^64-1 core tokens
+        // [1, 2 ** 64 * 10 ** (weiDifference))
+        amount = uint64(bound(amount, scale, type(uint64).max * scale - 1));
+
+        IHyperAsset memory oftAsset = IHyperAsset({
+            assetBridgeAddress: HyperLiquidComposerCodec.into_assetBridgeAddress(1),
+            coreIndexId: 1,
+            decimalDiff: evmExtraWeiDecimals
+        });
+
+        IHyperAssetAmount memory amounts = HyperLiquidComposerCodec.into_hyperAssetAmount(
+            amount,
+            maxAmountTransferable,
+            oftAsset
+        );
+
+        uint256 expectedDust = amount % scale;
+        uint256 expectedEvm = amount - expectedDust;
+        uint256 expectedCore = amount / scale;
+
+        assertEq(amounts.evm, amounts.core * scale, "evm and core amounts should differ by a factor of scale");
+        assertEq(amounts.dust + amounts.evm, amount, "dust + evm is not equal to the input amount");
+
+        if (amount > maxAmountTransferable * scale) {
+            uint256 overflowAmount = amount - (maxAmountTransferable * scale) - expectedDust;
+            expectedDust += overflowAmount;
+            expectedEvm -= overflowAmount;
+            expectedCore -= overflowAmount / scale;
+        }
+
+        assertEq(amounts.dust, expectedDust, "dust is not equal to the remainder of the input amount");
+        assertEq(amounts.evm, expectedEvm, "evm amount is not equal to the input amount");
+        assertEq(amounts.core, expectedCore, "core amount is not equal to the input amount");
+    }
+}

--- a/packages/hyperliquid-composer/src/cli.ts
+++ b/packages/hyperliquid-composer/src/cli.ts
@@ -2,7 +2,8 @@ import { Command } from 'commander'
 import { LogLevel } from '@layerzerolabs/io-devtools'
 import {
     setBlock,
-    registerToken,
+    requestEvmContract,
+    finalizeEvmContract,
     coreSpotDeployment,
     tradingFee,
     userGenesis,
@@ -24,14 +25,24 @@ program
     .action(setBlock)
 
 program
-    .command('register-token')
-    .description('Register a token on HyperLiquid')
+    .command('request-evm-contract')
+    .description('Set the core spot to connect to an EVM contract')
+    .option('-oapp, --oapp-config <oapp-config>', 'OAPP config')
+    .requiredOption('-idx, --token-index <token-index>', 'Token index')
+    .requiredOption('-n, --network <network>', 'Network (mainnet/testnet)')
+    .option('-l, --log-level <level>', 'Log level', LogLevel.info)
+    .option('-pk, --private-key <0x>', 'HyperCore Asset deployer private key')
+    .action(requestEvmContract)
+
+program
+    .command('finalize-evm-contract')
+    .description('Finalize the EVM contract')
     .option('-oapp, --oapp-config <oapp-config>', 'OAPP config')
     .requiredOption('-idx, --token-index <token-index>', 'Token index')
     .requiredOption('-n, --network <network>', 'Network (mainnet/testnet)')
     .option('-l, --log-level <level>', 'Log level', LogLevel.info)
     .option('-pk, --private-key <0x>', 'Private key')
-    .action(registerToken)
+    .action(finalizeEvmContract)
 
 program
     .command('core-spot')
@@ -55,7 +66,7 @@ program
     .requiredOption('-s, --share <share>', 'Share')
     .requiredOption('-n, --network <network>', 'Network (mainnet/testnet)')
     .option('-l, --log-level <level>', 'Log level', LogLevel.info)
-    .option('-pk, --private-key', 'Private key')
+    .option('-pk, --private-key <0x>', 'Private key')
     .action(tradingFee)
 
 program

--- a/packages/hyperliquid-composer/src/commands/register-token.ts
+++ b/packages/hyperliquid-composer/src/commands/register-token.ts
@@ -3,10 +3,57 @@ import inquirer from 'inquirer'
 
 import { getCoreSpotDeployment, getHyperEVMOAppDeployment, writeUpdatedCoreSpotDeployment } from '@/io/parser'
 import { getHyperliquidWallet } from '@/signer'
-import { requestEvmContract, finalizeEvmContract } from '@/operations'
+import { setRequestEvmContract, setFinalizeEvmContract } from '@/operations'
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export async function registerToken(args: any): Promise<void> {
+export async function requestEvmContract(args: any): Promise<void> {
+    setDefaultLogLevel(args.logLevel)
+    const logger = createModuleLogger('register-token', args.logLevel)
+    logger.verbose(JSON.stringify(args, null, 2))
+
+    const wallet = await getHyperliquidWallet(args.privateKey)
+
+    const oappConfig = args.oappConfig
+    const hyperAssetIndex = args.tokenIndex
+    const network = args.network
+    const isTestnet = network == 'testnet'
+
+    logger.info(`Found public key ${wallet.address} from .env file`)
+    const coreSpotDeployment = getCoreSpotDeployment(hyperAssetIndex, isTestnet, logger)
+    const txData = coreSpotDeployment.txData
+
+    const { deployment } = await getHyperEVMOAppDeployment(oappConfig, network, logger)
+
+    if (!deployment) {
+        logger.error(`Deployment file not found for ${network}`)
+        return
+    }
+
+    const oftAddress = deployment['address']
+
+    logger.verbose(`txData: \n ${JSON.stringify(txData, null, 2)}`)
+
+    const hyperAssetIndexInt = parseInt(hyperAssetIndex)
+
+    const { executeTx } = await inquirer.prompt([
+        {
+            type: 'confirm',
+            name: 'executeTx',
+            message: `Trying to populate a request to connect HyperCore-EVM ${hyperAssetIndex} to ${oftAddress}. This should be sent by the Spot Deployer and before finalizeEvmContract is executed. Do you want to execute the transaction?`,
+            default: false,
+        },
+    ])
+
+    if (!executeTx) {
+        logger.info('Transaction cancelled - quitting.')
+        process.exit(1)
+    }
+
+    logger.info(`Request EVM contract`)
+    await setRequestEvmContract(wallet, isTestnet, oftAddress, txData.weiDiff, hyperAssetIndexInt, args.logLevel)
+}
+
+export async function finalizeEvmContract(args: any): Promise<void> {
     setDefaultLogLevel(args.logLevel)
     const logger = createModuleLogger('register-token', args.logLevel)
     logger.verbose(JSON.stringify(args, null, 2))
@@ -40,7 +87,7 @@ export async function registerToken(args: any): Promise<void> {
         {
             type: 'confirm',
             name: 'executeTx',
-            message: `Found evm address for HyperCore-EVM ${oftAddress}. Do you want to execute the transaction?`,
+            message: `Confirms the connection of ${oftAddress} to HyperCore-EVM ${hyperAssetIndex}. This should be sent by the EVM Deployer and after requestEvmContract is executed. Do you want to execute the transaction?`,
             default: false,
         },
     ])
@@ -50,13 +97,33 @@ export async function registerToken(args: any): Promise<void> {
         process.exit(1)
     }
 
-    logger.info(`Request EVM contract`)
-    await requestEvmContract(wallet, isTestnet, oftAddress, txData.weiDiff, hyperAssetIndexInt, args.loglevel)
+    const { confirmTx } = await inquirer.prompt([
+        {
+            type: 'confirm',
+            name: 'confirmTx',
+            message: `Confirm that you want to finalize the connection of ${oftAddress} to HyperCore-EVM ${hyperAssetIndex}? This is irreversible.`,
+            default: false,
+        },
+    ])
+
+    if (!confirmTx) {
+        logger.info('Transaction cancelled - quitting.')
+        process.exit(1)
+    }
 
     logger.info(`Finalize EVM contract`)
-    await finalizeEvmContract(wallet, isTestnet, hyperAssetIndexInt, txData.nonce, args.logLevel)
-
-    writeUpdatedCoreSpotDeployment(hyperAssetIndex, isTestnet, nativeSpot.fullName ?? '', oftAddress, txData, logger)
-
-    logger.info(`Token ${hyperAssetIndex} registered on ${network}`)
+    try {
+        await setFinalizeEvmContract(wallet, isTestnet, hyperAssetIndexInt, txData.nonce, args.logLevel)
+        writeUpdatedCoreSpotDeployment(
+            hyperAssetIndex,
+            isTestnet,
+            nativeSpot.fullName ?? '',
+            oftAddress,
+            txData,
+            logger
+        )
+        logger.info(`Token ${hyperAssetIndex} registered on ${network}`)
+    } catch (error) {
+        process.exit(1)
+    }
 }

--- a/packages/hyperliquid-composer/src/operations/registerEvmContract.ts
+++ b/packages/hyperliquid-composer/src/operations/registerEvmContract.ts
@@ -3,7 +3,7 @@ import { Wallet } from 'ethers'
 import { HyperliquidClient } from '../signer'
 import { EvmSpotDeploy, FinalizeEvmContract } from '../types'
 
-export async function requestEvmContract(
+export async function setRequestEvmContract(
     wallet: Wallet,
     isTestnet: boolean,
     evmSpotTokenAddress: string,
@@ -23,11 +23,15 @@ export async function requestEvmContract(
     }
 
     const hyperliquidClient = new HyperliquidClient(isTestnet, logLevel)
-    const response = await hyperliquidClient.submitHyperliquidAction('/exchange', wallet, action)
-    return response
+    try {
+        const response = await hyperliquidClient.submitHyperliquidAction('/exchange', wallet, action)
+        return response
+    } catch (error) {
+        throw new Error(`Error requesting EVM contract: ${error}`)
+    }
 }
 
-export async function finalizeEvmContract(
+export async function setFinalizeEvmContract(
     wallet: Wallet,
     isTestnet: boolean,
     coreSpotTokenId: number,
@@ -45,6 +49,10 @@ export async function finalizeEvmContract(
     }
 
     const hyperliquidClient = new HyperliquidClient(isTestnet, logLevel)
+
     const response = await hyperliquidClient.submitHyperliquidAction('/exchange', wallet, action)
+    if (response.status === 'err') {
+        throw new Error(response.response)
+    }
     return response
 }

--- a/packages/hyperliquid-composer/src/types/constants.ts
+++ b/packages/hyperliquid-composer/src/types/constants.ts
@@ -8,6 +8,11 @@ export const RPC_URLS = {
     TESTNET: 'https://rpc.hyperliquid-testnet.xyz/evm',
 }
 
+export const CHAIN_IDS = {
+    MAINNET: 999,
+    TESTNET: 998,
+}
+
 export const ENDPOINTS = {
     INFO: '/info',
     EXCHANGE: '/exchange',


### PR DESCRIPTION
## SDK
`register-token` used to be a command that would execute 2 hypercore actions `requestEvmContract` and `finalizeEvmContract`. It is possible that the EVM contract and Core Spot are deployed from different accounts, in that event `register-token` would fail as it would run into a `"invalid deployer address"` error. This change introduces

### `registerEvmContract`
```bash
npx @layerzerolabs/hyperliquid-composer request-evm-contract  --oapp-config <layerzero.config.ts>  --token-index <idx> --network <testnet | mainnet> --private-key $PRIVATE_KEY_HYPERLIQUID_DEPLOYER
```

### `finalizeEvmContract`
```bash
npx @layerzerolabs/hyperliquid-composer finalize-evm-contract  --oapp-config <layerzero.config.ts>  --token-index <idx>  --network <testnet | mainnet> --private-key $PRIVATE_KEY_EVM_DEPLOYER
```

## Deploy Script
using `chainId` instead of network name to differentiate between non-hyperliquid networks and hyperliquid (for block switching) as network names are use configurable while networks aren't.

## Test
Bringing over some tests from `packages/hyperliquid-composer` 