### PR TITLE
doc(lzapp-migration): fix, add clarifications and warning

### DIFF
--- a/examples/lzapp-migration/README.md
+++ b/examples/lzapp-migration/README.md
@@ -185,6 +185,8 @@ To deploy your contracts to your desired EVM chains, run the following command i
 npx hardhat lz:deploy
 ```
 
+When prompted for the deploy tag to use, input `MyEndpointV1OFTV2Mock`, which is a contract that is using OFTV2 on EndpointV1.
+
 More information about available CLI arguments can be found using the `--help` flag:
 
 ```bash

--- a/examples/lzapp-migration/README.md
+++ b/examples/lzapp-migration/README.md
@@ -135,7 +135,6 @@ pnpm compile
 Create `programId` keypair files by running:
 
 ```bash
-solana-keygen new -o target/deploy/endpoint-keypair.json --force
 solana-keygen new -o target/deploy/oft-keypair.json --force
 
 anchor keys sync
@@ -323,6 +322,12 @@ npx hardhat lz:oft:solana:send --amount 1000000000 --from-eid 40168 --to <EVM_AD
 
 Congratulations!
 
+## Deploying to Mainnet
+
+In EndpointV1, message libraries for a chain are set globally and not per pathway. This means, if you migrate one chain to ULN301, you must update all other existing chains in the mesh to ULN301 too.
+
+:warning: If you only partially migrate your mesh to ULN301, pathways will be broken and OFTs will not be transferrable between chains that are not using the same message library.
+
 ## Behind The Scenes
 
 Below is an expanded README section that describes not only the overall configuration and wiring between the V1 and V2 endpoints but also explains the purpose of the overridden tasks provided in the repository:
@@ -335,7 +340,7 @@ This example demonstrates how to establish cross-chain communication between a L
 
 - **Endpoints:**
 
-  - **SEPOLIA_TESTNET (V1):** Represented by the contract `MyLzApp`.
+  - **SEPOLIA_TESTNET (V1):** Represented by the contract `MyEndpointV1OFTV2Mock`.
   - **SOLANA_V2_TESTNET (V2):** Represented by the program `OFT202`.
 
 - **Connection Parameters:**  
@@ -344,7 +349,7 @@ This example demonstrates how to establish cross-chain communication between a L
   - **Executor & ULN Configurations:** These determine how messages are processed, including confirmation settings and DVN (Data Validation Node) requirements.
 - **Wiring Process:**  
   The wiring tasks filter connections by endpoint version:
-  - **V1 Endpoint Logic:** Custom configuration logic is applied for **SEPOLIA_TESTNET** to handle the specific requirements of a V1 LzApp.
+  - **V1 Endpoint Logic:** Custom configuration logic is applied for **SEPOLIA_TESTNET** to handle the specific requirements of a V1 MyEndpointV1OFTV2Mock.
   - **V2 Endpoint Logic:** The default logic is used for **SOLANA_V2_TESTNET**, ensuring that the V2 OApp receives the configuration it expects.
 
 ## Overridden Tasks and Their Purpose
@@ -388,7 +393,7 @@ The repository includes several custom tasks that extend or override the default
 3. **Deployment & Execution:**  
    When you run the provided deployment and wiring commands, the tasks work together to:
    - Automatically fetch the configuration settings.
-   - Adjust the deployed contracts so that a V1 LzApp (**SEPOLIA_TESTNET**) can communicate with a V2 OApp (**SOLANA_V2_TESTNET**).
+   - Adjust the deployed contracts so that a MyEndpointV1OFTV2Mock (**SEPOLIA_TESTNET**) can communicate with a Solana OFT202 (**SOLANA_V2_TESTNET**).
 
 By overriding these tasks, the example streamlines the complex process of ensuring compatibility between different LayerZero versions, allowing developers to focus on building omnichain solutions without being bogged down by the underlying cross-chain configuration details.
 

--- a/examples/lzapp-migration/deploy/MyLzApp.ts
+++ b/examples/lzapp-migration/deploy/MyLzApp.ts
@@ -2,7 +2,10 @@ import assert from 'assert'
 
 import { type DeployFunction } from 'hardhat-deploy/types'
 
-// TODO declare your contract name here
+// Note: If you are using this example to migrate your existing Endpoint V1 OFT to use ULN301, then you should be using the MyEndpointV1OFTV2Mock.ts deploy script instead
+// This deploy script is for deploying an Endpoint V1 LzApp, which is relevant if you have an existing LzApp on Endpoint V1
+
+// Note: declare your contract name here
 const contractName = 'MyLzApp'
 
 const deploy: DeployFunction = async (hre) => {

--- a/examples/lzapp-migration/deploy/MyOApp.ts
+++ b/examples/lzapp-migration/deploy/MyOApp.ts
@@ -2,7 +2,10 @@ import assert from 'assert'
 
 import { type DeployFunction } from 'hardhat-deploy/types'
 
-// TODO declare your contract name here
+// Note: If you are using this example to migrate your existing Endpoint V1 OFT to use ULN301, then you should be using the MyEndpointV1OFTV2Mock.ts deploy script instead
+// This deploy script is for deploying a generic OApp on Endpoint V2, which is relevant if you want to test out connecting to an LzApp instance that is using ULN301
+
+// Note: declare your contract name here
 const contractName = 'MyOApp'
 
 const deploy: DeployFunction = async (hre) => {

--- a/examples/lzapp-migration/layerzero.config.ts
+++ b/examples/lzapp-migration/layerzero.config.ts
@@ -3,6 +3,7 @@ import { ExecutorOptionType } from '@layerzerolabs/lz-v2-utilities'
 
 import type { OAppOmniGraphHardhat, OmniPointHardhat } from '@layerzerolabs/toolbox-hardhat'
 
+// Note:  Do not use address for EVM OmniPointHardhat contracts.  Contracts are loaded using hardhat-deploy.
 const sepoliaContract: OmniPointHardhat = {
     eid: EndpointId.SEPOLIA_TESTNET, /// EndpointV1
     contractName: 'MyEndpointV1OFTV2Mock', // Update this if trying out the other contracts


### PR DESCRIPTION
clarifications added to prevent devs from accidentally using MyOApp or LzApp when their intention is to test OFT