### PR TITLE
fix: replace release.solana.com

### DIFF
--- a/examples/lzapp-migration/README.md
+++ b/examples/lzapp-migration/README.md
@@ -40,7 +40,7 @@ curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 ### Install Solana
 
 ```bash
-sh -c "$(curl -sSfL https://release.solana.com/v1.17.31/install)"
+sh -c "$(curl -sSfL https://release.anza.xyz/v1.17.31/install)"
 ```
 
 ### Install Anchor
@@ -203,7 +203,7 @@ While for building, we must use Solana `v1.17.31`, for deploying, we will be usi
 First, we switch to Solana `v1.18.26` (remember to switch back to `v1.17.31` later)
 
 ```bash
-sh -c "$(curl -sSfL https://release.solana.com/v1.18.26/install)"
+sh -c "$(curl -sSfL https://release.anza.xyz/v1.18.26/install)"
 ```
 
 ##### (Recommended) Deploying with a priority fee
@@ -229,7 +229,7 @@ solana program deploy --program-id target/deploy/oft-keypair.json target/verifia
 :warning: After deploying, make sure to switch back to v1.17.31 after deploying. If you need to rebuild artifacts, you must use Solana CLI version `1.17.31` and Anchor version `0.29.0`
 
 ```bash
-sh -c "$(curl -sSfL https://release.solana.com/v1.17.31/install)"
+sh -c "$(curl -sSfL https://release.anza.xyz/v1.17.31/install)"
 ```
 
 #### Create the Solana OFT202 acounts

--- a/examples/mint-burn-oft-adapter/package.json
+++ b/examples/mint-burn-oft-adapter/package.json
@@ -16,6 +16,16 @@
     "test:forge": "forge test",
     "test:hardhat": "hardhat test"
   },
+  "pnpm": {
+    "overrides": {
+      "ethers": "^5.7.2",
+      "hardhat-deploy": "^0.12.1"
+    }
+  },
+  "overrides": {
+    "ethers": "^5.7.2",
+    "hardhat-deploy": "^0.12.1"
+  },
   "resolutions": {
     "ethers": "^5.7.2",
     "hardhat-deploy": "^0.12.1"
@@ -61,15 +71,5 @@
   },
   "engines": {
     "node": ">=18.16.0"
-  },
-  "pnpm": {
-    "overrides": {
-      "ethers": "^5.7.2",
-      "hardhat-deploy": "^0.12.1"
-    }
-  },
-  "overrides": {
-    "ethers": "^5.7.2",
-    "hardhat-deploy": "^0.12.1"
   }
 }

--- a/examples/mint-burn-oft-adapter/package.json
+++ b/examples/mint-burn-oft-adapter/package.json
@@ -16,10 +16,6 @@
     "test:forge": "forge test",
     "test:hardhat": "hardhat test"
   },
-  "overrides": {
-    "ethers": "^5.7.2",
-    "hardhat-deploy": "^0.12.1"
-  },
   "resolutions": {
     "ethers": "^5.7.2",
     "hardhat-deploy": "^0.12.1"
@@ -71,5 +67,9 @@
       "ethers": "^5.7.2",
       "hardhat-deploy": "^0.12.1"
     }
+  },
+  "overrides": {
+    "ethers": "^5.7.2",
+    "hardhat-deploy": "^0.12.1"
   }
 }

--- a/examples/mint-burn-oft-adapter/package.json
+++ b/examples/mint-burn-oft-adapter/package.json
@@ -16,12 +16,6 @@
     "test:forge": "forge test",
     "test:hardhat": "hardhat test"
   },
-  "pnpm": {
-    "overrides": {
-      "ethers": "^5.7.2",
-      "hardhat-deploy": "^0.12.1"
-    }
-  },
   "overrides": {
     "ethers": "^5.7.2",
     "hardhat-deploy": "^0.12.1"
@@ -71,5 +65,11 @@
   },
   "engines": {
     "node": ">=18.16.0"
+  },
+  "pnpm": {
+    "overrides": {
+      "ethers": "^5.7.2",
+      "hardhat-deploy": "^0.12.1"
+    }
   }
 }

--- a/examples/oft-solana/README.md
+++ b/examples/oft-solana/README.md
@@ -36,7 +36,7 @@ curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 ### Install Solana
 
 ```bash
-sh -c "$(curl -sSfL https://release.solana.com/v1.17.31/install)"
+sh -c "$(curl -sSfL https://release.anza.xyz/v1.17.31/install)"
 ```
 
 ### Install Anchor
@@ -178,7 +178,7 @@ While for building, we must use Solana `v1.17.31`, for deploying, we will be usi
 First, we switch to Solana `v1.18.26` (remember to switch back to `v1.17.31` later)
 
 ```bash
-sh -c "$(curl -sSfL https://release.solana.com/v1.18.26/install)"
+sh -c "$(curl -sSfL https://release.anza.xyz/v1.18.26/install)"
 ```
 
 ##### (Recommended) Deploying with a priority fee
@@ -204,7 +204,7 @@ solana program deploy --program-id target/deploy/oft-keypair.json target/verifia
 :warning: After deploying, make sure to switch back to v1.17.31 after deploying. If you need to rebuild artifacts, you must use Solana CLI version `1.17.31` and Anchor version `0.29.0`
 
 ```bash
-sh -c "$(curl -sSfL https://release.solana.com/v1.17.31/install)"
+sh -c "$(curl -sSfL https://release.anza.xyz/v1.17.31/install)"
 ```
 
 ### Create the Solana OFT


### PR DESCRIPTION
release.solana.com has been discontinued. Current instructions would lead to an error. 

This PR replaces the domain to release.anza.xyz, the successor

Unrelated change made to fix lint error that's blocking this PR:

```
# > @layerzerolabs/mint-burn-oft-adapter-example@0.0.8 lint:js /tmp/tmp.RSN696we7s/pnpm-mint-burn-oft-adapter
# > eslint '**/*.{js,ts,json}' && prettier --check .
#
#
# /tmp/tmp.RSN696we7s/pnpm-mint-burn-oft-adapter/package.json
#   23:4  error  Insert `overrides":·{⏎····"ethers":·"^5.7.2",⏎····"hardhat-deploy":·"^0.12.1"⏎··},⏎··"`  prettier/prettier
#   69:6  error  Delete `⏎··},⏎··"overrides":·{⏎····"ethers":·"^5.7.2",⏎····"hardhat-deploy":·"^0.12.1"`  prettier/prettier
#
# ✖ 2 problems (2 errors, 0 warnings)
#   2 errors and 0 warnings potentially fixable with the `--fix` option.
```