### PR TITLE
add initia compile and test

### DIFF
--- a/examples/oft-adapter-initia/package.json
+++ b/examples/oft-adapter-initia/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "scripts": {
     "clean": "rm -rf artifacts cache out build",
-    "compile": "$npm_execpath run compile:forge && $npm_execpath run compile:hardhat",
+    "compile": "$npm_execpath run compile:forge && $npm_execpath run compile:hardhat && $npm_execpath run compile:initia",
     "compile:forge": "forge build",
     "compile:hardhat": "hardhat compile",
     "compile:initia": "initiad move build --dev",

--- a/examples/oft-initia/package.json
+++ b/examples/oft-initia/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "scripts": {
     "clean": "rm -rf artifacts cache out build",
-    "compile": "$npm_execpath run compile:forge && $npm_execpath run compile:hardhat",
+    "compile": "$npm_execpath run compile:forge && $npm_execpath run compile:hardhat && $npm_execpath run compile:initia",
     "compile:forge": "forge build",
     "compile:hardhat": "hardhat compile",
     "compile:initia": "initiad move build --dev",
@@ -34,7 +34,7 @@
     "lz:sdk:move:transfer-object-owner": "ts-node scripts/cli.ts --vm move --op transfer-object-owner",
     "lz:sdk:move:unset-rate-limit": "ts-node scripts/cli.ts --vm move --op unset-rate-limit",
     "lz:sdk:move:wire": "ts-node scripts/cli.ts --vm move --op wire",
-    "test": "$npm_execpath run test:forge && $npm_execpath run test:hardhat",
+    "test": "$npm_execpath run test:forge && $npm_execpath run test:hardhat && $npm_execpath run test:initia",
     "test:forge": "forge test",
     "test:hardhat": "hardhat test",
     "test:initia": "initiad move test --dev --skip-fetch-latest-git-deps"


### PR DESCRIPTION
## What is added
Certain examples were missing unit tests and compile for initia

## What is not added
Since aptos and initia use a wrapper to build and test. We need testing for that. Support for this does not exist in devtools-move notably the inclusion of --dev flag