### PR TITLE
🧹 hyperliquid docs - fix typo + cleanup

### DIFF
--- a/.changeset/red-beds-flash.md
+++ b/.changeset/red-beds-flash.md
@@ -1,0 +1,6 @@
+---
+"@layerzerolabs/hyperliquid-composer": patch
+"@layerzerolabs/oft-hyperliquid-example": patch
+---
+
+docs typo cleanup

--- a/examples/oft-hyperliquid/HYPERLIQUID.README.md
+++ b/examples/oft-hyperliquid/HYPERLIQUID.README.md
@@ -9,6 +9,14 @@ Feel free to checkout our internal docs [here](https://github.com/LayerZero-Labs
 
 ## Using the LayerZero Hyperliquid SDK
 
+The following are just syntax and usage. Explanations are below in the section on "Deploy and Connect your OFT Guide".
+
+To view all commands, run:
+
+```bash
+npx @layerzerolabs/hyperliquid-composer -h
+```
+
 ### Type conversions
 
 #### Get the asset bridge address
@@ -83,7 +91,7 @@ npx @layerzerolabs/hyperliquid-composer user-genesis \
     --token-index <coreIndex> \
     [--action  {* | userAndWei | existingTokenAndWei | blacklistUsers}]
     --network {testnet | mainnet} \
-    -private-key $PRIVATE_KEY_HYPERLIQUID \
+    --private-key $PRIVATE_KEY_HYPERLIQUID \
     [--log-level {info | verbose}]
 ```
 
@@ -93,7 +101,7 @@ npx @layerzerolabs/hyperliquid-composer user-genesis \
 npx @layerzerolabs/hyperliquid-composer set-genesis \
     --token-index <coreIndex> \
     --network {testnet | mainnet} \
-    -private-key $PRIVATE_KEY_HYPERLIQUID \
+    --private-key $PRIVATE_KEY_HYPERLIQUID \
     [--log-level {info | verbose}]
 ```
 
@@ -103,7 +111,7 @@ npx @layerzerolabs/hyperliquid-composer set-genesis \
 npx @layerzerolabs/hyperliquid-composer register-spot \
     --token-index <coreIndex> \
     --network {testnet | mainnet} \
-    -private-key $PRIVATE_KEY_HYPERLIQUID \
+    --private-key $PRIVATE_KEY_HYPERLIQUID \
     [--log-level {info | verbose}]
 ```
 
@@ -262,7 +270,7 @@ npx @layerzerolabs/hyperliquid-composer user-genesis \
     --token-index <coreIndex> \
     [--action  {* | userAndWei | existingTokenAndWei | blacklistUsers}]
     --network {testnet | mainnet} \
-    -private-key $PRIVATE_KEY_HYPERLIQUID \
+    --private-key $PRIVATE_KEY_HYPERLIQUID \
     [--log-level {info | verbose}]
 ```
 
@@ -278,7 +286,7 @@ This is the step that registers the above genesis balances on `HyperCore`.
 npx @layerzerolabs/hyperliquid-composer set-genesis \
     --token-index <coreIndex> \
     --network {testnet | mainnet} \
-    -private-key $PRIVATE_KEY_HYPERLIQUID \
+    --private-key $PRIVATE_KEY_HYPERLIQUID \
     [--log-level {info | verbose}]
 ```
 
@@ -290,7 +298,7 @@ This is the step that registers the core spot on `HyperCore` and creates a base-
 npx @layerzerolabs/hyperliquid-composer register-spot \
     --token-index <coreIndex> \
     --network {testnet | mainnet} \
-    -private-key $PRIVATE_KEY_HYPERLIQUID \
+    --private-key $PRIVATE_KEY_HYPERLIQUID \
 ```
 
 Your core spot (that does not use hyperliquidity) has now been deployed and registered on `HyperCore`.

--- a/examples/oft-hyperliquid/README.md
+++ b/examples/oft-hyperliquid/README.md
@@ -8,7 +8,7 @@
   <a href="https://layerzero.network" style="color: #a77dff">Homepage</a> | <a href="https://docs.layerzero.network/" style="color: #a77dff">Docs</a> | <a href="https://layerzero.network/developers" style="color: #a77dff">Developers</a>
 </p>
 
-<h1 align="center">Omnichain Fungible Token (OFT) Example - Hyperliquid Variant</h1>
+<h1 align="center">Omnichain Fungible Token (OFT) Example - Hyperliquid Variant (with Composer)</h1>
 
 <p align="center">
   <a href="https://docs.layerzero.network/v2/developers/evm/oft/quickstart" style="color: #a77dff">Quickstart</a> | <a href="https://docs.layerzero.network/contracts/oapp-configuration" style="color: #a77dff">Configuration</a> | <a href="https://docs.layerzero.network/contracts/options" style="color: #a77dff">Message Execution Options</a> | <a href="https://docs.layerzero.network/v2/developers/evm/technical-reference/deployed-contracts" style="color: #a77dff">Endpoint, MessageLib, & Executor Addresses</a> | <a

--- a/examples/oft-hyperliquid/layerzero.config.ts
+++ b/examples/oft-hyperliquid/layerzero.config.ts
@@ -2,11 +2,6 @@ import { EndpointId } from '@layerzerolabs/lz-definitions'
 
 import type { OAppOmniGraphHardhat, OmniPointHardhat } from '@layerzerolabs/toolbox-hardhat'
 
-enum MsgType {
-    SEND = 1,
-    SEND_AND_CALL = 2,
-}
-
 const bscTestnetContract: OmniPointHardhat = {
     eid: EndpointId.BSC_V2_TESTNET,
     contractName: 'MyOFT',

--- a/packages/hyperliquid-composer/HYPERLIQUID.README.md
+++ b/packages/hyperliquid-composer/HYPERLIQUID.README.md
@@ -351,7 +351,7 @@ npx @layerzerolabs/hyperliquid-composer user-genesis \
     --token-index <coreIndex> \ 
     [--action  {* | userAndWei | existingTokenAndWei | blacklistUsers}]
     --network {testnet | mainnet} \ 
-    -private-key $PRIVATE_KEY_HYPERLIQUID \ 
+    --private-key $PRIVATE_KEY_HYPERLIQUID \ 
     [--log-level {info | verbose}]
 ```
 
@@ -361,7 +361,7 @@ npx @layerzerolabs/hyperliquid-composer user-genesis \
 npx @layerzerolabs/hyperliquid-composer set-genesis \
     --token-index <coreIndex> \
     --network {testnet | mainnet} \
-    -private-key $PRIVATE_KEY_HYPERLIQUID \ 
+    --private-key $PRIVATE_KEY_HYPERLIQUID \ 
     [--log-level {info | verbose}]
 ```
 
@@ -371,7 +371,7 @@ npx @layerzerolabs/hyperliquid-composer set-genesis \
 npx @layerzerolabs/hyperliquid-composer register-spot \
     --token-index <coreIndex> \
     --network {testnet | mainnet} \ 
-    -private-key $PRIVATE_KEY_HYPERLIQUID \ 
+    --private-key $PRIVATE_KEY_HYPERLIQUID \ 
     [--log-level {info | verbose}]
 ```
 
@@ -527,7 +527,7 @@ npx @layerzerolabs/hyperliquid-composer user-genesis \
     --token-index <coreIndex> \
     [--action  {* | userAndWei | existingTokenAndWei | blacklistUsers}]
     --network {testnet | mainnet} \ 
-    -private-key $PRIVATE_KEY_HYPERLIQUID \ 
+    --private-key $PRIVATE_KEY_HYPERLIQUID \ 
     [--log-level {info | verbose}]
 ```
 
@@ -542,7 +542,7 @@ This is the step that registers the above genesis balances on `HyperCore`.
 npx @layerzerolabs/hyperliquid-composer set-genesis \
     --token-index <coreIndex> \
     --network {testnet | mainnet} \
-    -private-key $PRIVATE_KEY_HYPERLIQUID \ 
+    --private-key $PRIVATE_KEY_HYPERLIQUID \ 
     [--log-level {info | verbose}]
 ```
 
@@ -554,7 +554,7 @@ This is the step that registers the Core Spot on `HyperCore` and creates a base-
 npx @layerzerolabs/hyperliquid-composer register-spot \
     --token-index <CoreIndex> \
     --network {testnet | mainnet} \ 
-    -private-key $PRIVATE_KEY_HYPERLIQUID \ 
+    --private-key $PRIVATE_KEY_HYPERLIQUID \ 
 ```
 
 Your Core Spot (that does not use Hyperliquidity) has now been deployed and registered on `HyperCore`.

--- a/packages/hyperliquid-composer/README.md
+++ b/packages/hyperliquid-composer/README.md
@@ -20,6 +20,11 @@
 
 The following are just syntax and usage. Explanations are below in the section on "Deploy and Connect your OFT Guide".
 
+To view all commands, run:
+```bash
+npx @layerzerolabs/hyperliquid-composer -h
+```
+
 ### Reading Core Spot state
 
 #### List Core Spot metadata
@@ -77,7 +82,7 @@ npx @layerzerolabs/hyperliquid-composer user-genesis \
     --token-index <coreIndex> \ 
     [--action  {* | userAndWei | existingTokenAndWei | blacklistUsers}]
     --network {testnet | mainnet} \ 
-    -private-key $PRIVATE_KEY_HYPERLIQUID \ 
+    --private-key $PRIVATE_KEY_HYPERLIQUID \ 
     [--log-level {info | verbose}]
 ```
 
@@ -87,7 +92,7 @@ npx @layerzerolabs/hyperliquid-composer user-genesis \
 npx @layerzerolabs/hyperliquid-composer set-genesis \
     --token-index <coreIndex> \
     --network {testnet | mainnet} \
-    -private-key $PRIVATE_KEY_HYPERLIQUID \ 
+    --private-key $PRIVATE_KEY_HYPERLIQUID \ 
     [--log-level {info | verbose}]
 ```
 
@@ -97,7 +102,7 @@ npx @layerzerolabs/hyperliquid-composer set-genesis \
 npx @layerzerolabs/hyperliquid-composer register-spot \
     --token-index <coreIndex> \
     --network {testnet | mainnet} \ 
-    -private-key $PRIVATE_KEY_HYPERLIQUID \ 
+    --private-key $PRIVATE_KEY_HYPERLIQUID \ 
     [--log-level {info | verbose}]
 ```
 


### PR DESCRIPTION
Primarily fixing a typo where `--private-key` was called `-private-key` in the docs