### PR TITLE
🧹 CI - adding in initia compile and test for examples

### DIFF
--- a/examples/oft-adapter-initia/package.json
+++ b/examples/oft-adapter-initia/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "scripts": {
     "clean": "rm -rf artifacts cache out build",
-    "compile": "$npm_execpath run compile:forge && $npm_execpath run compile:hardhat",
+    "compile": "$npm_execpath run compile:forge && $npm_execpath run compile:hardhat && $npm_execpath run compile:initia",
     "compile:forge": "forge build",
     "compile:hardhat": "hardhat compile",
     "compile:initia": "initiad move build --dev",

--- a/examples/oft-initia/package.json
+++ b/examples/oft-initia/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "scripts": {
     "clean": "rm -rf artifacts cache out build",
-    "compile": "$npm_execpath run compile:forge && $npm_execpath run compile:hardhat",
+    "compile": "$npm_execpath run compile:forge && $npm_execpath run compile:hardhat && $npm_execpath run compile:initia",
     "compile:forge": "forge build",
     "compile:hardhat": "hardhat compile",
     "compile:initia": "initiad move build --dev",
@@ -34,7 +34,7 @@
     "lz:sdk:move:transfer-object-owner": "ts-node scripts/cli.ts --vm move --op transfer-object-owner",
     "lz:sdk:move:unset-rate-limit": "ts-node scripts/cli.ts --vm move --op unset-rate-limit",
     "lz:sdk:move:wire": "ts-node scripts/cli.ts --vm move --op wire",
-    "test": "$npm_execpath run test:forge && $npm_execpath run test:hardhat",
+    "test": "$npm_execpath run test:forge && $npm_execpath run test:hardhat && $npm_execpath run test:initia",
     "test:forge": "forge test",
     "test:hardhat": "hardhat test",
     "test:initia": "initiad move test --dev --skip-fetch-latest-git-deps"

--- a/packages/oft-move/tasks/initOFTFA.ts
+++ b/packages/oft-move/tasks/initOFTFA.ts
@@ -1,4 +1,5 @@
 import { sendInitTransaction, TaskContext } from '@layerzerolabs/devtools-move'
+import { endpointIdToChainType, ChainType } from '@layerzerolabs/lz-definitions'
 
 import { endpointIdToChainType, ChainType } from '@layerzerolabs/lz-definitions'
 import inquirer from 'inquirer'
@@ -59,6 +60,16 @@ async function initOFTFA(
                     `Current config specifies: ${local_decimals}. Please update your configuration.`
             )
         }
+    }
+
+    const chainType = endpointIdToChainType(taskContext.srcEid)
+    const INITIA_SUPPORTED_DECIMALS = 6
+
+    // Initia only supports local decimals = 6
+    if (chainType == ChainType.INITIA && local_decimals != INITIA_SUPPORTED_DECIMALS) {
+        throw new Error(
+            `OFTFA config : Initia only supportts local decimals = ${INITIA_SUPPORTED_DECIMALS}. Found ${local_decimals} in config`
+        )
     }
 
     const payloads = [{ payload: initializePayload, description: 'Initialize Aptos OFT', eid: taskContext.srcEid }]


### PR DESCRIPTION
## What is added
Certain examples were missing unit tests and compile for `initia`

## What is not added
Since `aptos` and `initia` use a wrapper to build and test. We need testing for that. Support for this does not exist in `devtools-move` notably the inclusion of `--dev` flag