### PR TITLE
CI: tell prettier to ignore package.json

### DIFF
--- a/examples/lzapp-migration/.prettierignore
+++ b/examples/lzapp-migration/.prettierignore
@@ -8,3 +8,4 @@ out/
 *.yaml
 *.lock
 package-lock.json
+package.json

--- a/examples/mint-burn-oft-adapter/.prettierignore
+++ b/examples/mint-burn-oft-adapter/.prettierignore
@@ -8,3 +8,4 @@ out/
 *.yaml
 *.lock
 package-lock.json
+package.json

--- a/examples/native-oft-adapter/.prettierignore
+++ b/examples/native-oft-adapter/.prettierignore
@@ -8,3 +8,4 @@ out/
 *.yaml
 *.lock
 package-lock.json
+package.json

--- a/examples/oapp-aptos-move/.prettierignore
+++ b/examples/oapp-aptos-move/.prettierignore
@@ -8,3 +8,4 @@ out/
 *.yaml
 *.lock
 package-lock.json
+package.json

--- a/examples/oapp-read/.prettierignore
+++ b/examples/oapp-read/.prettierignore
@@ -8,3 +8,4 @@ out/
 *.yaml
 *.lock
 package-lock.json
+package.json

--- a/examples/oapp/.prettierignore
+++ b/examples/oapp/.prettierignore
@@ -8,3 +8,4 @@ out/
 *.yaml
 *.lock
 package-lock.json
+package.json

--- a/examples/oft-adapter-aptos-move/.prettierignore
+++ b/examples/oft-adapter-aptos-move/.prettierignore
@@ -8,3 +8,4 @@ out/
 *.yaml
 *.lock
 package-lock.json
+package.json

--- a/examples/oft-adapter/.prettierignore
+++ b/examples/oft-adapter/.prettierignore
@@ -8,3 +8,4 @@ out/
 *.yaml
 *.lock
 package-lock.json
+package.json

--- a/examples/oft-alt/.prettierignore
+++ b/examples/oft-alt/.prettierignore
@@ -8,3 +8,4 @@ out/
 *.yaml
 *.lock
 package-lock.json
+package.json

--- a/examples/oft-aptos-move/.prettierignore
+++ b/examples/oft-aptos-move/.prettierignore
@@ -8,3 +8,4 @@ out/
 *.yaml
 *.lock
 package-lock.json
+package.json

--- a/examples/oft-hyperliquid/.prettierignore
+++ b/examples/oft-hyperliquid/.prettierignore
@@ -8,3 +8,4 @@ out/
 *.yaml
 *.lock
 package-lock.json
+package.json

--- a/examples/oft-initia/.prettierignore
+++ b/examples/oft-initia/.prettierignore
@@ -8,3 +8,4 @@ out/
 *.yaml
 *.lock
 package-lock.json
+package.json

--- a/examples/oft-solana/.prettierignore
+++ b/examples/oft-solana/.prettierignore
@@ -11,3 +11,4 @@ out/
 *.yaml
 *.lock
 package-lock.json
+package.json

--- a/examples/oft-upgradeable/.prettierignore
+++ b/examples/oft-upgradeable/.prettierignore
@@ -8,3 +8,4 @@ out/
 *.yaml
 *.lock
 package-lock.json
+package.json

--- a/examples/oft/.prettierignore
+++ b/examples/oft/.prettierignore
@@ -8,3 +8,4 @@ out/
 *.yaml
 *.lock
 package-lock.json
+package.json

--- a/examples/onft721-zksync/.prettierignore
+++ b/examples/onft721-zksync/.prettierignore
@@ -8,3 +8,4 @@ out/
 *.yaml
 *.lock
 package-lock.json
+package.json

--- a/examples/onft721/.prettierignore
+++ b/examples/onft721/.prettierignore
@@ -8,3 +8,4 @@ out/
 *.yaml
 *.lock
 package-lock.json
+package.json

--- a/examples/uniswap-read/.prettierignore
+++ b/examples/uniswap-read/.prettierignore
@@ -8,3 +8,4 @@ out/
 *.yaml
 *.lock
 package-lock.json
+package.json

--- a/examples/view-pure-read/.prettierignore
+++ b/examples/view-pure-read/.prettierignore
@@ -8,3 +8,4 @@ out/
 *.yaml
 *.lock
 package-lock.json
+package.json

--- a/packages/oft-move/.prettierignore
+++ b/packages/oft-move/.prettierignore
@@ -8,3 +8,4 @@ out/
 *.yaml
 *.lock
 package-lock.json
+package.json


### PR DESCRIPTION
Several PRs are right now blocked to a prettier check that's impossible to fix. 

The prettier (reported by eslint) error involves needing to move `overrides` in the example `package.json` from a lower line to a higher line. After doing so and re-running CI, it would then error saying it needs to be moved from the higher line to the lower line.

Research and attempts at resolving through other means were unsuccessful. This is happening for all the examples.

Note: I tried to tell eslint to ignore prettier's rules, but then the run of prettier would cause the CI to abort. It's triggered via the `lint:js` script:

```
"lint:js": "eslint '**/*.{js,ts,json}' && prettier --check .",
```

If no better solution is found, we should merge this in to unblock the other PRs.

Why telling prettier to ignore package.json isn't too bad:
- prettier is just a formatter, we don't lose confidence on correctness by skipping `package.json`
- if the package.json is malformed, it would show up anyways when running any of the other scripts