### PR TITLE
DEVREL-631 simple config: support no required dvns and block message library

### DIFF
--- a/.changeset/bright-paws-turn.md
+++ b/.changeset/bright-paws-turn.md
@@ -1,0 +1,9 @@
+---
+"@layerzerolabs/protocol-devtools-solana": patch
+"@layerzerolabs/protocol-devtools-evm": patch
+"@layerzerolabs/protocol-devtools": patch
+"@layerzerolabs/metadata-tools": patch
+"@layerzerolabs/ua-devtools": patch
+---
+
+add block msg lib support on evm and optional dvns support on evm and solana

--- a/.changeset/nervous-cups-agree.md
+++ b/.changeset/nervous-cups-agree.md
@@ -1,0 +1,10 @@
+---
+"@layerzerolabs/protocol-devtools-solana": patch
+"@layerzerolabs/protocol-devtools-evm": patch
+"@layerzerolabs/protocol-devtools": patch
+"@layerzerolabs/metadata-tools": patch
+"@layerzerolabs/devtools-move": patch
+"@layerzerolabs/ua-devtools": patch
+---
+
+Updates simple config to support blocked messageLib on Solana and EVM

--- a/.changeset/olive-berries-shake.md
+++ b/.changeset/olive-berries-shake.md
@@ -1,5 +1,0 @@
----
-"@layerzerolabs/metadata-tools": patch
----
-
-support no required dvns and block message library

--- a/.changeset/olive-berries-shake.md
+++ b/.changeset/olive-berries-shake.md
@@ -1,0 +1,5 @@
+---
+"@layerzerolabs/metadata-tools": patch
+---
+
+support no required dvns and block message library

--- a/examples/oft-solana/README.md
+++ b/examples/oft-solana/README.md
@@ -327,13 +327,13 @@ For Solana -> Sepolia, you should pass in the options value into the script at [
 #### Send From Solana Devnet -> To Ethereum Sepolia
 
 ```bash
-npx hardhat lz:oft:send --src-eid 40168 --dst-eid 40161 --to <RECEIVER_BYTES20>  --amount <AMOUNT>
+npx hardhat lz:oft:send --src-eid 40168 --dst-eid 40161 --to <RECEIVER_BYTES20> --amount <AMOUNT>
 ```
 
 #### Send From Ethereum Sepolia -> To Solana Devnet
 
 ```bash
-npx hardhat lz:oft:send --src-eid 40161 --dst-eid 40168 --to <RECEIVER_BASE58>  --amount <AMOUNT>
+npx hardhat lz:oft:send --src-eid 40161 --dst-eid 40168 --to <RECEIVER_BASE58> --amount <AMOUNT>
 ```
 
 For more information, run:

--- a/examples/oft-solana/tasks/common/wire.ts
+++ b/examples/oft-solana/tasks/common/wire.ts
@@ -5,6 +5,7 @@ import { firstFactory } from '@layerzerolabs/devtools'
 import { SUBTASK_LZ_SIGN_AND_SEND, types as devtoolsTypes } from '@layerzerolabs/devtools-evm-hardhat'
 import { setTransactionSizeBuffer } from '@layerzerolabs/devtools-solana'
 import { type LogLevel, createLogger } from '@layerzerolabs/io-devtools'
+import { DebugLogger, KnownErrors } from '@layerzerolabs/io-devtools'
 import { ChainType, endpointIdToChainType } from '@layerzerolabs/lz-definitions'
 import { type IOApp, type OAppConfigurator, type OAppOmniGraph, configureOwnable } from '@layerzerolabs/ua-devtools'
 import {
@@ -20,8 +21,6 @@ import { findSolanaEndpointIdInGraph } from '../solana/utils'
 
 import { publicKey as publicKeyType } from './types'
 import {
-    DebugLogger,
-    KnownErrors,
     createSdkFactory,
     createSolanaConnectionFactory,
     createSolanaSignerFactory,
@@ -124,38 +123,51 @@ task(TASK_LZ_OAPP_WIRE)
             async (subtaskArgs: SubtaskConfigureTaskArgs<OAppOmniGraph, IOApp>, _hre, runSuper) => {
                 // start of pre-wiring checks. we only do this when the current task is wire. if the current task is init-config, we shouldn't run this.
                 if (!args.isSolanaInitConfig) {
-                    logger.debug('Running pre-wiring checks...')
+                    logger.verbose('Running pre-wiring checks...')
                     const { graph } = subtaskArgs
                     for (const connection of graph.connections) {
                         // check if from Solana Endpoint
                         if (endpointIdToChainType(connection.vector.from.eid) === ChainType.SOLANA) {
                             if (connection.config?.sendLibrary) {
-                                // if from Solana Endpoint, ensure the PeerConfig account was already initialized
-                                const solanaConnection = await connectionFactory(connection.vector.from.eid)
+                                // Check if this is BlockedMessageLib - if so, skip the config checks
+                                const BLOCKED_MESSAGE_LIB_SOLANA_MAINNET =
+                                    '2XrYqmhBMPJgDsb4SVbjV1PnJBprurd5bzRCkHwiFCJB'
+                                const BLOCKED_MESSAGE_LIB_SOLANA_TESTNET =
+                                    '2XrYqmhBMPJgDsb4SVbjV1PnJBprurd5bzRCkHwiFCJB'
+                                const sendLibraryAddress = connection.config.sendLibrary
 
-                                const [sendConfig, receiveConfig] = await getSolanaUlnConfigPDAs(
-                                    connection.vector.to.eid,
-                                    solanaConnection,
-                                    new PublicKey(connection.config.sendLibrary),
-                                    new PublicKey(solanaDeployment.oftStore)
-                                )
-
-                                if (sendConfig == null) {
-                                    DebugLogger.printErrorAndFixSuggestion(
-                                        KnownErrors.ULN_INIT_CONFIG_SKIPPED,
-                                        `SendConfig on ${connection.vector.from.eid} not initialized for remote ${connection.vector.to.eid}.`
+                                // Check if this is a BlockedMessageLib address for either mainnet or testnet
+                                if (
+                                    sendLibraryAddress === BLOCKED_MESSAGE_LIB_SOLANA_MAINNET ||
+                                    sendLibraryAddress === BLOCKED_MESSAGE_LIB_SOLANA_TESTNET
+                                ) {
+                                    logger.verbose(
+                                        `Skipping ULN config checks for BlockedMessageLib on ${connection.vector.from.eid}`
                                     )
+                                    continue
                                 }
 
-                                if (receiveConfig == null) {
+                                logger.verbose(`Send library found. Checking if ULN configs have been initialized...`)
+
+                                try {
+                                    // Use the SDK to check if configs exist
+                                    const [sendConfig, receiveConfig] = await getSolanaUlnConfigPDAs(
+                                        connection.vector.to.eid,
+                                        await connectionFactory(connection.vector.from.eid),
+                                        new PublicKey(connection.config.sendLibrary),
+                                        new PublicKey(connection.vector.from.address)
+                                    )
+
+                                    logger.verbose(
+                                        `ULN configs checked successfully for ${connection.vector.from.eid} -> ${connection.vector.to.eid}`
+                                    )
+                                } catch (error) {
+                                    logger.verbose(`Error checking ULN configs: ${error}`)
                                     DebugLogger.printErrorAndFixSuggestion(
                                         KnownErrors.ULN_INIT_CONFIG_SKIPPED,
-                                        `ReceiveConfig on ${connection.vector.from.eid} not initialized for remote ${connection.vector.to.eid}.`
+                                        `ULN configs on ${connection.vector.from.eid} not initialized for remote ${connection.vector.to.eid}.`
                                     )
-                                }
-
-                                if (sendConfig == null || receiveConfig == null) {
-                                    throw new Error('SendConfig or ReceiveConfig not initialized. ')
+                                    throw new Error('ULN configs not initialized. Please run init-config task first.')
                                 }
                             } else {
                                 logger.debug(

--- a/examples/oft-upgradeable/test/hardhat/MyOFTUpgradeable.test.ts
+++ b/examples/oft-upgradeable/test/hardhat/MyOFTUpgradeable.test.ts
@@ -58,7 +58,7 @@ describe('MyOFTUpgradeable Test', () => {
         const myOFTUpgradeable = await upgrades.deployProxy(MyOFTUpgradeable, ['MyOFT', 'MOFT', ownerA.address], {
             initializer: 'initialize',
             constructorArgs: [mockEndpointV2A.address],
-            unsafeAllow: ['constructor', 'state-variable-immutable'],
+            unsafeAllow: ['constructor', 'state-variable-immutable', 'missing-initializer-call'],
         })
         const myOFTUpgradeableImpl = (await upgrades.admin.getInstance(ownerA)).functions.getProxyImplementation(
             myOFTUpgradeable.address
@@ -68,7 +68,7 @@ describe('MyOFTUpgradeable Test', () => {
         const MyOFTUpgradeableMock = await ethers.getContractFactory('MyOFTUpgradeableMock')
         const myOFTUpgradeableMock = await upgrades.upgradeProxy(myOFTUpgradeable.address, MyOFTUpgradeableMock, {
             constructorArgs: [mockEndpointV2A.address],
-            unsafeAllow: ['constructor', 'state-variable-immutable'],
+            unsafeAllow: ['constructor', 'state-variable-immutable', 'missing-initializer-call', 'missing-initializer'],
         })
 
         // Ensure the proxy remains constant after the upgrade
@@ -87,7 +87,7 @@ describe('MyOFTUpgradeable Test', () => {
         // Downgrade the contract to remove mint
         const myOFTUpgradeableAgain = await upgrades.upgradeProxy(myOFTUpgradeableMock.address, MyOFTUpgradeable, {
             constructorArgs: [mockEndpointV2A.address],
-            unsafeAllow: ['constructor', 'state-variable-immutable'],
+            unsafeAllow: ['constructor', 'state-variable-immutable', 'missing-initializer-call'],
         })
         // Ensure the proxy remains constant after the upgrade
         expect(myOFTUpgradeableMock.address).to.equal(myOFTUpgradeableAgain.address)

--- a/examples/oft-upgradeable/test/hardhat/MyOFTUpgradeable.test.ts
+++ b/examples/oft-upgradeable/test/hardhat/MyOFTUpgradeable.test.ts
@@ -58,7 +58,7 @@ describe('MyOFTUpgradeable Test', () => {
         const myOFTUpgradeable = await upgrades.deployProxy(MyOFTUpgradeable, ['MyOFT', 'MOFT', ownerA.address], {
             initializer: 'initialize',
             constructorArgs: [mockEndpointV2A.address],
-            unsafeAllow: ['constructor', 'state-variable-immutable', 'missing-initializer-call'],
+            unsafeAllow: ['constructor', 'state-variable-immutable'],
         })
         const myOFTUpgradeableImpl = (await upgrades.admin.getInstance(ownerA)).functions.getProxyImplementation(
             myOFTUpgradeable.address
@@ -68,7 +68,7 @@ describe('MyOFTUpgradeable Test', () => {
         const MyOFTUpgradeableMock = await ethers.getContractFactory('MyOFTUpgradeableMock')
         const myOFTUpgradeableMock = await upgrades.upgradeProxy(myOFTUpgradeable.address, MyOFTUpgradeableMock, {
             constructorArgs: [mockEndpointV2A.address],
-            unsafeAllow: ['constructor', 'state-variable-immutable', 'missing-initializer-call', 'missing-initializer'],
+            unsafeAllow: ['constructor', 'state-variable-immutable'],
         })
 
         // Ensure the proxy remains constant after the upgrade
@@ -87,7 +87,7 @@ describe('MyOFTUpgradeable Test', () => {
         // Downgrade the contract to remove mint
         const myOFTUpgradeableAgain = await upgrades.upgradeProxy(myOFTUpgradeableMock.address, MyOFTUpgradeable, {
             constructorArgs: [mockEndpointV2A.address],
-            unsafeAllow: ['constructor', 'state-variable-immutable', 'missing-initializer-call'],
+            unsafeAllow: ['constructor', 'state-variable-immutable'],
         })
         // Ensure the proxy remains constant after the upgrade
         expect(myOFTUpgradeableMock.address).to.equal(myOFTUpgradeableAgain.address)

--- a/packages/devtools-move/tasks/evm/utils/libraryConfigUtils.ts
+++ b/packages/devtools-move/tasks/evm/utils/libraryConfigUtils.ts
@@ -8,6 +8,9 @@ import type { SetConfigParam, address, eid } from './types'
 
 const DEFAULT_CONFIG_MESSAGE = `${constants.AddressZero} - DEFAULT`
 
+// A value used to indicate that no DVNs are required. It has to be used instead of 0, because 0 falls back to default value.
+const NIL_DVN_COUNT = (1 << 8) - 1 // type(uint8).max = 255
+
 export async function getConfig(
     epv2Contract: Contract,
     evmAddress: address,
@@ -60,7 +63,7 @@ export function buildConfig(
         [
             {
                 confirmations: ulnConfig.confirmations,
-                requiredDVNCount: _requiredDVNs.length,
+                requiredDVNCount: _requiredDVNs.length > 0 ? _requiredDVNs.length : NIL_DVN_COUNT,
                 optionalDVNCount: _optionalDVNs.length,
                 optionalDVNThreshold: ulnConfig.optionalDVNThreshold,
                 requiredDVNs: _requiredDVNs.sort(),

--- a/packages/devtools-move/tasks/move/utils/index.ts
+++ b/packages/devtools-move/tasks/move/utils/index.ts
@@ -1,6 +1,9 @@
 import { Deserializer, Serializer } from '@layerzerolabs/lz-serdes'
 import { addressToBytes32, trim0x } from '@layerzerolabs/lz-v2-utilities'
 
+// A value used to indicate that no DVNs are required. It has to be used instead of 0, because 0 falls back to default value.
+const NIL_DVN_COUNT = (1 << 8) - 1 // type(uint8).max = 255
+
 /**
  * Interface representing the limits.
  */
@@ -125,7 +128,7 @@ export const UlnConfig = {
         const serializer = new Serializer(false)
         serializer.serializeU64(obj.confirmations)
         serializer.serializeU8(obj.optional_dvn_threshold)
-        const requiredDVNCount = obj.required_dvns.length
+        const requiredDVNCount = obj.required_dvns.length > 0 ? obj.required_dvns.length : NIL_DVN_COUNT
         serializer.serializeU8(requiredDVNCount)
         for (const item of obj.required_dvns) {
             serializer.serializeFixedBytes(addressToBytes32(item))

--- a/packages/metadata-tools/README.md
+++ b/packages/metadata-tools/README.md
@@ -130,10 +130,17 @@ Using such configuration will mean that your OApp doesn't require any DVN to alw
 
 Blocked Messaged Library is a library that can be used both on block messages on certain pathway. It might be useful for some scenarios eg. migration, or when you no longer need specific pathway to be operational.
 
-Simple Config supports setting Blocked Message Library by using following syntax (notice change in the place for block confirmations):
+Simple Config supports setting Blocked Message Library using three options:
+```typescript
+export const MSG_LIB_BLOCK_SEND_AND_RECEIVE = 'BLOCK_SEND_AND_RECEIVE'
+export const MSG_LIB_BLOCK_SEND_ONLY = 'BLOCK_SEND_ONLY'
+export const MSG_LIB_BLOCK_RECEIVE_ONLY = 'BLOCK_RECEIVE_ONLY'
+```
+
+Example of blocking both send and receive for pathway A to B:
 
 ```typescript
-import { generateConnectionsConfig, BLOCKED_MESSAGE_LIB_INDICATOR } from '@layerzerolabs/metadata-tools';
+import { generateConnectionsConfig, MSG_LIB_BLOCK_SEND_AND_RECEIVE } from '@layerzerolabs/metadata-tools';
 
 // ...
 
@@ -142,7 +149,7 @@ const pathways: TwoWayConfig[] = [
         ethereumContract,
         bscContract,
         [['LayerZero Labs'], []],
-        [[15, BLOCKED_MESSAGE_LIB_INDICATOR], 20], // BLOCKED_MESSAGE_LIB_INDICATOR
+        [[15, MSG_LIB_BLOCK_SEND_AND_RECEIVE], 20],
         [undefined, undefined],
     ],
 ]
@@ -150,4 +157,4 @@ const pathways: TwoWayConfig[] = [
 
 Using above configuration will set Blocked Message Library as Send Library on pathway from Chain A to B and as Receive Library for messages coming to chain B from A. This means that both Sending Messages from A to B will be blocked as well as receiving messages on B from A will be blocked.
 
-Blocked configuration in the above example has been set only for A to B, so it means that pathway B to A will operate normally. 
+Blocked configuration in the above example has been set only for A to B, so it means that pathway B to A will operate normally. You can however also use remaining: `MSG_LIB_BLOCK_SEND_ONLY` and `MSG_LIB_BLOCK_RECEIVE_ONLY` which will block messages only in respective direction.

--- a/packages/metadata-tools/README.md
+++ b/packages/metadata-tools/README.md
@@ -107,3 +107,47 @@ const connections = await generateConnectionsConfig(pathways, { fetchMetadata: c
 ```
 
 In the above example, we extended the result of the default `fetchMetadata` with our own DVN entries - under the respective chains. We added a DVN with the `canonicalName` of `SuperCustomDVN` and id `super-custom-dvn`. The `canonicalName` and `id` can be arbitrary, but they must be consistent for all pathways that require that DVN. In our case, since we have a pathway between Fuji and Amoy, we extended the DVNs entry in both Fuji and Amoy.
+
+### Specifying only Optional DVNs
+
+Specifying only Optional DVNs and no Required DVNs is supported in Simple Config. For example this is how you can declare a config with no Required DVNs and only 2 (threshold) out of 3 Optional DVNs:
+
+```typescript
+const connections = await generateConnectionsConfig([
+    [
+      ethereumContract, // Chain A contract
+      bscContract, // Chain B contract
+      [[], [['LayerZero Labs', 'Horizen', 'P2P'], 2]], // [ requiredDVN[], [ optionalDVN[], threshold ] ]
+      [15, 20], // [A to B confirmations, B to A confirmations]
+      [EVM_ENFORCED_OPTIONS, EVM_ENFORCED_OPTIONS], // Chain B enforcedOptions, Chain A enforcedOptions
+    ],
+]);
+```
+
+Using such configuration will mean that your OApp doesn't require any DVN to always verify - instead it's enough if 2 out of 3 DVNs will verify the message.
+
+### Using Blocked Message Library
+
+Blocked Messaged Library is a library that can be used both on block messages on certain pathway. It might be useful for some scenarios eg. migration, or when you no longer need specific pathway to be operational.
+
+Simple Config supports setting Blocked Message Library by using following syntax (notice change in the place for block confirmations):
+
+```typescript
+import { generateConnectionsConfig, BLOCKED_MESSAGE_LIB_INDICATOR } from '@layerzerolabs/metadata-tools';
+
+// ...
+
+const pathways: TwoWayConfig[] = [
+    [
+        ethereumContract,
+        bscContract,
+        [['LayerZero Labs'], []],
+        [[15, BLOCKED_MESSAGE_LIB_INDICATOR], 20], // BLOCKED_MESSAGE_LIB_INDICATOR
+        [undefined, undefined],
+    ],
+]
+```
+
+Using above configuration will set Blocked Message Library as Send Library on pathway from Chain A to B and as Receive Library for messages coming to chain B from A. This means that both Sending Messages from A to B will be blocked as well as receiving messages on B from A will be blocked.
+
+Blocked configuration in the above example has been set only for A to B, so it means that pathway B to A will operate normally. 

--- a/packages/metadata-tools/package.json
+++ b/packages/metadata-tools/package.json
@@ -37,6 +37,7 @@
     "test:jest": "jest"
   },
   "devDependencies": {
+    "@ethersproject/address": "~5.7.0",
     "@layerzerolabs/devtools-evm-hardhat": "~4.0.0",
     "@layerzerolabs/ua-devtools": "~5.0.0",
     "@swc/core": "^1.4.0",

--- a/packages/metadata-tools/src/config-metadata.ts
+++ b/packages/metadata-tools/src/config-metadata.ts
@@ -6,13 +6,13 @@ import {
     METADATA_KEY_EVM_BLOCKED_MESSAGE,
     METADATA_KEY_RECEIVE_LIBRARY,
     METADATA_KEY_SEND_LIBRARY,
-    METADATA_KEY_SOLANA_BLOCKED_MESSAGE,
     METADATA_URL,
     MSG_LIB_BLOCK_RECEIVE_ONLY,
     MSG_LIB_BLOCK_SEND_AND_RECEIVE,
     MSG_LIB_BLOCK_SEND_ONLY,
     NIL_DVN_COUNT,
 } from './constants'
+import { getAddress } from '@ethersproject/address'
 
 function getEndpointIdDeployment(eid: number, metadata: IMetadata) {
     const srcEidString = eid.toString()
@@ -87,7 +87,12 @@ function isSolanaDeployment(deployment: { chainKey: string; executor?: { pda?: s
 // Helper to resolve library metadata key based on operation and chain
 function resolveLibraryMetadataKey(isSend: boolean, isBlocked: boolean, deployment: { chainKey: string }) {
     if (isBlocked) {
-        return isSolanaDeployment(deployment) ? METADATA_KEY_SOLANA_BLOCKED_MESSAGE : METADATA_KEY_EVM_BLOCKED_MESSAGE
+        if (isSolanaDeployment(deployment)) {
+            throw new Error('BlockedMessageLib is not currently supported by simple config generator on Solana')
+            // return METADATA_KEY_SOLANA_BLOCKED_MESSAGE // @TODO uncomment this when blocked message lib is supported on Solana
+        }
+
+        return METADATA_KEY_EVM_BLOCKED_MESSAGE
     }
     return isSend ? METADATA_KEY_SEND_LIBRARY : METADATA_KEY_RECEIVE_LIBRARY
 }
@@ -118,6 +123,9 @@ function isBlocked(blockConfirmationsDefinition: BlockConfirmationsDefinition | 
             keys.includes(blockConfirmationsDefinition[1])
     )
 }
+
+const getLibraryAddress = (deployment: any, metadataKey: string) =>
+    isSolanaDeployment(deployment) ? deployment[metadataKey].address : getAddress(deployment[metadataKey].address)
 
 export async function translatePathwayToConfig(
     pathway: TwoWayConfig,
@@ -179,10 +187,10 @@ export async function translatePathwayToConfig(
     assertHasKey(BLZDeployment, sendLibraryBToAMetadataKey, BContract.eid)
     assertHasKey(ALZDeployment, receiveLibraryBToAMetadataKey, AContract.eid)
 
-    const sendLibraryAToB = ALZDeployment[sendLibraryAToBMetadataKey].address
-    const receiveLibraryAToB = BLZDeployment[receiveLibraryAToBMetadataKey].address
-    const sendLibraryBToA = BLZDeployment[sendLibraryBToAMetadataKey].address
-    const receiveLibraryBToA = ALZDeployment[receiveLibraryBToAMetadataKey].address
+    const sendLibraryAToB = getLibraryAddress(ALZDeployment, sendLibraryAToBMetadataKey)
+    const receiveLibraryAToB = getLibraryAddress(BLZDeployment, receiveLibraryAToBMetadataKey)
+    const sendLibraryBToA = getLibraryAddress(BLZDeployment, sendLibraryBToAMetadataKey)
+    const receiveLibraryBToA = getLibraryAddress(ALZDeployment, receiveLibraryBToAMetadataKey)
 
     const AToBConfig: OmniEdgeHardhat<OAppEdgeConfig> = {
         from: AContract,

--- a/packages/metadata-tools/src/config-metadata.ts
+++ b/packages/metadata-tools/src/config-metadata.ts
@@ -4,6 +4,7 @@ import { BlockConfirmationsDefinition, BlockConfirmationsType, IMetadata } from 
 import { TwoWayConfig } from './types'
 import {
     METADATA_KEY_EVM_BLOCKED_MESSAGE,
+    METADATA_KEY_SOLANA_BLOCKED_MESSAGE,
     METADATA_KEY_RECEIVE_LIBRARY,
     METADATA_KEY_SEND_LIBRARY,
     METADATA_URL,
@@ -88,8 +89,7 @@ function isSolanaDeployment(deployment: { chainKey: string; executor?: { pda?: s
 function resolveLibraryMetadataKey(isSend: boolean, isBlocked: boolean, deployment: { chainKey: string }) {
     if (isBlocked) {
         if (isSolanaDeployment(deployment)) {
-            throw new Error('BlockedMessageLib is not currently supported by simple config generator on Solana')
-            // return METADATA_KEY_SOLANA_BLOCKED_MESSAGE // @TODO uncomment this when blocked message lib is supported on Solana
+            return METADATA_KEY_SOLANA_BLOCKED_MESSAGE
         }
 
         return METADATA_KEY_EVM_BLOCKED_MESSAGE

--- a/packages/metadata-tools/src/config-metadata.ts
+++ b/packages/metadata-tools/src/config-metadata.ts
@@ -1,6 +1,6 @@
 import type { OmniEdgeHardhat } from '@layerzerolabs/devtools-evm-hardhat'
 import type { OAppEdgeConfig } from '@layerzerolabs/ua-devtools'
-import { IMetadata } from './types'
+import { BlockConfirmationsType, IMetadata } from './types'
 import { TwoWayConfig } from './types'
 import { BLOCKED_MESSAGE_LIB_INDICATOR, METADATA_URL, NIL_DVN_COUNT } from './constants'
 
@@ -114,19 +114,23 @@ export async function translatePathwayToConfig(
         BOptionalDVNs = DVNsToAddresses(optionalDVNs, BLZDeployment.chainKey, metadata)
     }
 
-    const AToBConfirmations: number =
-        typeof AToBConfirmationsDefinition === 'number' ? AToBConfirmationsDefinition : AToBConfirmationsDefinition[0]
-    const BToAConfirmations: number | undefined =
-        typeof BToAConfirmationsDefinition === 'number' ? BToAConfirmationsDefinition : BToAConfirmationsDefinition?.[0]
+    const AToBConfirmations: BlockConfirmationsType = ['bigint', 'number'].includes(typeof AToBConfirmationsDefinition)
+        ? AToBConfirmationsDefinition
+        : AToBConfirmationsDefinition[0]
+    const BToAConfirmations: BlockConfirmationsType | undefined = ['bigint', 'number'].includes(
+        typeof BToAConfirmationsDefinition
+    )
+        ? BToAConfirmationsDefinition
+        : BToAConfirmationsDefinition?.[0]
 
     const blockSendAToB: boolean = Boolean(
         AToBConfirmationsDefinition &&
-            typeof AToBConfirmationsDefinition !== 'number' &&
+            !['bigint', 'number'].includes(typeof AToBConfirmationsDefinition) &&
             AToBConfirmationsDefinition[1] === BLOCKED_MESSAGE_LIB_INDICATOR
     )
     const blockSendBToA: boolean = Boolean(
         BToAConfirmationsDefinition &&
-            typeof BToAConfirmationsDefinition !== 'number' &&
+            !['bigint', 'number'].includes(typeof BToAConfirmationsDefinition) &&
             BToAConfirmationsDefinition[1] === BLOCKED_MESSAGE_LIB_INDICATOR
     )
 

--- a/packages/metadata-tools/src/config-metadata.ts
+++ b/packages/metadata-tools/src/config-metadata.ts
@@ -2,7 +2,7 @@ import type { OmniEdgeHardhat } from '@layerzerolabs/devtools-evm-hardhat'
 import type { OAppEdgeConfig } from '@layerzerolabs/ua-devtools'
 import { IMetadata } from './types'
 import { TwoWayConfig } from './types'
-import { METADATA_URL } from './constants'
+import { BLOCKED_MESSAGE_LIB_INDICATOR, METADATA_URL, NIL_DVN_COUNT } from './constants'
 
 function getEndpointIdDeployment(eid: number, metadata: IMetadata) {
     const srcEidString = eid.toString()
@@ -80,11 +80,11 @@ export async function translatePathwayToConfig(
 ): Promise<OmniEdgeHardhat<OAppEdgeConfig | undefined>[]> {
     const configs: OmniEdgeHardhat<OAppEdgeConfig | undefined>[] = []
 
-    const sourceContract = pathway[0]
-    const destinationContract = pathway[1]
+    const AContract = pathway[0]
+    const BContract = pathway[1]
     const [requiredDVNs, optionalDVNConfig] = pathway[2]
-    const [sourceToDestinationConfirmations, destinationToSourceConfirmations] = pathway[3]
-    const [enforcedOptionsSrcToDst, enforcedOptionsDstToSrc] = pathway[4]
+    const [AToBConfirmationsDefinition, BToAConfirmationsDefinition] = pathway[3]
+    const [enforcedOptionsAToB, enforcedOptionsBToA] = pathway[4]
 
     const optionalDVNs = optionalDVNConfig[0]
     const optionalDVNThreshold = optionalDVNConfig[1] || 0
@@ -93,125 +93,179 @@ export async function translatePathwayToConfig(
         throw new Error(`Optional DVN threshold is greater than the number of optional DVNs.`)
     }
 
-    const sourceLZDeployment = getEndpointIdDeployment(sourceContract.eid, metadata)
-    const destinationLZDeployment = getEndpointIdDeployment(destinationContract.eid, metadata)
+    const ALZDeployment = getEndpointIdDeployment(AContract.eid, metadata)
+    const BLZDeployment = getEndpointIdDeployment(BContract.eid, metadata)
 
-    const sourceExecutor = isSolanaDeployment(sourceLZDeployment)
-        ? sourceLZDeployment.executor?.pda
-        : sourceLZDeployment.executor?.address
+    const AExecutor = isSolanaDeployment(ALZDeployment) ? ALZDeployment.executor?.pda : ALZDeployment.executor?.address
 
-    if (!sourceExecutor) {
-        throw new Error(`Can't find executor for source endpoint with eid: "${sourceContract.eid}".`)
+    if (!AExecutor) {
+        throw new Error(`Can't find executor for endpoint with eid: "${AContract.eid}".`)
     }
 
-    const sourceRequiredDVNs = DVNsToAddresses(requiredDVNs, sourceLZDeployment.chainKey, metadata)
-    const destinationRequiredDVNs = DVNsToAddresses(requiredDVNs, destinationLZDeployment.chainKey, metadata)
+    const ARequiredDVNs = DVNsToAddresses(requiredDVNs, ALZDeployment.chainKey, metadata)
+    const BRequiredDVNs = DVNsToAddresses(requiredDVNs, BLZDeployment.chainKey, metadata)
+    const requiredDVNCount = requiredDVNs.length > 0 ? requiredDVNs.length : NIL_DVN_COUNT
 
-    let sourceOptionalDVNs: string[] = []
-    let destinationOptionalDVNs: string[] = []
+    let AOptionalDVNs: string[] = []
+    let BOptionalDVNs: string[] = []
 
     if (optionalDVNs) {
-        sourceOptionalDVNs = DVNsToAddresses(optionalDVNs, sourceLZDeployment.chainKey, metadata)
-        destinationOptionalDVNs = DVNsToAddresses(optionalDVNs, destinationLZDeployment.chainKey, metadata)
+        AOptionalDVNs = DVNsToAddresses(optionalDVNs, ALZDeployment.chainKey, metadata)
+        BOptionalDVNs = DVNsToAddresses(optionalDVNs, BLZDeployment.chainKey, metadata)
     }
 
-    if (!sourceLZDeployment.sendUln302 || !sourceLZDeployment.receiveUln302 || !sourceLZDeployment.executor) {
-        throw new Error(
-            `Can't find sendUln302, receiveUln302 or executor for source endpoint with eid: "${sourceContract.eid}".`
-        )
+    const AToBConfirmations: number =
+        typeof AToBConfirmationsDefinition === 'number' ? AToBConfirmationsDefinition : AToBConfirmationsDefinition[0]
+    const BToAConfirmations: number | undefined =
+        typeof BToAConfirmationsDefinition === 'number' ? BToAConfirmationsDefinition : BToAConfirmationsDefinition?.[0]
+
+    const blockSendAToB: boolean = Boolean(
+        AToBConfirmationsDefinition &&
+            typeof AToBConfirmationsDefinition !== 'number' &&
+            AToBConfirmationsDefinition[1] === BLOCKED_MESSAGE_LIB_INDICATOR
+    )
+    const blockSendBToA: boolean = Boolean(
+        BToAConfirmationsDefinition &&
+            typeof BToAConfirmationsDefinition !== 'number' &&
+            BToAConfirmationsDefinition[1] === BLOCKED_MESSAGE_LIB_INDICATOR
+    )
+
+    const sendLibraryAToBMetadataKey = blockSendAToB
+        ? isSolanaDeployment(ALZDeployment)
+            ? 'blocked_messagelib'
+            : 'blockedMessageLib'
+        : 'sendUln302'
+    const sendLibraryBToAMetadataKey = blockSendBToA
+        ? isSolanaDeployment(BLZDeployment)
+            ? 'blocked_messagelib'
+            : 'blockedMessageLib'
+        : 'sendUln302'
+
+    const receiveLibraryBFromAMetadataKey = blockSendAToB
+        ? isSolanaDeployment(BLZDeployment)
+            ? 'blocked_messagelib'
+            : 'blockedMessageLib'
+        : 'receiveUln302'
+    const receiveLibraryAFromBMetadataKey = blockSendBToA
+        ? isSolanaDeployment(ALZDeployment)
+            ? 'blocked_messagelib'
+            : 'blockedMessageLib'
+        : 'receiveUln302'
+
+    if (!ALZDeployment[sendLibraryAToBMetadataKey]) {
+        throw new Error(`Can't find ${sendLibraryAToBMetadataKey} for endpoint with eid: "${AContract.eid}".`)
     }
 
-    if (
-        !destinationLZDeployment.sendUln302 ||
-        !destinationLZDeployment.receiveUln302 ||
-        !destinationLZDeployment.executor
-    ) {
-        throw new Error(
-            `Can't find sendUln302, receiveUln302 or executor for destination endpoint with eid: "${destinationContract.eid}".`
-        )
+    if (!ALZDeployment[receiveLibraryAFromBMetadataKey]) {
+        throw new Error(`Can't find ${receiveLibraryAFromBMetadataKey} for endpoint with eid: "${AContract.eid}".`)
     }
 
-    const sourceToDestinationConfig: OmniEdgeHardhat<OAppEdgeConfig> = {
-        from: sourceContract,
-        to: destinationContract,
+    if (!BLZDeployment[sendLibraryBToAMetadataKey]) {
+        throw new Error(`Can't find ${sendLibraryBToAMetadataKey} for endpoint with eid: "${BContract.eid}".`)
+    }
+
+    if (!BLZDeployment[receiveLibraryBFromAMetadataKey]) {
+        throw new Error(`Can't find ${receiveLibraryBFromAMetadataKey} for endpoint with eid: "${BContract.eid}".`)
+    }
+
+    if (!ALZDeployment.executor) {
+        throw new Error(`Can't find executor for endpoint with eid: "${AContract.eid}".`)
+    }
+
+    const sendLibraryAToB = ALZDeployment[sendLibraryAToBMetadataKey].address
+    const receiveLibraryAFromB = ALZDeployment[receiveLibraryAFromBMetadataKey].address
+    const sendLibraryBToA = BLZDeployment[sendLibraryBToAMetadataKey].address
+    const receiveLibraryBFromA = BLZDeployment[receiveLibraryBFromAMetadataKey].address
+
+    if (!BLZDeployment.executor) {
+        throw new Error(`Can't find executor for endpoint with eid: "${BContract.eid}".`)
+    }
+
+    const AToBConfig: OmniEdgeHardhat<OAppEdgeConfig> = {
+        from: AContract,
+        to: BContract,
         config: {
-            sendLibrary: sourceLZDeployment.sendUln302.address,
+            sendLibrary: sendLibraryAToB,
             receiveLibraryConfig: {
-                receiveLibrary: sourceLZDeployment.receiveUln302.address,
+                receiveLibrary: receiveLibraryAFromB,
                 gracePeriod: BigInt(0),
             },
             sendConfig: {
                 executorConfig: {
                     maxMessageSize: 10000,
-                    executor: sourceExecutor,
+                    executor: AExecutor,
                 },
                 ulnConfig: {
-                    confirmations: BigInt(sourceToDestinationConfirmations),
-                    requiredDVNs: sourceRequiredDVNs,
-                    optionalDVNs: sourceOptionalDVNs,
+                    confirmations: BigInt(AToBConfirmations),
+                    requiredDVNs: ARequiredDVNs,
+                    requiredDVNCount,
+                    optionalDVNs: AOptionalDVNs,
                     optionalDVNThreshold,
                 },
             },
-            enforcedOptions: enforcedOptionsSrcToDst,
+            enforcedOptions: enforcedOptionsAToB,
         },
     }
 
-    const destinationToSourceConfig: OmniEdgeHardhat<OAppEdgeConfig> = {
-        from: destinationContract,
-        to: sourceContract,
+    const BToAConfig: OmniEdgeHardhat<OAppEdgeConfig> = {
+        from: BContract,
+        to: AContract,
         config: {
-            sendLibrary: destinationLZDeployment.sendUln302.address,
+            sendLibrary: sendLibraryBToA,
             receiveLibraryConfig: {
-                receiveLibrary: destinationLZDeployment.receiveUln302.address,
+                receiveLibrary: receiveLibraryBFromA,
                 gracePeriod: BigInt(0),
             },
             receiveConfig: {
                 ulnConfig: {
-                    confirmations: BigInt(sourceToDestinationConfirmations),
-                    requiredDVNs: destinationRequiredDVNs,
-                    optionalDVNs: destinationOptionalDVNs,
+                    confirmations: BigInt(AToBConfirmations),
+                    requiredDVNs: BRequiredDVNs,
+                    requiredDVNCount,
+                    optionalDVNs: BOptionalDVNs,
                     optionalDVNThreshold,
                 },
             },
         },
     }
 
-    if (destinationToSourceConfirmations) {
-        const destinationExecutor = isSolanaDeployment(destinationLZDeployment)
-            ? destinationLZDeployment.executor?.pda
-            : destinationLZDeployment.executor?.address
+    if (BToAConfirmations) {
+        const BExecutor = isSolanaDeployment(BLZDeployment)
+            ? BLZDeployment.executor?.pda
+            : BLZDeployment.executor?.address
 
-        if (!destinationExecutor) {
-            throw new Error(`Can't find executor for destination endpoint with eid: "${destinationContract.eid}".`)
+        if (!BExecutor) {
+            throw new Error(`Can't find executor for destination endpoint with eid: "${BContract.eid}".`)
         }
 
-        sourceToDestinationConfig.config.receiveConfig = {
+        AToBConfig.config.receiveConfig = {
             ulnConfig: {
-                confirmations: BigInt(destinationToSourceConfirmations),
-                requiredDVNs: sourceRequiredDVNs,
-                optionalDVNs: sourceOptionalDVNs,
+                confirmations: BigInt(BToAConfirmations),
+                requiredDVNs: ARequiredDVNs,
+                requiredDVNCount,
+                optionalDVNs: AOptionalDVNs,
                 optionalDVNThreshold,
             },
         }
 
-        destinationToSourceConfig.config.enforcedOptions = enforcedOptionsDstToSrc
+        BToAConfig.config.enforcedOptions = enforcedOptionsBToA
 
-        destinationToSourceConfig.config.sendConfig = {
+        BToAConfig.config.sendConfig = {
             executorConfig: {
                 maxMessageSize: 10000,
-                executor: destinationExecutor,
+                executor: BExecutor,
             },
             ulnConfig: {
-                confirmations: BigInt(destinationToSourceConfirmations),
-                requiredDVNs: destinationRequiredDVNs,
-                optionalDVNs: destinationOptionalDVNs,
+                confirmations: BigInt(BToAConfirmations),
+                requiredDVNs: BRequiredDVNs,
+                requiredDVNCount,
+                optionalDVNs: BOptionalDVNs,
                 optionalDVNThreshold,
             },
         }
     }
 
-    configs.push(sourceToDestinationConfig)
-    configs.push(destinationToSourceConfig)
+    configs.push(AToBConfig)
+    configs.push(BToAConfig)
 
     return configs
 }

--- a/packages/metadata-tools/src/config-metadata.ts
+++ b/packages/metadata-tools/src/config-metadata.ts
@@ -1,8 +1,18 @@
 import type { OmniEdgeHardhat } from '@layerzerolabs/devtools-evm-hardhat'
 import type { OAppEdgeConfig } from '@layerzerolabs/ua-devtools'
-import { BlockConfirmationsType, IMetadata } from './types'
+import { BlockConfirmationsDefinition, BlockConfirmationsType, IMetadata } from './types'
 import { TwoWayConfig } from './types'
-import { BLOCKED_MESSAGE_LIB_INDICATOR, METADATA_URL, NIL_DVN_COUNT } from './constants'
+import {
+    METADATA_KEY_EVM_BLOCKED_MESSAGE,
+    METADATA_KEY_RECEIVE_LIBRARY,
+    METADATA_KEY_SEND_LIBRARY,
+    METADATA_KEY_SOLANA_BLOCKED_MESSAGE,
+    METADATA_URL,
+    MSG_LIB_BLOCK_RECEIVE_ONLY,
+    MSG_LIB_BLOCK_SEND_AND_RECEIVE,
+    MSG_LIB_BLOCK_SEND_ONLY,
+    NIL_DVN_COUNT,
+} from './constants'
 
 function getEndpointIdDeployment(eid: number, metadata: IMetadata) {
     const srcEidString = eid.toString()
@@ -74,6 +84,41 @@ function isSolanaDeployment(deployment: { chainKey: string; executor?: { pda?: s
     return deployment.chainKey.startsWith('solana')
 }
 
+// Helper to resolve library metadata key based on operation and chain
+function resolveLibraryMetadataKey(isSend: boolean, isBlocked: boolean, deployment: { chainKey: string }) {
+    if (isBlocked) {
+        return isSolanaDeployment(deployment) ? METADATA_KEY_SOLANA_BLOCKED_MESSAGE : METADATA_KEY_EVM_BLOCKED_MESSAGE
+    }
+    return isSend ? METADATA_KEY_SEND_LIBRARY : METADATA_KEY_RECEIVE_LIBRARY
+}
+
+// Helper to assert presence of a metadata key on a deployment
+function assertHasKey(deployment: Record<string, any>, key: string, eid: number) {
+    if (!deployment[key]) {
+        throw new Error(`Can't find ${key} for endpoint with eid: "${eid}".`)
+    }
+}
+
+function getExecutor(deployment: { chainKey: string; executor?: { pda?: string; address?: string } }, eid: number) {
+    const executor = isSolanaDeployment(deployment) ? deployment.executor?.pda : deployment.executor?.address
+
+    if (!executor) {
+        throw new Error(`Can't find executor for endpoint with eid: "${eid}".`)
+    }
+
+    return executor
+}
+
+function isBlocked(blockConfirmationsDefinition: BlockConfirmationsDefinition | undefined, isSend: boolean): boolean {
+    const keys = [MSG_LIB_BLOCK_SEND_AND_RECEIVE, isSend ? MSG_LIB_BLOCK_SEND_ONLY : MSG_LIB_BLOCK_RECEIVE_ONLY]
+
+    return Boolean(
+        blockConfirmationsDefinition &&
+            typeof blockConfirmationsDefinition === 'object' &&
+            keys.includes(blockConfirmationsDefinition[1])
+    )
+}
+
 export async function translatePathwayToConfig(
     pathway: TwoWayConfig,
     metadata: IMetadata
@@ -96,11 +141,7 @@ export async function translatePathwayToConfig(
     const ALZDeployment = getEndpointIdDeployment(AContract.eid, metadata)
     const BLZDeployment = getEndpointIdDeployment(BContract.eid, metadata)
 
-    const AExecutor = isSolanaDeployment(ALZDeployment) ? ALZDeployment.executor?.pda : ALZDeployment.executor?.address
-
-    if (!AExecutor) {
-        throw new Error(`Can't find executor for endpoint with eid: "${AContract.eid}".`)
-    }
+    const AExecutor = getExecutor(ALZDeployment, AContract.eid)
 
     const ARequiredDVNs = DVNsToAddresses(requiredDVNs, ALZDeployment.chainKey, metadata)
     const BRequiredDVNs = DVNsToAddresses(requiredDVNs, BLZDeployment.chainKey, metadata)
@@ -123,67 +164,25 @@ export async function translatePathwayToConfig(
         ? BToAConfirmationsDefinition
         : BToAConfirmationsDefinition?.[0]
 
-    const blockSendAToB: boolean = Boolean(
-        AToBConfirmationsDefinition &&
-            !['bigint', 'number'].includes(typeof AToBConfirmationsDefinition) &&
-            AToBConfirmationsDefinition[1] === BLOCKED_MESSAGE_LIB_INDICATOR
-    )
-    const blockSendBToA: boolean = Boolean(
-        BToAConfirmationsDefinition &&
-            !['bigint', 'number'].includes(typeof BToAConfirmationsDefinition) &&
-            BToAConfirmationsDefinition[1] === BLOCKED_MESSAGE_LIB_INDICATOR
-    )
+    const blockSendAToB = isBlocked(AToBConfirmationsDefinition, true)
+    const blockReceiveAToB = isBlocked(AToBConfirmationsDefinition, false)
+    const blockSendBToA = isBlocked(BToAConfirmationsDefinition, true)
+    const blockReceiveBToA = isBlocked(BToAConfirmationsDefinition, false)
 
-    const sendLibraryAToBMetadataKey = blockSendAToB
-        ? isSolanaDeployment(ALZDeployment)
-            ? 'blocked_messagelib'
-            : 'blockedMessageLib'
-        : 'sendUln302'
-    const sendLibraryBToAMetadataKey = blockSendBToA
-        ? isSolanaDeployment(BLZDeployment)
-            ? 'blocked_messagelib'
-            : 'blockedMessageLib'
-        : 'sendUln302'
+    const sendLibraryAToBMetadataKey = resolveLibraryMetadataKey(true, blockSendAToB, ALZDeployment)
+    const receiveLibraryAToBMetadataKey = resolveLibraryMetadataKey(false, blockReceiveAToB, BLZDeployment)
+    const sendLibraryBToAMetadataKey = resolveLibraryMetadataKey(true, blockSendBToA, BLZDeployment)
+    const receiveLibraryBToAMetadataKey = resolveLibraryMetadataKey(false, blockReceiveBToA, ALZDeployment)
 
-    const receiveLibraryBFromAMetadataKey = blockSendAToB
-        ? isSolanaDeployment(BLZDeployment)
-            ? 'blocked_messagelib'
-            : 'blockedMessageLib'
-        : 'receiveUln302'
-    const receiveLibraryAFromBMetadataKey = blockSendBToA
-        ? isSolanaDeployment(ALZDeployment)
-            ? 'blocked_messagelib'
-            : 'blockedMessageLib'
-        : 'receiveUln302'
-
-    if (!ALZDeployment[sendLibraryAToBMetadataKey]) {
-        throw new Error(`Can't find ${sendLibraryAToBMetadataKey} for endpoint with eid: "${AContract.eid}".`)
-    }
-
-    if (!ALZDeployment[receiveLibraryAFromBMetadataKey]) {
-        throw new Error(`Can't find ${receiveLibraryAFromBMetadataKey} for endpoint with eid: "${AContract.eid}".`)
-    }
-
-    if (!BLZDeployment[sendLibraryBToAMetadataKey]) {
-        throw new Error(`Can't find ${sendLibraryBToAMetadataKey} for endpoint with eid: "${BContract.eid}".`)
-    }
-
-    if (!BLZDeployment[receiveLibraryBFromAMetadataKey]) {
-        throw new Error(`Can't find ${receiveLibraryBFromAMetadataKey} for endpoint with eid: "${BContract.eid}".`)
-    }
-
-    if (!ALZDeployment.executor) {
-        throw new Error(`Can't find executor for endpoint with eid: "${AContract.eid}".`)
-    }
+    assertHasKey(ALZDeployment, sendLibraryAToBMetadataKey, AContract.eid)
+    assertHasKey(BLZDeployment, receiveLibraryAToBMetadataKey, BContract.eid)
+    assertHasKey(BLZDeployment, sendLibraryBToAMetadataKey, BContract.eid)
+    assertHasKey(ALZDeployment, receiveLibraryBToAMetadataKey, AContract.eid)
 
     const sendLibraryAToB = ALZDeployment[sendLibraryAToBMetadataKey].address
-    const receiveLibraryAFromB = ALZDeployment[receiveLibraryAFromBMetadataKey].address
+    const receiveLibraryAToB = BLZDeployment[receiveLibraryAToBMetadataKey].address
     const sendLibraryBToA = BLZDeployment[sendLibraryBToAMetadataKey].address
-    const receiveLibraryBFromA = BLZDeployment[receiveLibraryBFromAMetadataKey].address
-
-    if (!BLZDeployment.executor) {
-        throw new Error(`Can't find executor for endpoint with eid: "${BContract.eid}".`)
-    }
+    const receiveLibraryBToA = ALZDeployment[receiveLibraryBToAMetadataKey].address
 
     const AToBConfig: OmniEdgeHardhat<OAppEdgeConfig> = {
         from: AContract,
@@ -191,7 +190,7 @@ export async function translatePathwayToConfig(
         config: {
             sendLibrary: sendLibraryAToB,
             receiveLibraryConfig: {
-                receiveLibrary: receiveLibraryAFromB,
+                receiveLibrary: receiveLibraryBToA,
                 gracePeriod: BigInt(0),
             },
             sendConfig: {
@@ -217,7 +216,7 @@ export async function translatePathwayToConfig(
         config: {
             sendLibrary: sendLibraryBToA,
             receiveLibraryConfig: {
-                receiveLibrary: receiveLibraryBFromA,
+                receiveLibrary: receiveLibraryAToB,
                 gracePeriod: BigInt(0),
             },
             receiveConfig: {
@@ -233,13 +232,7 @@ export async function translatePathwayToConfig(
     }
 
     if (BToAConfirmations) {
-        const BExecutor = isSolanaDeployment(BLZDeployment)
-            ? BLZDeployment.executor?.pda
-            : BLZDeployment.executor?.address
-
-        if (!BExecutor) {
-            throw new Error(`Can't find executor for destination endpoint with eid: "${BContract.eid}".`)
-        }
+        const BExecutor = getExecutor(BLZDeployment, BContract.eid)
 
         AToBConfig.config.receiveConfig = {
             ulnConfig: {

--- a/packages/metadata-tools/src/constants.ts
+++ b/packages/metadata-tools/src/constants.ts
@@ -1,7 +1,7 @@
 export const METADATA_URL = process.env.LZ_METADATA_URL || 'https://metadata.layerzero-api.com/v1/metadata'
 // A value used to indicate that no DVNs are required. It has to be used instead of 0, because 0 falls back to default value.
-export const NIL_DVN_COUNT = 255 // type(uint8).max;
+export const NIL_DVN_COUNT = (1 << 8) - 1 // type(uint8).max;
 // A value used to indicate that no confirmations are required. It has to be used instead of 0, because 0 falls back to default value.
-export const NIL_CONFIRMATIONS = 0 // type(uint64).max;
+export const NIL_CONFIRMATIONS = (BigInt(1) << BigInt(64)) - BigInt(1) // type(uint64).max;
 // A value used to indicate to use the blocked message library.
 export const BLOCKED_MESSAGE_LIB_INDICATOR = 'BLOCKED'

--- a/packages/metadata-tools/src/constants.ts
+++ b/packages/metadata-tools/src/constants.ts
@@ -1,1 +1,7 @@
 export const METADATA_URL = process.env.LZ_METADATA_URL || 'https://metadata.layerzero-api.com/v1/metadata'
+// A value used to indicate that no DVNs are required. It has to be used instead of 0, because 0 falls back to default value.
+export const NIL_DVN_COUNT = 255 // type(uint8).max;
+// A value used to indicate that no confirmations are required. It has to be used instead of 0, because 0 falls back to default value.
+export const NIL_CONFIRMATIONS = 0 // type(uint64).max;
+// A value used to indicate to use the blocked message library.
+export const BLOCKED_MESSAGE_LIB_INDICATOR = 'BLOCKED'

--- a/packages/metadata-tools/src/constants.ts
+++ b/packages/metadata-tools/src/constants.ts
@@ -3,5 +3,13 @@ export const METADATA_URL = process.env.LZ_METADATA_URL || 'https://metadata.lay
 export const NIL_DVN_COUNT = (1 << 8) - 1 // type(uint8).max;
 // A value used to indicate that no confirmations are required. It has to be used instead of 0, because 0 falls back to default value.
 export const NIL_CONFIRMATIONS = (BigInt(1) << BigInt(64)) - BigInt(1) // type(uint64).max;
-// A value used to indicate to use the blocked message library.
-export const BLOCKED_MESSAGE_LIB_INDICATOR = 'BLOCKED'
+
+export const MSG_LIB_BLOCK_SEND_AND_RECEIVE = 'BLOCK_SEND_AND_RECEIVE'
+export const MSG_LIB_BLOCK_SEND_ONLY = 'BLOCK_SEND_ONLY'
+export const MSG_LIB_BLOCK_RECEIVE_ONLY = 'BLOCK_RECEIVE_ONLY'
+
+// Constants for metadata key names
+export const METADATA_KEY_SOLANA_BLOCKED_MESSAGE = 'blocked_messagelib'
+export const METADATA_KEY_EVM_BLOCKED_MESSAGE = 'blockedMessageLib'
+export const METADATA_KEY_SEND_LIBRARY = 'sendUln302'
+export const METADATA_KEY_RECEIVE_LIBRARY = 'receiveUln302'

--- a/packages/metadata-tools/src/types.ts
+++ b/packages/metadata-tools/src/types.ts
@@ -3,14 +3,18 @@ import type { OAppEnforcedOption } from '@layerzerolabs/ua-devtools'
 
 import { BLOCKED_MESSAGE_LIB_INDICATOR } from './constants'
 
-export type CUSTOM_MESSAGE_LIBRARY_TYPE = typeof BLOCKED_MESSAGE_LIB_INDICATOR
+export type CustomMessageLibraryType = typeof BLOCKED_MESSAGE_LIB_INDICATOR
+export type BlockConfirmationsType = number | bigint
 
 // [AContract, BContract, [requiredDVNs, [optionalDVNs, threshold]], [AToBConfirmations, BToAConfirmations]], [enforcedOptionsAToB, enforcedOptionsBToA]
 export type TwoWayConfig = [
     OmniPointHardhat, // AContract
     OmniPointHardhat, // BContract
     [string[], [string[], number] | []], // [requiredDVNs, [optionalDVNs, threshold]]
-    [number | [number, CUSTOM_MESSAGE_LIBRARY_TYPE], number | [number, CUSTOM_MESSAGE_LIBRARY_TYPE] | undefined], // [AToBConfirmations, BToAConfirmations]
+    [
+        BlockConfirmationsType | [BlockConfirmationsType, CustomMessageLibraryType],
+        BlockConfirmationsType | [BlockConfirmationsType, CustomMessageLibraryType] | undefined,
+    ], // [AToBConfirmations, BToAConfirmations]
     [OAppEnforcedOption[] | undefined, OAppEnforcedOption[] | undefined], // [enforcedOptionsAToB, enforcedOptionsBToA]
 ]
 

--- a/packages/metadata-tools/src/types.ts
+++ b/packages/metadata-tools/src/types.ts
@@ -1,20 +1,20 @@
 import type { OmniPointHardhat } from '@layerzerolabs/devtools-evm-hardhat'
 import type { OAppEnforcedOption } from '@layerzerolabs/ua-devtools'
+import { MSG_LIB_BLOCK_RECEIVE_ONLY, MSG_LIB_BLOCK_SEND_AND_RECEIVE, MSG_LIB_BLOCK_SEND_ONLY } from './constants'
 
-import { BLOCKED_MESSAGE_LIB_INDICATOR } from './constants'
-
-export type CustomMessageLibraryType = typeof BLOCKED_MESSAGE_LIB_INDICATOR
+export type CustomMessageLibraryType =
+    | typeof MSG_LIB_BLOCK_SEND_ONLY
+    | typeof MSG_LIB_BLOCK_RECEIVE_ONLY
+    | typeof MSG_LIB_BLOCK_SEND_AND_RECEIVE
 export type BlockConfirmationsType = number | bigint
+export type BlockConfirmationsDefinition = BlockConfirmationsType | [BlockConfirmationsType, CustomMessageLibraryType]
 
 // [AContract, BContract, [requiredDVNs, [optionalDVNs, threshold]], [AToBConfirmations, BToAConfirmations]], [enforcedOptionsAToB, enforcedOptionsBToA]
 export type TwoWayConfig = [
     OmniPointHardhat, // AContract
     OmniPointHardhat, // BContract
     [string[], [string[], number] | []], // [requiredDVNs, [optionalDVNs, threshold]]
-    [
-        BlockConfirmationsType | [BlockConfirmationsType, CustomMessageLibraryType],
-        BlockConfirmationsType | [BlockConfirmationsType, CustomMessageLibraryType] | undefined,
-    ], // [AToBConfirmations, BToAConfirmations]
+    [BlockConfirmationsDefinition, BlockConfirmationsDefinition | undefined], // [AToBConfirmations, BToAConfirmations]
     [OAppEnforcedOption[] | undefined, OAppEnforcedOption[] | undefined], // [enforcedOptionsAToB, enforcedOptionsBToA]
 ]
 

--- a/packages/metadata-tools/src/types.ts
+++ b/packages/metadata-tools/src/types.ts
@@ -1,13 +1,17 @@
 import type { OmniPointHardhat } from '@layerzerolabs/devtools-evm-hardhat'
 import type { OAppEnforcedOption } from '@layerzerolabs/ua-devtools'
 
-// [srcContract, dstContract, [requiredDVNs, [optionalDVNs, threshold]], [srcToDstConfirmations, dstToSrcConfirmations]], [enforcedOptionsSrcToDst, enforcedOptionsDstToSrc]
+import { BLOCKED_MESSAGE_LIB_INDICATOR } from './constants'
+
+export type CUSTOM_MESSAGE_LIBRARY_TYPE = typeof BLOCKED_MESSAGE_LIB_INDICATOR
+
+// [AContract, BContract, [requiredDVNs, [optionalDVNs, threshold]], [AToBConfirmations, BToAConfirmations]], [enforcedOptionsAToB, enforcedOptionsBToA]
 export type TwoWayConfig = [
-    OmniPointHardhat, // srcContract
-    OmniPointHardhat, // dstContract
+    OmniPointHardhat, // AContract
+    OmniPointHardhat, // BContract
     [string[], [string[], number] | []], // [requiredDVNs, [optionalDVNs, threshold]]
-    [number, number | undefined], // [srcToDstConfirmations, dstToSrcConfirmations]
-    [OAppEnforcedOption[] | undefined, OAppEnforcedOption[] | undefined], // [enforcedOptionsSrcToDst, enforcedOptionsDstToSrc]
+    [number | [number, CUSTOM_MESSAGE_LIBRARY_TYPE], number | [number, CUSTOM_MESSAGE_LIBRARY_TYPE] | undefined], // [AToBConfirmations, BToAConfirmations]
+    [OAppEnforcedOption[] | undefined, OAppEnforcedOption[] | undefined], // [enforcedOptionsAToB, enforcedOptionsBToA]
 ]
 
 export interface IMetadataDvns {
@@ -40,6 +44,7 @@ export interface IMetadata {
             deadDVN?: { address: string }
             endpointV2?: { address: string }
             sendUln302?: { address: string }
+            blockedMessageLib?: { address: string }
             lzExecutor?: { address: string }
             sendUln301?: { address: string }
             receiveUln301?: { address: string }

--- a/packages/metadata-tools/test/__snapshots__/config-metadata.test.ts.snap
+++ b/packages/metadata-tools/test/__snapshots__/config-metadata.test.ts.snap
@@ -484,15 +484,15 @@ exports[`config-metadata generateConnectionsConfig supports using block send and
           ],
         },
       },
-      "sendLibrary": "0x0c77d8d771ab35e2e184e7ce127f19ced31ff8c0",
+      "sendLibrary": "0x0C77d8d771aB35E2E184E7cE127f19CEd31FF8C0",
     },
     "from": {
       "contractName": "MyOFT",
       "eid": 40106,
     },
     "to": {
-      "address": "HBTWw2VKNLuDBjg9e5dArxo5axJRX8csCEBcCo3CFdAy",
-      "eid": 40168,
+      "contractName": "MyOFT",
+      "eid": 40267,
     },
   },
   {
@@ -505,17 +505,17 @@ exports[`config-metadata generateConnectionsConfig supports using block send and
           "optionalDVNs": [],
           "requiredDVNCount": 1,
           "requiredDVNs": [
-            "4VDjp6XQaxoZf5RGwiPU9NR1EXSZn2TP4ATMmiSzLfhb",
+            "0x55c175dd5b039331db251424538169d8495c18d1",
           ],
         },
       },
       "receiveLibraryConfig": {
         "gracePeriod": 0n,
-        "receiveLibrary": "2XrYqmhBMPJgDsb4SVbjV1PnJBprurd5bzRCkHwiFCJB",
+        "receiveLibrary": "0x0C77d8d771aB35E2E184E7cE127f19CEd31FF8C0",
       },
       "sendConfig": {
         "executorConfig": {
-          "executor": "AwrbHeCyniXaQhiJZkLhgWdUCteeWSGaSN1sTfLiY7xK",
+          "executor": "0x4Cf1B3Fa61465c2c907f82fC488B43223BA0CF93",
           "maxMessageSize": 10000,
         },
         "ulnConfig": {
@@ -524,15 +524,15 @@ exports[`config-metadata generateConnectionsConfig supports using block send and
           "optionalDVNs": [],
           "requiredDVNCount": 1,
           "requiredDVNs": [
-            "4VDjp6XQaxoZf5RGwiPU9NR1EXSZn2TP4ATMmiSzLfhb",
+            "0x55c175dd5b039331db251424538169d8495c18d1",
           ],
         },
       },
-      "sendLibrary": "7a4WjyR8VZ7yZz5XJAKm39BUGn5iT9CKcv2pmG9tdXVH",
+      "sendLibrary": "0x1d186C560281B8F1AF831957ED5047fD3AB902F9",
     },
     "from": {
-      "address": "HBTWw2VKNLuDBjg9e5dArxo5axJRX8csCEBcCo3CFdAy",
-      "eid": 40168,
+      "contractName": "MyOFT",
+      "eid": 40267,
     },
     "to": {
       "contractName": "MyOFT",
@@ -560,7 +560,7 @@ exports[`config-metadata generateConnectionsConfig supports using block send and
       },
       "receiveLibraryConfig": {
         "gracePeriod": 0n,
-        "receiveLibrary": "0x0c77d8d771ab35e2e184e7ce127f19ced31ff8c0",
+        "receiveLibrary": "0x0C77d8d771aB35E2E184E7cE127f19CEd31FF8C0",
       },
       "sendConfig": {
         "executorConfig": {
@@ -577,15 +577,15 @@ exports[`config-metadata generateConnectionsConfig supports using block send and
           ],
         },
       },
-      "sendLibrary": "0x0c77d8d771ab35e2e184e7ce127f19ced31ff8c0",
+      "sendLibrary": "0x0C77d8d771aB35E2E184E7cE127f19CEd31FF8C0",
     },
     "from": {
       "contractName": "MyOFT",
       "eid": 40106,
     },
     "to": {
-      "address": "HBTWw2VKNLuDBjg9e5dArxo5axJRX8csCEBcCo3CFdAy",
-      "eid": 40168,
+      "contractName": "MyOFT",
+      "eid": 40267,
     },
   },
   {
@@ -598,17 +598,17 @@ exports[`config-metadata generateConnectionsConfig supports using block send and
           "optionalDVNs": [],
           "requiredDVNCount": 1,
           "requiredDVNs": [
-            "4VDjp6XQaxoZf5RGwiPU9NR1EXSZn2TP4ATMmiSzLfhb",
+            "0x55c175dd5b039331db251424538169d8495c18d1",
           ],
         },
       },
       "receiveLibraryConfig": {
         "gracePeriod": 0n,
-        "receiveLibrary": "2XrYqmhBMPJgDsb4SVbjV1PnJBprurd5bzRCkHwiFCJB",
+        "receiveLibrary": "0x0C77d8d771aB35E2E184E7cE127f19CEd31FF8C0",
       },
       "sendConfig": {
         "executorConfig": {
-          "executor": "AwrbHeCyniXaQhiJZkLhgWdUCteeWSGaSN1sTfLiY7xK",
+          "executor": "0x4Cf1B3Fa61465c2c907f82fC488B43223BA0CF93",
           "maxMessageSize": 10000,
         },
         "ulnConfig": {
@@ -617,15 +617,15 @@ exports[`config-metadata generateConnectionsConfig supports using block send and
           "optionalDVNs": [],
           "requiredDVNCount": 1,
           "requiredDVNs": [
-            "4VDjp6XQaxoZf5RGwiPU9NR1EXSZn2TP4ATMmiSzLfhb",
+            "0x55c175dd5b039331db251424538169d8495c18d1",
           ],
         },
       },
-      "sendLibrary": "2XrYqmhBMPJgDsb4SVbjV1PnJBprurd5bzRCkHwiFCJB",
+      "sendLibrary": "0x0C77d8d771aB35E2E184E7cE127f19CEd31FF8C0",
     },
     "from": {
-      "address": "HBTWw2VKNLuDBjg9e5dArxo5axJRX8csCEBcCo3CFdAy",
-      "eid": 40168,
+      "contractName": "MyOFT",
+      "eid": 40267,
     },
     "to": {
       "contractName": "MyOFT",

--- a/packages/metadata-tools/test/__snapshots__/config-metadata.test.ts.snap
+++ b/packages/metadata-tools/test/__snapshots__/config-metadata.test.ts.snap
@@ -10,6 +10,7 @@ exports[`config-metadata generateConnectionsConfig should allow for call without
           "confirmations": 1n,
           "optionalDVNThreshold": 0,
           "optionalDVNs": [],
+          "requiredDVNCount": 1,
           "requiredDVNs": [
             "0x9f0e79aeb198750f963b6f30b99d87c6ee5a0467",
           ],
@@ -28,6 +29,7 @@ exports[`config-metadata generateConnectionsConfig should allow for call without
           "confirmations": 1n,
           "optionalDVNThreshold": 0,
           "optionalDVNs": [],
+          "requiredDVNCount": 1,
           "requiredDVNs": [
             "0x9f0e79aeb198750f963b6f30b99d87c6ee5a0467",
           ],
@@ -52,6 +54,7 @@ exports[`config-metadata generateConnectionsConfig should allow for call without
           "confirmations": 1n,
           "optionalDVNThreshold": 0,
           "optionalDVNs": [],
+          "requiredDVNCount": 1,
           "requiredDVNs": [
             "4VDjp6XQaxoZf5RGwiPU9NR1EXSZn2TP4ATMmiSzLfhb",
           ],
@@ -70,6 +73,7 @@ exports[`config-metadata generateConnectionsConfig should allow for call without
           "confirmations": 1n,
           "optionalDVNThreshold": 0,
           "optionalDVNs": [],
+          "requiredDVNCount": 1,
           "requiredDVNs": [
             "4VDjp6XQaxoZf5RGwiPU9NR1EXSZn2TP4ATMmiSzLfhb",
           ],
@@ -99,6 +103,7 @@ exports[`config-metadata generateConnectionsConfig should allow for custom DVNs 
           "confirmations": 1n,
           "optionalDVNThreshold": 0,
           "optionalDVNs": [],
+          "requiredDVNCount": 1,
           "requiredDVNs": [
             "0x9f0e79aeb198750f963b6f30b99d87c6ee5a0467",
           ],
@@ -117,6 +122,7 @@ exports[`config-metadata generateConnectionsConfig should allow for custom DVNs 
           "confirmations": 1n,
           "optionalDVNThreshold": 0,
           "optionalDVNs": [],
+          "requiredDVNCount": 1,
           "requiredDVNs": [
             "0x9f0e79aeb198750f963b6f30b99d87c6ee5a0467",
           ],
@@ -141,6 +147,7 @@ exports[`config-metadata generateConnectionsConfig should allow for custom DVNs 
           "confirmations": 1n,
           "optionalDVNThreshold": 0,
           "optionalDVNs": [],
+          "requiredDVNCount": 1,
           "requiredDVNs": [
             "29EKzmCscUg8mf4f5uskwMqvu2SXM8hKF1gWi1cCBoKT",
           ],
@@ -159,6 +166,7 @@ exports[`config-metadata generateConnectionsConfig should allow for custom DVNs 
           "confirmations": 1n,
           "optionalDVNThreshold": 0,
           "optionalDVNs": [],
+          "requiredDVNCount": 1,
           "requiredDVNs": [
             "29EKzmCscUg8mf4f5uskwMqvu2SXM8hKF1gWi1cCBoKT",
           ],
@@ -188,6 +196,7 @@ exports[`config-metadata generateConnectionsConfig should generate the connectio
           "confirmations": 1n,
           "optionalDVNThreshold": 0,
           "optionalDVNs": [],
+          "requiredDVNCount": 1,
           "requiredDVNs": [
             "0x9f0e79aeb198750f963b6f30b99d87c6ee5a0467",
           ],
@@ -206,6 +215,7 @@ exports[`config-metadata generateConnectionsConfig should generate the connectio
           "confirmations": 1n,
           "optionalDVNThreshold": 0,
           "optionalDVNs": [],
+          "requiredDVNCount": 1,
           "requiredDVNs": [
             "0x9f0e79aeb198750f963b6f30b99d87c6ee5a0467",
           ],
@@ -230,6 +240,7 @@ exports[`config-metadata generateConnectionsConfig should generate the connectio
           "confirmations": 1n,
           "optionalDVNThreshold": 0,
           "optionalDVNs": [],
+          "requiredDVNCount": 1,
           "requiredDVNs": [
             "4VDjp6XQaxoZf5RGwiPU9NR1EXSZn2TP4ATMmiSzLfhb",
           ],
@@ -248,9 +259,378 @@ exports[`config-metadata generateConnectionsConfig should generate the connectio
           "confirmations": 1n,
           "optionalDVNThreshold": 0,
           "optionalDVNs": [],
+          "requiredDVNCount": 1,
           "requiredDVNs": [
             "4VDjp6XQaxoZf5RGwiPU9NR1EXSZn2TP4ATMmiSzLfhb",
           ],
+        },
+      },
+      "sendLibrary": "7a4WjyR8VZ7yZz5XJAKm39BUGn5iT9CKcv2pmG9tdXVH",
+    },
+    "from": {
+      "address": "HBTWw2VKNLuDBjg9e5dArxo5axJRX8csCEBcCo3CFdAy",
+      "eid": 40168,
+    },
+    "to": {
+      "contractName": "MyOFT",
+      "eid": 40106,
+    },
+  },
+]
+`;
+
+exports[`config-metadata generateConnectionsConfig supports passing no required DVNs and no optional DVNs 1`] = `
+[
+  {
+    "config": {
+      "enforcedOptions": undefined,
+      "receiveConfig": {
+        "ulnConfig": {
+          "confirmations": 1n,
+          "optionalDVNThreshold": 0,
+          "optionalDVNs": [],
+          "requiredDVNCount": 255,
+          "requiredDVNs": [],
+        },
+      },
+      "receiveLibraryConfig": {
+        "gracePeriod": 0n,
+        "receiveLibrary": "0x819F0FAF2cb1Fba15b9cB24c9A2BDaDb0f895daf",
+      },
+      "sendConfig": {
+        "executorConfig": {
+          "executor": "0xa7BFA9D51032F82D649A501B6a1f922FC2f7d4e3",
+          "maxMessageSize": 10000,
+        },
+        "ulnConfig": {
+          "confirmations": 1n,
+          "optionalDVNThreshold": 0,
+          "optionalDVNs": [],
+          "requiredDVNCount": 255,
+          "requiredDVNs": [],
+        },
+      },
+      "sendLibrary": "0x69BF5f48d2072DfeBc670A1D19dff91D0F4E8170",
+    },
+    "from": {
+      "contractName": "MyOFT",
+      "eid": 40106,
+    },
+    "to": {
+      "address": "HBTWw2VKNLuDBjg9e5dArxo5axJRX8csCEBcCo3CFdAy",
+      "eid": 40168,
+    },
+  },
+  {
+    "config": {
+      "enforcedOptions": undefined,
+      "receiveConfig": {
+        "ulnConfig": {
+          "confirmations": 1n,
+          "optionalDVNThreshold": 0,
+          "optionalDVNs": [],
+          "requiredDVNCount": 255,
+          "requiredDVNs": [],
+        },
+      },
+      "receiveLibraryConfig": {
+        "gracePeriod": 0n,
+        "receiveLibrary": "7a4WjyR8VZ7yZz5XJAKm39BUGn5iT9CKcv2pmG9tdXVH",
+      },
+      "sendConfig": {
+        "executorConfig": {
+          "executor": "AwrbHeCyniXaQhiJZkLhgWdUCteeWSGaSN1sTfLiY7xK",
+          "maxMessageSize": 10000,
+        },
+        "ulnConfig": {
+          "confirmations": 1n,
+          "optionalDVNThreshold": 0,
+          "optionalDVNs": [],
+          "requiredDVNCount": 255,
+          "requiredDVNs": [],
+        },
+      },
+      "sendLibrary": "7a4WjyR8VZ7yZz5XJAKm39BUGn5iT9CKcv2pmG9tdXVH",
+    },
+    "from": {
+      "address": "HBTWw2VKNLuDBjg9e5dArxo5axJRX8csCEBcCo3CFdAy",
+      "eid": 40168,
+    },
+    "to": {
+      "contractName": "MyOFT",
+      "eid": 40106,
+    },
+  },
+]
+`;
+
+exports[`config-metadata generateConnectionsConfig supports using block send library for A to B 1`] = `
+[
+  {
+    "config": {
+      "enforcedOptions": undefined,
+      "receiveConfig": {
+        "ulnConfig": {
+          "confirmations": 1n,
+          "optionalDVNThreshold": 0,
+          "optionalDVNs": [],
+          "requiredDVNCount": 1,
+          "requiredDVNs": [
+            "0x9f0e79aeb198750f963b6f30b99d87c6ee5a0467",
+          ],
+        },
+      },
+      "receiveLibraryConfig": {
+        "gracePeriod": 0n,
+        "receiveLibrary": "0x819F0FAF2cb1Fba15b9cB24c9A2BDaDb0f895daf",
+      },
+      "sendConfig": {
+        "executorConfig": {
+          "executor": "0xa7BFA9D51032F82D649A501B6a1f922FC2f7d4e3",
+          "maxMessageSize": 10000,
+        },
+        "ulnConfig": {
+          "confirmations": 1n,
+          "optionalDVNThreshold": 0,
+          "optionalDVNs": [],
+          "requiredDVNCount": 1,
+          "requiredDVNs": [
+            "0x9f0e79aeb198750f963b6f30b99d87c6ee5a0467",
+          ],
+        },
+      },
+      "sendLibrary": "0x0c77d8d771ab35e2e184e7ce127f19ced31ff8c0",
+    },
+    "from": {
+      "contractName": "MyOFT",
+      "eid": 40106,
+    },
+    "to": {
+      "address": "HBTWw2VKNLuDBjg9e5dArxo5axJRX8csCEBcCo3CFdAy",
+      "eid": 40168,
+    },
+  },
+  {
+    "config": {
+      "enforcedOptions": undefined,
+      "receiveConfig": {
+        "ulnConfig": {
+          "confirmations": 1n,
+          "optionalDVNThreshold": 0,
+          "optionalDVNs": [],
+          "requiredDVNCount": 1,
+          "requiredDVNs": [
+            "4VDjp6XQaxoZf5RGwiPU9NR1EXSZn2TP4ATMmiSzLfhb",
+          ],
+        },
+      },
+      "receiveLibraryConfig": {
+        "gracePeriod": 0n,
+        "receiveLibrary": "2XrYqmhBMPJgDsb4SVbjV1PnJBprurd5bzRCkHwiFCJB",
+      },
+      "sendConfig": {
+        "executorConfig": {
+          "executor": "AwrbHeCyniXaQhiJZkLhgWdUCteeWSGaSN1sTfLiY7xK",
+          "maxMessageSize": 10000,
+        },
+        "ulnConfig": {
+          "confirmations": 1n,
+          "optionalDVNThreshold": 0,
+          "optionalDVNs": [],
+          "requiredDVNCount": 1,
+          "requiredDVNs": [
+            "4VDjp6XQaxoZf5RGwiPU9NR1EXSZn2TP4ATMmiSzLfhb",
+          ],
+        },
+      },
+      "sendLibrary": "7a4WjyR8VZ7yZz5XJAKm39BUGn5iT9CKcv2pmG9tdXVH",
+    },
+    "from": {
+      "address": "HBTWw2VKNLuDBjg9e5dArxo5axJRX8csCEBcCo3CFdAy",
+      "eid": 40168,
+    },
+    "to": {
+      "contractName": "MyOFT",
+      "eid": 40106,
+    },
+  },
+]
+`;
+
+exports[`config-metadata generateConnectionsConfig supports using block send library for both A to B and B to A 1`] = `
+[
+  {
+    "config": {
+      "enforcedOptions": undefined,
+      "receiveConfig": {
+        "ulnConfig": {
+          "confirmations": 1n,
+          "optionalDVNThreshold": 0,
+          "optionalDVNs": [],
+          "requiredDVNCount": 1,
+          "requiredDVNs": [
+            "0x9f0e79aeb198750f963b6f30b99d87c6ee5a0467",
+          ],
+        },
+      },
+      "receiveLibraryConfig": {
+        "gracePeriod": 0n,
+        "receiveLibrary": "0x0c77d8d771ab35e2e184e7ce127f19ced31ff8c0",
+      },
+      "sendConfig": {
+        "executorConfig": {
+          "executor": "0xa7BFA9D51032F82D649A501B6a1f922FC2f7d4e3",
+          "maxMessageSize": 10000,
+        },
+        "ulnConfig": {
+          "confirmations": 1n,
+          "optionalDVNThreshold": 0,
+          "optionalDVNs": [],
+          "requiredDVNCount": 1,
+          "requiredDVNs": [
+            "0x9f0e79aeb198750f963b6f30b99d87c6ee5a0467",
+          ],
+        },
+      },
+      "sendLibrary": "0x0c77d8d771ab35e2e184e7ce127f19ced31ff8c0",
+    },
+    "from": {
+      "contractName": "MyOFT",
+      "eid": 40106,
+    },
+    "to": {
+      "address": "HBTWw2VKNLuDBjg9e5dArxo5axJRX8csCEBcCo3CFdAy",
+      "eid": 40168,
+    },
+  },
+  {
+    "config": {
+      "enforcedOptions": undefined,
+      "receiveConfig": {
+        "ulnConfig": {
+          "confirmations": 1n,
+          "optionalDVNThreshold": 0,
+          "optionalDVNs": [],
+          "requiredDVNCount": 1,
+          "requiredDVNs": [
+            "4VDjp6XQaxoZf5RGwiPU9NR1EXSZn2TP4ATMmiSzLfhb",
+          ],
+        },
+      },
+      "receiveLibraryConfig": {
+        "gracePeriod": 0n,
+        "receiveLibrary": "2XrYqmhBMPJgDsb4SVbjV1PnJBprurd5bzRCkHwiFCJB",
+      },
+      "sendConfig": {
+        "executorConfig": {
+          "executor": "AwrbHeCyniXaQhiJZkLhgWdUCteeWSGaSN1sTfLiY7xK",
+          "maxMessageSize": 10000,
+        },
+        "ulnConfig": {
+          "confirmations": 1n,
+          "optionalDVNThreshold": 0,
+          "optionalDVNs": [],
+          "requiredDVNCount": 1,
+          "requiredDVNs": [
+            "4VDjp6XQaxoZf5RGwiPU9NR1EXSZn2TP4ATMmiSzLfhb",
+          ],
+        },
+      },
+      "sendLibrary": "2XrYqmhBMPJgDsb4SVbjV1PnJBprurd5bzRCkHwiFCJB",
+    },
+    "from": {
+      "address": "HBTWw2VKNLuDBjg9e5dArxo5axJRX8csCEBcCo3CFdAy",
+      "eid": 40168,
+    },
+    "to": {
+      "contractName": "MyOFT",
+      "eid": 40106,
+    },
+  },
+]
+`;
+
+exports[`config-metadata generateConnectionsConfig uses NIL_DVN_COUNT when no required DVNs are provided 1`] = `
+[
+  {
+    "config": {
+      "enforcedOptions": undefined,
+      "receiveConfig": {
+        "ulnConfig": {
+          "confirmations": 1n,
+          "optionalDVNThreshold": 1,
+          "optionalDVNs": [
+            "0x9f0e79aeb198750f963b6f30b99d87c6ee5a0467",
+            "0xdbec329a5e6d7fb0113eb0a098750d2afd61e9ae",
+          ],
+          "requiredDVNCount": 255,
+          "requiredDVNs": [],
+        },
+      },
+      "receiveLibraryConfig": {
+        "gracePeriod": 0n,
+        "receiveLibrary": "0x819F0FAF2cb1Fba15b9cB24c9A2BDaDb0f895daf",
+      },
+      "sendConfig": {
+        "executorConfig": {
+          "executor": "0xa7BFA9D51032F82D649A501B6a1f922FC2f7d4e3",
+          "maxMessageSize": 10000,
+        },
+        "ulnConfig": {
+          "confirmations": 1n,
+          "optionalDVNThreshold": 1,
+          "optionalDVNs": [
+            "0x9f0e79aeb198750f963b6f30b99d87c6ee5a0467",
+            "0xdbec329a5e6d7fb0113eb0a098750d2afd61e9ae",
+          ],
+          "requiredDVNCount": 255,
+          "requiredDVNs": [],
+        },
+      },
+      "sendLibrary": "0x69BF5f48d2072DfeBc670A1D19dff91D0F4E8170",
+    },
+    "from": {
+      "contractName": "MyOFT",
+      "eid": 40106,
+    },
+    "to": {
+      "address": "HBTWw2VKNLuDBjg9e5dArxo5axJRX8csCEBcCo3CFdAy",
+      "eid": 40168,
+    },
+  },
+  {
+    "config": {
+      "enforcedOptions": undefined,
+      "receiveConfig": {
+        "ulnConfig": {
+          "confirmations": 1n,
+          "optionalDVNThreshold": 1,
+          "optionalDVNs": [
+            "29EKzmCscUg8mf4f5uskwMqvu2SXM8hKF1gWi1cCBoKT",
+            "4VDjp6XQaxoZf5RGwiPU9NR1EXSZn2TP4ATMmiSzLfhb",
+          ],
+          "requiredDVNCount": 255,
+          "requiredDVNs": [],
+        },
+      },
+      "receiveLibraryConfig": {
+        "gracePeriod": 0n,
+        "receiveLibrary": "7a4WjyR8VZ7yZz5XJAKm39BUGn5iT9CKcv2pmG9tdXVH",
+      },
+      "sendConfig": {
+        "executorConfig": {
+          "executor": "AwrbHeCyniXaQhiJZkLhgWdUCteeWSGaSN1sTfLiY7xK",
+          "maxMessageSize": 10000,
+        },
+        "ulnConfig": {
+          "confirmations": 1n,
+          "optionalDVNThreshold": 1,
+          "optionalDVNs": [
+            "29EKzmCscUg8mf4f5uskwMqvu2SXM8hKF1gWi1cCBoKT",
+            "4VDjp6XQaxoZf5RGwiPU9NR1EXSZn2TP4ATMmiSzLfhb",
+          ],
+          "requiredDVNCount": 255,
+          "requiredDVNs": [],
         },
       },
       "sendLibrary": "7a4WjyR8VZ7yZz5XJAKm39BUGn5iT9CKcv2pmG9tdXVH",
@@ -277,6 +657,7 @@ exports[`config-metadata translatePathwayToConfig should be able to translate a 
           "confirmations": 1n,
           "optionalDVNThreshold": 0,
           "optionalDVNs": [],
+          "requiredDVNCount": 1,
           "requiredDVNs": [
             "0x9f0e79aeb198750f963b6f30b99d87c6ee5a0467",
           ],
@@ -295,6 +676,7 @@ exports[`config-metadata translatePathwayToConfig should be able to translate a 
           "confirmations": 1n,
           "optionalDVNThreshold": 0,
           "optionalDVNs": [],
+          "requiredDVNCount": 1,
           "requiredDVNs": [
             "0x9f0e79aeb198750f963b6f30b99d87c6ee5a0467",
           ],
@@ -319,6 +701,7 @@ exports[`config-metadata translatePathwayToConfig should be able to translate a 
           "confirmations": 1n,
           "optionalDVNThreshold": 0,
           "optionalDVNs": [],
+          "requiredDVNCount": 1,
           "requiredDVNs": [
             "4VDjp6XQaxoZf5RGwiPU9NR1EXSZn2TP4ATMmiSzLfhb",
           ],
@@ -337,6 +720,7 @@ exports[`config-metadata translatePathwayToConfig should be able to translate a 
           "confirmations": 1n,
           "optionalDVNThreshold": 0,
           "optionalDVNs": [],
+          "requiredDVNCount": 1,
           "requiredDVNs": [
             "4VDjp6XQaxoZf5RGwiPU9NR1EXSZn2TP4ATMmiSzLfhb",
           ],

--- a/packages/metadata-tools/test/__snapshots__/config-metadata.test.ts.snap
+++ b/packages/metadata-tools/test/__snapshots__/config-metadata.test.ts.snap
@@ -279,6 +279,91 @@ exports[`config-metadata generateConnectionsConfig should generate the connectio
 ]
 `;
 
+exports[`config-metadata generateConnectionsConfig supports NIL_CONFIRMATIONS 1`] = `
+[
+  {
+    "config": {
+      "enforcedOptions": undefined,
+      "receiveConfig": {
+        "ulnConfig": {
+          "confirmations": 18446744073709551615n,
+          "optionalDVNThreshold": 0,
+          "optionalDVNs": [],
+          "requiredDVNCount": 255,
+          "requiredDVNs": [],
+        },
+      },
+      "receiveLibraryConfig": {
+        "gracePeriod": 0n,
+        "receiveLibrary": "0x819F0FAF2cb1Fba15b9cB24c9A2BDaDb0f895daf",
+      },
+      "sendConfig": {
+        "executorConfig": {
+          "executor": "0xa7BFA9D51032F82D649A501B6a1f922FC2f7d4e3",
+          "maxMessageSize": 10000,
+        },
+        "ulnConfig": {
+          "confirmations": 18446744073709551615n,
+          "optionalDVNThreshold": 0,
+          "optionalDVNs": [],
+          "requiredDVNCount": 255,
+          "requiredDVNs": [],
+        },
+      },
+      "sendLibrary": "0x69BF5f48d2072DfeBc670A1D19dff91D0F4E8170",
+    },
+    "from": {
+      "contractName": "MyOFT",
+      "eid": 40106,
+    },
+    "to": {
+      "address": "HBTWw2VKNLuDBjg9e5dArxo5axJRX8csCEBcCo3CFdAy",
+      "eid": 40168,
+    },
+  },
+  {
+    "config": {
+      "enforcedOptions": undefined,
+      "receiveConfig": {
+        "ulnConfig": {
+          "confirmations": 18446744073709551615n,
+          "optionalDVNThreshold": 0,
+          "optionalDVNs": [],
+          "requiredDVNCount": 255,
+          "requiredDVNs": [],
+        },
+      },
+      "receiveLibraryConfig": {
+        "gracePeriod": 0n,
+        "receiveLibrary": "7a4WjyR8VZ7yZz5XJAKm39BUGn5iT9CKcv2pmG9tdXVH",
+      },
+      "sendConfig": {
+        "executorConfig": {
+          "executor": "AwrbHeCyniXaQhiJZkLhgWdUCteeWSGaSN1sTfLiY7xK",
+          "maxMessageSize": 10000,
+        },
+        "ulnConfig": {
+          "confirmations": 18446744073709551615n,
+          "optionalDVNThreshold": 0,
+          "optionalDVNs": [],
+          "requiredDVNCount": 255,
+          "requiredDVNs": [],
+        },
+      },
+      "sendLibrary": "7a4WjyR8VZ7yZz5XJAKm39BUGn5iT9CKcv2pmG9tdXVH",
+    },
+    "from": {
+      "address": "HBTWw2VKNLuDBjg9e5dArxo5axJRX8csCEBcCo3CFdAy",
+      "eid": 40168,
+    },
+    "to": {
+      "contractName": "MyOFT",
+      "eid": 40106,
+    },
+  },
+]
+`;
+
 exports[`config-metadata generateConnectionsConfig supports passing no required DVNs and no optional DVNs 1`] = `
 [
   {

--- a/packages/metadata-tools/test/__snapshots__/config-metadata.test.ts.snap
+++ b/packages/metadata-tools/test/__snapshots__/config-metadata.test.ts.snap
@@ -449,7 +449,7 @@ exports[`config-metadata generateConnectionsConfig supports passing no required 
 ]
 `;
 
-exports[`config-metadata generateConnectionsConfig supports using block send library for A to B 1`] = `
+exports[`config-metadata generateConnectionsConfig supports using block send and receive for A to B 1`] = `
 [
   {
     "config": {
@@ -542,7 +542,7 @@ exports[`config-metadata generateConnectionsConfig supports using block send lib
 ]
 `;
 
-exports[`config-metadata generateConnectionsConfig supports using block send library for both A to B and B to A 1`] = `
+exports[`config-metadata generateConnectionsConfig supports using block send and receive for both A to B and B to A 1`] = `
 [
   {
     "config": {

--- a/packages/metadata-tools/test/config-metadata.test.ts
+++ b/packages/metadata-tools/test/config-metadata.test.ts
@@ -5,6 +5,7 @@ import fujiMetadata from './data/fuji.json'
 import polygonMainnetMetadata from './data/polygon-mainnet.json'
 import solanaMainnetMetadata from './data/solana-mainnet.json'
 import solanaTestnetMetadata from './data/solana-testnet.json'
+import { BLOCKED_MESSAGE_LIB_INDICATOR, NIL_DVN_COUNT } from '@/constants'
 
 describe('config-metadata', () => {
     const metadata: IMetadata = {
@@ -53,7 +54,6 @@ describe('config-metadata', () => {
                 address: 'HBTWw2VKNLuDBjg9e5dArxo5axJRX8csCEBcCo3CFdAy',
             }
 
-            // This array is your TwoWayConfig[]
             const pathways: TwoWayConfig[] = [
                 [avalancheContract, solanaContract, [['LayerZero Labs'], []], [1, 1], [undefined, undefined]],
             ]
@@ -116,6 +116,132 @@ describe('config-metadata', () => {
             // Generate config using our custom fetchMetadata
             const config = await generateConnectionsConfig(pathways, { fetchMetadata: customFetchMetadata })
             expect(config).toMatchSnapshot()
+        })
+
+        it('uses NIL_DVN_COUNT when no required DVNs are provided', async () => {
+            const avalancheContract = {
+                eid: 40106,
+                contractName: 'MyOFT',
+            }
+
+            const solanaContract = {
+                eid: 40168,
+                address: 'HBTWw2VKNLuDBjg9e5dArxo5axJRX8csCEBcCo3CFdAy',
+            }
+
+            const pathways: TwoWayConfig[] = [
+                [
+                    avalancheContract,
+                    solanaContract,
+                    [[], [['LayerZero Labs', 'P2P'], 1]],
+                    [1, 1],
+                    [undefined, undefined],
+                ],
+            ]
+
+            const config = await generateConnectionsConfig(pathways)
+            expect(config).toMatchSnapshot()
+
+            expect(config[0]?.config?.sendConfig?.ulnConfig?.requiredDVNCount).toBe(NIL_DVN_COUNT)
+            expect(config[0]?.config?.sendConfig?.ulnConfig?.optionalDVNThreshold).toBe(1)
+            expect(config[0]?.config?.receiveConfig?.ulnConfig?.requiredDVNCount).toBe(NIL_DVN_COUNT)
+            expect(config[0]?.config?.receiveConfig?.ulnConfig?.optionalDVNThreshold).toBe(1)
+            expect(config[1]?.config?.sendConfig?.ulnConfig?.requiredDVNCount).toBe(NIL_DVN_COUNT)
+            expect(config[1]?.config?.sendConfig?.ulnConfig?.optionalDVNThreshold).toBe(1)
+            expect(config[1]?.config?.receiveConfig?.ulnConfig?.requiredDVNCount).toBe(NIL_DVN_COUNT)
+            expect(config[1]?.config?.receiveConfig?.ulnConfig?.optionalDVNThreshold).toBe(1)
+        })
+
+        it('supports passing no required DVNs and no optional DVNs', async () => {
+            const avalancheContract = {
+                eid: 40106,
+                contractName: 'MyOFT',
+            }
+
+            const solanaContract = {
+                eid: 40168,
+                address: 'HBTWw2VKNLuDBjg9e5dArxo5axJRX8csCEBcCo3CFdAy',
+            }
+
+            const pathways: TwoWayConfig[] = [
+                [avalancheContract, solanaContract, [[], []], [1, 1], [undefined, undefined]],
+            ]
+
+            const config = await generateConnectionsConfig(pathways)
+            expect(config).toMatchSnapshot()
+        })
+
+        it('supports using block send library for A to B', async () => {
+            const avalancheContract = {
+                eid: 40106,
+                contractName: 'MyOFT',
+            }
+
+            const solanaContract = {
+                eid: 40168,
+                address: 'HBTWw2VKNLuDBjg9e5dArxo5axJRX8csCEBcCo3CFdAy',
+            }
+
+            const pathways: TwoWayConfig[] = [
+                [
+                    avalancheContract,
+                    solanaContract,
+                    [['LayerZero Labs'], []],
+                    [[1, BLOCKED_MESSAGE_LIB_INDICATOR], 1],
+                    [undefined, undefined],
+                ],
+            ]
+
+            const config = await generateConnectionsConfig(pathways)
+            expect(config).toMatchSnapshot()
+
+            expect(config[0]?.config?.sendLibrary).toBe(
+                fujiMetadata.deployments?.find((d) => d.version === 2)?.blockedMessageLib?.address
+            )
+            expect(config[1]?.config?.receiveLibraryConfig?.receiveLibrary).toBe(
+                solanaTestnetMetadata.deployments?.find((d) => d.version === 2)?.blocked_messagelib?.address
+            )
+        })
+
+        it('supports using block send library for both A to B and B to A', async () => {
+            const avalancheContract = {
+                eid: 40106,
+                contractName: 'MyOFT',
+            }
+
+            const solanaContract = {
+                eid: 40168,
+                address: 'HBTWw2VKNLuDBjg9e5dArxo5axJRX8csCEBcCo3CFdAy',
+            }
+
+            const pathways: TwoWayConfig[] = [
+                [
+                    avalancheContract,
+                    solanaContract,
+                    [['LayerZero Labs'], []],
+                    [
+                        [1, BLOCKED_MESSAGE_LIB_INDICATOR],
+                        [1, BLOCKED_MESSAGE_LIB_INDICATOR],
+                    ],
+                    [undefined, undefined],
+                ],
+            ]
+
+            const config = await generateConnectionsConfig(pathways)
+            expect(config).toMatchSnapshot()
+
+            expect(config[0]?.config?.sendLibrary).toBe(
+                fujiMetadata.deployments?.find((d) => d.version === 2)?.blockedMessageLib?.address
+            )
+            expect(config[0]?.config?.receiveLibraryConfig?.receiveLibrary).toBe(
+                fujiMetadata.deployments?.find((d) => d.version === 2)?.blockedMessageLib?.address
+            )
+            expect(config[1]?.config?.sendLibrary).toBe(
+                solanaTestnetMetadata.deployments?.find((d) => d.version === 2)?.blocked_messagelib?.address
+            )
+            expect(config[1]?.config?.receiveLibraryConfig?.receiveLibrary).toBe(
+                solanaTestnetMetadata.deployments?.find((d) => d.version === 2)?.blocked_messagelib?.address
+            )
         })
     })
 

--- a/packages/metadata-tools/test/config-metadata.test.ts
+++ b/packages/metadata-tools/test/config-metadata.test.ts
@@ -5,7 +5,7 @@ import fujiMetadata from './data/fuji.json'
 import polygonMainnetMetadata from './data/polygon-mainnet.json'
 import solanaMainnetMetadata from './data/solana-mainnet.json'
 import solanaTestnetMetadata from './data/solana-testnet.json'
-import { BLOCKED_MESSAGE_LIB_INDICATOR, NIL_DVN_COUNT } from '@/constants'
+import { BLOCKED_MESSAGE_LIB_INDICATOR, NIL_CONFIRMATIONS, NIL_DVN_COUNT } from '@/constants'
 
 describe('config-metadata', () => {
     const metadata: IMetadata = {
@@ -242,6 +242,31 @@ describe('config-metadata', () => {
             expect(config[1]?.config?.receiveLibraryConfig?.receiveLibrary).toBe(
                 solanaTestnetMetadata.deployments?.find((d) => d.version === 2)?.blocked_messagelib?.address
             )
+        })
+
+        it('supports NIL_CONFIRMATIONS', async () => {
+            const avalancheContract = {
+                eid: 40106,
+                contractName: 'MyOFT',
+            }
+
+            const solanaContract = {
+                eid: 40168,
+                address: 'HBTWw2VKNLuDBjg9e5dArxo5axJRX8csCEBcCo3CFdAy',
+            }
+
+            const pathways: TwoWayConfig[] = [
+                [
+                    avalancheContract,
+                    solanaContract,
+                    [[], []],
+                    [NIL_CONFIRMATIONS, NIL_CONFIRMATIONS],
+                    [undefined, undefined],
+                ],
+            ]
+
+            const config = await generateConnectionsConfig(pathways)
+            expect(config).toMatchSnapshot()
         })
     })
 

--- a/packages/metadata-tools/test/config-metadata.test.ts
+++ b/packages/metadata-tools/test/config-metadata.test.ts
@@ -1,14 +1,22 @@
 import { DVNsToAddresses, generateConnectionsConfig, translatePathwayToConfig } from '@/config-metadata'
 import { IMetadataDvns, IMetadata, TwoWayConfig } from '@/types'
+import {
+    MSG_LIB_BLOCK_RECEIVE_ONLY,
+    MSG_LIB_BLOCK_SEND_AND_RECEIVE,
+    MSG_LIB_BLOCK_SEND_ONLY,
+    NIL_CONFIRMATIONS,
+    NIL_DVN_COUNT,
+} from '@/constants'
 
 import fujiMetadata from './data/fuji.json'
 import polygonMainnetMetadata from './data/polygon-mainnet.json'
 import solanaMainnetMetadata from './data/solana-mainnet.json'
 import solanaTestnetMetadata from './data/solana-testnet.json'
-import { BLOCKED_MESSAGE_LIB_INDICATOR, NIL_CONFIRMATIONS, NIL_DVN_COUNT } from '@/constants'
+import dummyIncompleteMetadata from './data/dummy-incomplete.json'
 
 describe('config-metadata', () => {
     const metadata: IMetadata = {
+        dummy: dummyIncompleteMetadata,
         fuji: fujiMetadata,
         solana: solanaMainnetMetadata,
         polygon: polygonMainnetMetadata,
@@ -16,13 +24,6 @@ describe('config-metadata', () => {
     }
 
     describe('generateConnectionsConfig', () => {
-        const metadata: IMetadata = {
-            fuji: fujiMetadata,
-            solana: solanaMainnetMetadata,
-            polygon: polygonMainnetMetadata,
-            'solana-testnet': solanaTestnetMetadata,
-        }
-
         it('should allow for call without custom params', async () => {
             const avalancheContract = {
                 eid: 40106,
@@ -63,6 +64,7 @@ describe('config-metadata', () => {
             const config = await generateConnectionsConfig(pathways, { fetchMetadata: mockFetchMetadata })
             expect(config).toMatchSnapshot()
         })
+
         it('should allow for custom DVNs in the metadata', async () => {
             // extend the Solana DVNs with custom DVN(s)
             const solanaTestnetDVNsWithCustom: IMetadataDvns = {
@@ -171,7 +173,7 @@ describe('config-metadata', () => {
             expect(config).toMatchSnapshot()
         })
 
-        it('supports using block send library for A to B', async () => {
+        it('supports using block send and receive for A to B', async () => {
             const avalancheContract = {
                 eid: 40106,
                 contractName: 'MyOFT',
@@ -187,7 +189,7 @@ describe('config-metadata', () => {
                     avalancheContract,
                     solanaContract,
                     [['LayerZero Labs'], []],
-                    [[1, BLOCKED_MESSAGE_LIB_INDICATOR], 1],
+                    [[1, MSG_LIB_BLOCK_SEND_AND_RECEIVE], 1],
                     [undefined, undefined],
                 ],
             ]
@@ -203,7 +205,7 @@ describe('config-metadata', () => {
             )
         })
 
-        it('supports using block send library for both A to B and B to A', async () => {
+        it('supports using block send and receive for both A to B and B to A', async () => {
             const avalancheContract = {
                 eid: 40106,
                 contractName: 'MyOFT',
@@ -220,8 +222,8 @@ describe('config-metadata', () => {
                     solanaContract,
                     [['LayerZero Labs'], []],
                     [
-                        [1, BLOCKED_MESSAGE_LIB_INDICATOR],
-                        [1, BLOCKED_MESSAGE_LIB_INDICATOR],
+                        [1, MSG_LIB_BLOCK_SEND_AND_RECEIVE],
+                        [1, MSG_LIB_BLOCK_SEND_AND_RECEIVE],
                     ],
                     [undefined, undefined],
                 ],
@@ -241,6 +243,115 @@ describe('config-metadata', () => {
             )
             expect(config[1]?.config?.receiveLibraryConfig?.receiveLibrary).toBe(
                 solanaTestnetMetadata.deployments?.find((d) => d.version === 2)?.blocked_messagelib?.address
+            )
+        })
+
+        it('supports using block send only for A to B', async () => {
+            const avalancheContract = {
+                eid: 40106,
+                contractName: 'MyOFT',
+            }
+
+            const solanaContract = {
+                eid: 40168,
+                address: 'HBTWw2VKNLuDBjg9e5dArxo5axJRX8csCEBcCo3CFdAy',
+            }
+
+            const pathways: TwoWayConfig[] = [
+                [
+                    avalancheContract,
+                    solanaContract,
+                    [['LayerZero Labs'], []],
+                    [[1, MSG_LIB_BLOCK_SEND_ONLY], 1],
+                    [undefined, undefined],
+                ],
+            ]
+
+            const config = await generateConnectionsConfig(pathways)
+
+            expect(config[0]?.config?.sendLibrary).toBe(
+                fujiMetadata.deployments?.find((d) => d.version === 2)?.blockedMessageLib?.address
+            )
+            expect(config[1]?.config?.receiveLibraryConfig?.receiveLibrary).toBe(
+                solanaTestnetMetadata.deployments?.find((d) => d.version === 2)?.sendUln302?.address
+            )
+        })
+
+        it('supports using block receive only for A to B', async () => {
+            const avalancheContract = {
+                eid: 40106,
+                contractName: 'MyOFT',
+            }
+
+            const solanaContract = {
+                eid: 40168,
+                address: 'HBTWw2VKNLuDBjg9e5dArxo5axJRX8csCEBcCo3CFdAy',
+            }
+
+            const pathways: TwoWayConfig[] = [
+                [
+                    avalancheContract,
+                    solanaContract,
+                    [['LayerZero Labs'], []],
+                    [[1, MSG_LIB_BLOCK_RECEIVE_ONLY], 1],
+                    [undefined, undefined],
+                ],
+            ]
+
+            const config = await generateConnectionsConfig(pathways)
+
+            expect(config[0]?.config?.sendLibrary).toBe(
+                fujiMetadata.deployments?.find((d) => d.version === 2)?.sendUln302?.address
+            )
+            expect(config[0]?.config?.receiveLibraryConfig?.receiveLibrary).toBe(
+                fujiMetadata.deployments?.find((d) => d.version === 2)?.receiveUln302?.address
+            )
+            expect(config[1]?.config?.sendLibrary).toBe(
+                solanaTestnetMetadata.deployments?.find((d) => d.version === 2)?.sendUln302?.address
+            )
+            expect(config[1]?.config?.receiveLibraryConfig?.receiveLibrary).toBe(
+                solanaTestnetMetadata.deployments?.find((d) => d.version === 2)?.blocked_messagelib?.address
+            )
+        })
+
+        it('supports using blocking send only on A to B and B to A', async () => {
+            const avalancheContract = {
+                eid: 40106,
+                contractName: 'MyOFT',
+            }
+
+            const solanaContract = {
+                eid: 40168,
+                address: 'HBTWw2VKNLuDBjg9e5dArxo5axJRX8csCEBcCo3CFdAy',
+            }
+
+            const pathways: TwoWayConfig[] = [
+                [
+                    avalancheContract,
+                    solanaContract,
+                    [['LayerZero Labs'], []],
+                    [
+                        [1, MSG_LIB_BLOCK_SEND_ONLY],
+                        [1, MSG_LIB_BLOCK_SEND_ONLY],
+                    ],
+                    [undefined, undefined],
+                ],
+            ]
+
+            const config = await generateConnectionsConfig(pathways)
+
+            expect(config[0]?.config?.sendLibrary).toBe(
+                fujiMetadata.deployments?.find((d) => d.version === 2)?.blockedMessageLib?.address
+            )
+            expect(config[0]?.config?.receiveLibraryConfig?.receiveLibrary).toBe(
+                fujiMetadata.deployments?.find((d) => d.version === 2)?.receiveUln302?.address
+            )
+
+            expect(config[1]?.config?.sendLibrary).toBe(
+                solanaTestnetMetadata.deployments?.find((d) => d.version === 2)?.blocked_messagelib?.address
+            )
+            expect(config[1]?.config?.receiveLibraryConfig?.receiveLibrary).toBe(
+                solanaTestnetMetadata.deployments?.find((d) => d.version === 2)?.receiveUln302?.address
             )
         })
 
@@ -267,6 +378,36 @@ describe('config-metadata', () => {
 
             const config = await generateConnectionsConfig(pathways)
             expect(config).toMatchSnapshot()
+        })
+
+        it('should error when executor is missing', async () => {
+            const dummyContract = {
+                eid: 49999,
+                contractName: 'MyOFT',
+            }
+
+            const solanaContract = {
+                eid: 40168,
+                address: 'HBTWw2VKNLuDBjg9e5dArxo5axJRX8csCEBcCo3CFdAy',
+            }
+
+            const mockFetchMetadata = async () => metadata
+
+            await expect(
+                async () =>
+                    await generateConnectionsConfig(
+                        [[dummyContract, solanaContract, [['LayerZero Labs'], []], [1, 1], [undefined, undefined]]],
+                        { fetchMetadata: mockFetchMetadata }
+                    )
+            ).rejects.toThrow('Can\'t find executor for endpoint with eid: "49999".')
+
+            await expect(
+                async () =>
+                    await generateConnectionsConfig(
+                        [[solanaContract, dummyContract, [['LayerZero Labs'], []], [1, 1], [undefined, undefined]]],
+                        { fetchMetadata: mockFetchMetadata }
+                    )
+            ).rejects.toThrow('Can\'t find executor for endpoint with eid: "49999".')
         })
     })
 

--- a/packages/metadata-tools/test/config-metadata.test.ts
+++ b/packages/metadata-tools/test/config-metadata.test.ts
@@ -13,6 +13,8 @@ import polygonMainnetMetadata from './data/polygon-mainnet.json'
 import solanaMainnetMetadata from './data/solana-mainnet.json'
 import solanaTestnetMetadata from './data/solana-testnet.json'
 import dummyIncompleteMetadata from './data/dummy-incomplete.json'
+import amoyTestnetMetadata from './data/amoy-testnet.json'
+import { getAddress } from '@ethersproject/address'
 
 describe('config-metadata', () => {
     const metadata: IMetadata = {
@@ -21,6 +23,7 @@ describe('config-metadata', () => {
         solana: solanaMainnetMetadata,
         polygon: polygonMainnetMetadata,
         'solana-testnet': solanaTestnetMetadata,
+        'amoy-testnet': amoyTestnetMetadata,
     }
 
     describe('generateConnectionsConfig', () => {
@@ -179,15 +182,15 @@ describe('config-metadata', () => {
                 contractName: 'MyOFT',
             }
 
-            const solanaContract = {
-                eid: 40168,
-                address: 'HBTWw2VKNLuDBjg9e5dArxo5axJRX8csCEBcCo3CFdAy',
+            const amoyContract = {
+                eid: 40267,
+                contractName: 'MyOFT',
             }
 
             const pathways: TwoWayConfig[] = [
                 [
                     avalancheContract,
-                    solanaContract,
+                    amoyContract,
                     [['LayerZero Labs'], []],
                     [[1, MSG_LIB_BLOCK_SEND_AND_RECEIVE], 1],
                     [undefined, undefined],
@@ -198,10 +201,12 @@ describe('config-metadata', () => {
             expect(config).toMatchSnapshot()
 
             expect(config[0]?.config?.sendLibrary).toBe(
-                fujiMetadata.deployments?.find((d) => d.version === 2)?.blockedMessageLib?.address
+                getAddress(fujiMetadata.deployments?.find((d) => d.version === 2)?.blockedMessageLib?.address ?? '')
             )
             expect(config[1]?.config?.receiveLibraryConfig?.receiveLibrary).toBe(
-                solanaTestnetMetadata.deployments?.find((d) => d.version === 2)?.blocked_messagelib?.address
+                getAddress(
+                    amoyTestnetMetadata.deployments?.find((d) => d.version === 2)?.blockedMessageLib?.address ?? ''
+                )
             )
         })
 
@@ -211,15 +216,15 @@ describe('config-metadata', () => {
                 contractName: 'MyOFT',
             }
 
-            const solanaContract = {
-                eid: 40168,
-                address: 'HBTWw2VKNLuDBjg9e5dArxo5axJRX8csCEBcCo3CFdAy',
+            const amoyContract = {
+                eid: 40267,
+                contractName: 'MyOFT',
             }
 
             const pathways: TwoWayConfig[] = [
                 [
                     avalancheContract,
-                    solanaContract,
+                    amoyContract,
                     [['LayerZero Labs'], []],
                     [
                         [1, MSG_LIB_BLOCK_SEND_AND_RECEIVE],
@@ -233,16 +238,20 @@ describe('config-metadata', () => {
             expect(config).toMatchSnapshot()
 
             expect(config[0]?.config?.sendLibrary).toBe(
-                fujiMetadata.deployments?.find((d) => d.version === 2)?.blockedMessageLib?.address
+                getAddress(fujiMetadata.deployments?.find((d) => d.version === 2)?.blockedMessageLib?.address ?? '')
             )
             expect(config[0]?.config?.receiveLibraryConfig?.receiveLibrary).toBe(
-                fujiMetadata.deployments?.find((d) => d.version === 2)?.blockedMessageLib?.address
+                getAddress(fujiMetadata.deployments?.find((d) => d.version === 2)?.blockedMessageLib?.address ?? '')
             )
             expect(config[1]?.config?.sendLibrary).toBe(
-                solanaTestnetMetadata.deployments?.find((d) => d.version === 2)?.blocked_messagelib?.address
+                getAddress(
+                    amoyTestnetMetadata.deployments?.find((d) => d.version === 2)?.blockedMessageLib?.address ?? ''
+                )
             )
             expect(config[1]?.config?.receiveLibraryConfig?.receiveLibrary).toBe(
-                solanaTestnetMetadata.deployments?.find((d) => d.version === 2)?.blocked_messagelib?.address
+                getAddress(
+                    amoyTestnetMetadata.deployments?.find((d) => d.version === 2)?.blockedMessageLib?.address ?? ''
+                )
             )
         })
 
@@ -252,15 +261,15 @@ describe('config-metadata', () => {
                 contractName: 'MyOFT',
             }
 
-            const solanaContract = {
-                eid: 40168,
-                address: 'HBTWw2VKNLuDBjg9e5dArxo5axJRX8csCEBcCo3CFdAy',
+            const amoyContract = {
+                eid: 40267,
+                contractName: 'MyOFT',
             }
 
             const pathways: TwoWayConfig[] = [
                 [
                     avalancheContract,
-                    solanaContract,
+                    amoyContract,
                     [['LayerZero Labs'], []],
                     [[1, MSG_LIB_BLOCK_SEND_ONLY], 1],
                     [undefined, undefined],
@@ -270,10 +279,10 @@ describe('config-metadata', () => {
             const config = await generateConnectionsConfig(pathways)
 
             expect(config[0]?.config?.sendLibrary).toBe(
-                fujiMetadata.deployments?.find((d) => d.version === 2)?.blockedMessageLib?.address
+                getAddress(fujiMetadata.deployments?.find((d) => d.version === 2)?.blockedMessageLib?.address ?? '')
             )
             expect(config[1]?.config?.receiveLibraryConfig?.receiveLibrary).toBe(
-                solanaTestnetMetadata.deployments?.find((d) => d.version === 2)?.sendUln302?.address
+                getAddress(amoyTestnetMetadata.deployments?.find((d) => d.version === 2)?.receiveUln302?.address ?? '')
             )
         })
 
@@ -283,15 +292,15 @@ describe('config-metadata', () => {
                 contractName: 'MyOFT',
             }
 
-            const solanaContract = {
-                eid: 40168,
-                address: 'HBTWw2VKNLuDBjg9e5dArxo5axJRX8csCEBcCo3CFdAy',
+            const amoyContract = {
+                eid: 40267,
+                contractName: 'MyOFT',
             }
 
             const pathways: TwoWayConfig[] = [
                 [
                     avalancheContract,
-                    solanaContract,
+                    amoyContract,
                     [['LayerZero Labs'], []],
                     [[1, MSG_LIB_BLOCK_RECEIVE_ONLY], 1],
                     [undefined, undefined],
@@ -301,16 +310,18 @@ describe('config-metadata', () => {
             const config = await generateConnectionsConfig(pathways)
 
             expect(config[0]?.config?.sendLibrary).toBe(
-                fujiMetadata.deployments?.find((d) => d.version === 2)?.sendUln302?.address
+                getAddress(fujiMetadata.deployments?.find((d) => d.version === 2)?.sendUln302?.address ?? '')
             )
             expect(config[0]?.config?.receiveLibraryConfig?.receiveLibrary).toBe(
-                fujiMetadata.deployments?.find((d) => d.version === 2)?.receiveUln302?.address
+                getAddress(fujiMetadata.deployments?.find((d) => d.version === 2)?.receiveUln302?.address ?? '')
             )
             expect(config[1]?.config?.sendLibrary).toBe(
-                solanaTestnetMetadata.deployments?.find((d) => d.version === 2)?.sendUln302?.address
+                getAddress(amoyTestnetMetadata.deployments?.find((d) => d.version === 2)?.sendUln302?.address ?? '')
             )
             expect(config[1]?.config?.receiveLibraryConfig?.receiveLibrary).toBe(
-                solanaTestnetMetadata.deployments?.find((d) => d.version === 2)?.blocked_messagelib?.address
+                getAddress(
+                    amoyTestnetMetadata.deployments?.find((d) => d.version === 2)?.blockedMessageLib?.address ?? ''
+                )
             )
         })
 
@@ -320,15 +331,15 @@ describe('config-metadata', () => {
                 contractName: 'MyOFT',
             }
 
-            const solanaContract = {
-                eid: 40168,
-                address: 'HBTWw2VKNLuDBjg9e5dArxo5axJRX8csCEBcCo3CFdAy',
+            const amoyContract = {
+                eid: 40267,
+                contractName: 'MyOFT',
             }
 
             const pathways: TwoWayConfig[] = [
                 [
                     avalancheContract,
-                    solanaContract,
+                    amoyContract,
                     [['LayerZero Labs'], []],
                     [
                         [1, MSG_LIB_BLOCK_SEND_ONLY],
@@ -341,17 +352,19 @@ describe('config-metadata', () => {
             const config = await generateConnectionsConfig(pathways)
 
             expect(config[0]?.config?.sendLibrary).toBe(
-                fujiMetadata.deployments?.find((d) => d.version === 2)?.blockedMessageLib?.address
+                getAddress(fujiMetadata.deployments?.find((d) => d.version === 2)?.blockedMessageLib?.address ?? '')
             )
             expect(config[0]?.config?.receiveLibraryConfig?.receiveLibrary).toBe(
-                fujiMetadata.deployments?.find((d) => d.version === 2)?.receiveUln302?.address
+                getAddress(fujiMetadata.deployments?.find((d) => d.version === 2)?.receiveUln302?.address ?? '')
             )
 
             expect(config[1]?.config?.sendLibrary).toBe(
-                solanaTestnetMetadata.deployments?.find((d) => d.version === 2)?.blocked_messagelib?.address
+                getAddress(
+                    amoyTestnetMetadata.deployments?.find((d) => d.version === 2)?.blockedMessageLib?.address ?? ''
+                )
             )
             expect(config[1]?.config?.receiveLibraryConfig?.receiveLibrary).toBe(
-                solanaTestnetMetadata.deployments?.find((d) => d.version === 2)?.receiveUln302?.address
+                getAddress(amoyTestnetMetadata.deployments?.find((d) => d.version === 2)?.receiveUln302?.address ?? '')
             )
         })
 
@@ -408,6 +421,32 @@ describe('config-metadata', () => {
                         { fetchMetadata: mockFetchMetadata }
                     )
             ).rejects.toThrow('Can\'t find executor for endpoint with eid: "49999".')
+        })
+
+        it('supports does not support blocked message lib on Solana', async () => {
+            const avalancheContract = {
+                eid: 40106,
+                contractName: 'MyOFT',
+            }
+
+            const solanaContract = {
+                eid: 40168,
+                address: 'HBTWw2VKNLuDBjg9e5dArxo5axJRX8csCEBcCo3CFdAy',
+            }
+
+            const pathways: TwoWayConfig[] = [
+                [
+                    avalancheContract,
+                    solanaContract,
+                    [['LayerZero Labs'], []],
+                    [[1, MSG_LIB_BLOCK_SEND_AND_RECEIVE], 1],
+                    [undefined, undefined],
+                ],
+            ]
+
+            await expect(generateConnectionsConfig(pathways)).rejects.toThrow(
+                'BlockedMessageLib is not currently supported by simple config generator on Solana'
+            )
         })
     })
 

--- a/packages/metadata-tools/test/config-metadata.test.ts
+++ b/packages/metadata-tools/test/config-metadata.test.ts
@@ -423,7 +423,7 @@ describe('config-metadata', () => {
             ).rejects.toThrow('Can\'t find executor for endpoint with eid: "49999".')
         })
 
-        it('supports does not support blocked message lib on Solana', async () => {
+        it('supports blocked message lib on Solana', async () => {
             const avalancheContract = {
                 eid: 40106,
                 contractName: 'MyOFT',
@@ -444,9 +444,12 @@ describe('config-metadata', () => {
                 ],
             ]
 
-            await expect(generateConnectionsConfig(pathways)).rejects.toThrow(
-                'BlockedMessageLib is not currently supported by simple config generator on Solana'
-            )
+            const config = await generateConnectionsConfig(pathways)
+            expect(config).toHaveLength(2)
+
+            // Verify blocked message lib is configured for both directions
+            expect(config[0]?.config?.sendLibrary).toBeDefined()
+            expect(config[1]?.config?.sendLibrary).toBeDefined()
         })
     })
 

--- a/packages/metadata-tools/test/data/amoy-testnet.json
+++ b/packages/metadata-tools/test/data/amoy-testnet.json
@@ -1,0 +1,157 @@
+{
+  "created": "2025-05-20T21:57:23.000Z",
+  "updated": "2025-05-20T21:57:23.000Z",
+  "tableName": "layerzero-chain_metadata",
+  "environment": "testnet",
+  "blockExplorers": [
+    {
+      "url": "https://amoy.polygonscan.com"
+    }
+  ],
+  "deployments": [
+    {
+      "eid": "10267",
+      "endpoint": {
+        "address": "0x55370E0fBB5f5b8dAeD978BA1c075a499eB107B8"
+      },
+      "chainKey": "amoy-testnet",
+      "stage": "testnet",
+      "relayerV2": {
+        "address": "0x6Ac7bdc07A0583A362F1497252872AE6c0A5F5B8"
+      },
+      "ultraLightNodeV2": {
+        "address": "0x35AdD9321507A87471a11EBd4aE4f592d531e620"
+      },
+      "sendUln301": {
+        "address": "0xa78A78a13074eD93aD447a26Ec57121f29E8feC2"
+      },
+      "receiveUln301": {
+        "address": "0x88B27057A9e00c5F05DDa29241027afF63f9e6e0"
+      },
+      "version": 1,
+      "nonceContract": {
+        "address": "0x88866E5A296FffA511EF8011CB1BBd4d01Cd094F"
+      }
+    },
+    {
+      "eid": "40267",
+      "endpointV2View": {
+        "address": "0xcF1B0F4106B0324F96fEfcC31bA9498caa80701C"
+      },
+      "chainKey": "amoy-testnet",
+      "stage": "testnet",
+      "executor": {
+        "address": "0x4Cf1B3Fa61465c2c907f82fC488B43223BA0CF93"
+      },
+      "endpointV2": {
+        "address": "0x6EDCE65403992e310A62460808c4b910D972f10f"
+      },
+      "sendUln302": {
+        "address": "0x1d186C560281B8F1AF831957ED5047fD3AB902F9"
+      },
+      "lzExecutor": {
+        "address": "0x4dFa426aEAA55E6044d2b47682842460a04aF45c"
+      },
+      "blockedMessageLib": {
+        "address": "0x0c77d8d771ab35e2e184e7ce127f19ced31ff8c0"
+      },
+      "version": 2,
+      "receiveUln302": {
+        "address": "0x53fd4C4fBBd53F6bC58CaE6704b92dB1f360A648"
+      }
+    }
+  ],
+  "chainDetails": {
+    "mainnetChainName": "polygon",
+    "chainKey": "amoy-testnet",
+    "chainStatus": "ACTIVE",
+    "nativeChainId": 80002,
+    "chainLayer": "L1",
+    "nativeCurrency": {
+      "symbol": "MATIC",
+      "cgId": "polygon-ecosystem-token",
+      "cmcId": 28321,
+      "decimals": 18
+    },
+    "chainType": "evm"
+  },
+  "dvns": {
+    "0x3ed2211f49ce343d70cb8ded927ca6c4a6198101": {
+      "version": 2,
+      "canonicalName": "Bitgo",
+      "id": "bitgo"
+    },
+    "0xe67ef84173d024603a844c4aea6a3a15ccccc32c": {
+      "version": 2,
+      "canonicalName": "Blockdaemon",
+      "id": "blockdaemon"
+    },
+    "0x5364192803e9c6da2e937ed602ac1854d4f223cb": {
+      "version": 2,
+      "canonicalName": "Frax",
+      "id": "frax"
+    },
+    "0xd44e25bea2bedcceceb7e104d5843a55d208e8a9": {
+      "version": 2,
+      "canonicalName": "Japan Blockchain Foundation",
+      "id": "joc"
+    },
+    "0x8ca915a3ea6b0757adb4a0358c54c62908230961": {
+      "id": "frax",
+      "version": 2,
+      "canonicalName": "Frax",
+      "deprecated": true
+    },
+    "0x02feab4e6ca6eebd60d85347762de70ca9ce162a": {
+      "id": "bitgo",
+      "version": 2,
+      "canonicalName": "Bitgo",
+      "deprecated": true
+    },
+    "0x35cea726508192472919c51951042dd140794b01": {
+      "version": 2,
+      "canonicalName": "Republic",
+      "id": "republic-crypto"
+    },
+    "0x55c175dd5b039331db251424538169d8495c18d1": {
+      "version": 2,
+      "canonicalName": "LayerZero Labs",
+      "id": "layerzero-labs"
+    }
+  },
+  "rpcs": [
+    {
+      "url": "https://rpc.ankr.com/polygon_amoy"
+    },
+    {
+      "url": "https://polygon-amoy.drpc.org"
+    },
+    {
+      "url": "https://rpc-amoy.polygon.technology"
+    }
+  ],
+  "addressToOApp": {
+    "0x6a4631a4ca1a7b1a6bbacae80915fa65d3250dc8": {
+      "id": "cadence-protocol",
+      "canonicalName": "Cadence Protocol"
+    },
+    "0x99e7dad184ee4b65ddba8744e00f4bfa49a98b3f": {
+      "id": "cadence-protocol",
+      "canonicalName": "Cadence Protocol"
+    },
+    "0xf64597697246f09aa71eb859f69512c4aabd4de5": {
+      "id": "hermes-v2",
+      "canonicalName": "Hermes V2"
+    },
+    "0x244e087d1bd4ffe7a75ababf1b60267f437d8d": {
+      "id": "cere-network",
+      "canonicalName": "Cere Network"
+    },
+    "0xcd23dbd7bdd30b5a9b31d4d7064c78ff0ce4c55d": {
+      "id": "synthr",
+      "canonicalName": "SYNTHR"
+    }
+  },
+  "chainName": "amoy",
+  "chainKey": "amoy-testnet"
+}

--- a/packages/metadata-tools/test/data/dummy-incomplete.json
+++ b/packages/metadata-tools/test/data/dummy-incomplete.json
@@ -1,0 +1,131 @@
+{
+  "created": "2024-12-12T03:31:20.000Z",
+  "updated": "2024-12-12T03:31:20.000Z",
+  "tableName": "layerzero-chain_metadata",
+  "environment": "testnet",
+  "blockExplorers": [
+    {
+      "url": "https://cchain.explorer.avax-test.network"
+    }
+  ],
+  "deployments": [
+    {
+      "eid": "49999",
+      "endpointV2View": {
+        "address": "0x31fFd858c7826817F830C3dF2bb2A74126d51126"
+      },
+      "chainKey": "dummy",
+      "stage": "testnet",
+      "endpointV2": {
+        "address": "0x6EDCE65403992e310A62460808c4b910D972f10f"
+      },
+      "sendUln302": {
+        "address": "0x69BF5f48d2072DfeBc670A1D19dff91D0F4E8170"
+      },
+      "lzExecutor": {
+        "address": "0x1356D9201036A216836925803512649d6BB2395e"
+      },
+      "blockedMessageLib": {
+        "address": "0x0c77d8d771ab35e2e184e7ce127f19ced31ff8c0"
+      },
+      "version": 2,
+      "receiveUln302": {
+        "address": "0x819F0FAF2cb1Fba15b9cB24c9A2BDaDb0f895daf"
+      }
+    }
+  ],
+  "chainDetails": {
+    "chainKey": "dummy",
+    "nativeChainId": 43113,
+    "chainLayer": "L1",
+    "nativeCurrency": {
+      "name": "Avalanche Token",
+      "symbol": "AVAX",
+      "cgId": "avalanche-2",
+      "cmcId": 5805,
+      "decimals": 18
+    },
+    "name": "dummy",
+    "chainType": "evm",
+    "shortName": "Avalanche"
+  },
+  "dvns": {
+    "0xca5ab7adcd3ea879f1a1c4eee81eaccd250173e4": {
+      "version": 2,
+      "canonicalName": "Switchboard",
+      "id": "switchboard"
+    },
+    "0x8ca279897cde74350bd880737fd60c047d6d3d64": {
+      "version": 2,
+      "canonicalName": "Bitgo",
+      "id": "bitgo",
+      "deprecated": true
+    },
+    "0x9f0e79aeb198750f963b6f30b99d87c6ee5a0467": {
+      "version": 2,
+      "canonicalName": "LayerZero Labs",
+      "id": "layerzero-labs"
+    },
+    "0x92cfdb3789693c2ae7225fcc2c263de94d630be4": {
+      "version": 1,
+      "canonicalName": "TSS",
+      "id": "tss"
+    },
+    "0xe0f3389bf8a8aa1576b420d888cd462483fdc2a0": {
+      "version": 2,
+      "canonicalName": "Delegate",
+      "id": "delegate"
+    },
+    "0xfde647565009b33b1df02689d5873bffff15d907": {
+      "version": 2,
+      "canonicalName": "Stablelab",
+      "id": "stablelab"
+    },
+    "0xdbec329a5e6d7fb0113eb0a098750d2afd61e9ae": {
+      "version": 2,
+      "canonicalName": "P2P",
+      "id": "p2p"
+    },
+    "0xefdd92121acb3acd6e2f09dd810752d8da3dfdaf": {
+      "version": 2,
+      "canonicalName": "Republic",
+      "id": "republic-crypto"
+    },
+    "0x071fbf35b35d48afc3edf84f0397980c25531560": {
+      "version": 2,
+      "canonicalName": "Gitcoin",
+      "id": "gitcoin"
+    },
+    "0xa4652582077afc447ea7c9e984d656ee4963fe95": {
+      "version": 2,
+      "canonicalName": "Google",
+      "id": "google-cloud"
+    },
+    "0x7883f83ea40a56137a63baf93bfee5b9b8c1c447": {
+      "version": 2,
+      "canonicalName": "Nethermind",
+      "id": "nethermind"
+    },
+    "0x0d88ab4c8e8f89d8d758cbd5a6373f86f7bd737b": {
+      "version": 2,
+      "canonicalName": "BWare",
+      "id": "bware-labs"
+    },
+    "0xa1d84e5576299acda9ffed53195eadbe60d48e83": {
+      "version": 2,
+      "canonicalName": "Bitgo",
+      "id": "bitgo"
+    },
+    "0xb1c95f6687299acda9ffed53195eadcf71d49f94": {
+      "version": 2,
+      "canonicalName": "Deprec",
+      "id": "deprec",
+      "deprecated": true
+    }
+  },
+  "rpcs": [],
+  "addressToOApp": {},
+  "chainName": "avalanche",
+  "tokens": {},
+  "chainKey": "dummy"
+}

--- a/packages/metadata-tools/test/data/fuji.json
+++ b/packages/metadata-tools/test/data/fuji.json
@@ -35,6 +35,9 @@
     },
     {
       "eid": "40106",
+      "endpointV2View": {
+        "address": "0x31fFd858c7826817F830C3dF2bb2A74126d51126"
+      },
       "chainKey": "fuji",
       "stage": "testnet",
       "executor": {
@@ -49,11 +52,8 @@
       "lzExecutor": {
         "address": "0x1356D9201036A216836925803512649d6BB2395e"
       },
-      "sendUln301": {
-        "address": "0x184e24e31657Cf853602589fe5304b144a826c85"
-      },
-      "receiveUln301": {
-        "address": "0x91df17bF1Ced54c6169e1E24722C0a88a447cBAf"
+      "blockedMessageLib": {
+        "address": "0x0c77d8d771ab35e2e184e7ce127f19ced31ff8c0"
       },
       "version": 2,
       "receiveUln302": {

--- a/packages/metadata-tools/test/data/solana-testnet.json
+++ b/packages/metadata-tools/test/data/solana-testnet.json
@@ -63,6 +63,11 @@
       "version": 2,
       "canonicalName": "Paxos",
       "id": "paxos"
+    },
+    "29EKzmCscUg8mf4f5uskwMqvu2SXM8hKF1gWi1cCBoKT": {
+      "version": 2,
+      "canonicalName": "P2P",
+      "id": "p2p"
     }
   },
   "rpcs": [

--- a/packages/protocol-devtools-evm/src/endpointv2/sdk.ts
+++ b/packages/protocol-devtools-evm/src/endpointv2/sdk.ts
@@ -437,7 +437,14 @@ export class EndpointV2 extends OmniSDK implements IEndpointV2 {
     }
 
     async isBlockedLibrary(uln: OmniAddress): Promise<boolean> {
-        return (await this.contract.contract.blockedLibrary()) === addChecksum(uln)
+        assert(!isZero(this.contract.contract.address), 'EndpointV2 can not be zero')
+
+        try {
+            return (await this.contract.contract.blockedLibrary()) === addChecksum(uln)
+        } catch (error) {
+            this.logger.error('Error calling EndpointV2.blockedLibrary()', error)
+            return false
+        }
     }
 
     async registerLibrary(uln: OmniAddress): Promise<OmniTransaction> {

--- a/packages/protocol-devtools-evm/src/uln302/blockedSdk.ts
+++ b/packages/protocol-devtools-evm/src/uln302/blockedSdk.ts
@@ -1,0 +1,71 @@
+import type { EndpointId } from '@layerzerolabs/lz-definitions'
+import type {
+    Uln302ConfigType,
+    Uln302ExecutorConfig,
+    Uln302UlnConfig,
+    Uln302UlnUserConfig,
+} from '@layerzerolabs/protocol-devtools'
+import { OmniAddress, formatEid } from '@layerzerolabs/devtools'
+import { AsyncRetriable } from '@layerzerolabs/devtools'
+import { Uln302 } from './sdk'
+
+export class BlockedUln302 extends Uln302 {
+    @AsyncRetriable()
+    override async getAppUlnConfig(
+        _eid: EndpointId,
+        _address: OmniAddress,
+        _type: Uln302ConfigType
+    ): Promise<Uln302UlnConfig> {
+        throw new Error('BlockedUln302.getAppUlnConfig is not implemented')
+    }
+
+    /**
+     * @see {@link IUln302.hasAppUlnConfig}
+     */
+    override async hasAppUlnConfig(
+        eid: EndpointId,
+        oapp: string,
+        _config: Uln302UlnUserConfig,
+        type: Uln302ConfigType
+    ): Promise<boolean> {
+        this.logger.verbose(
+            `Skipping check for ULN ${type} configs for eid ${eid} (${formatEid(eid)}) and OApp ${oapp} because the message library is BlockedMessageLib`
+        )
+
+        return true
+    }
+
+    /**
+     * @see {@link IUln302.getExecutorConfig}
+     */
+    @AsyncRetriable()
+    override async getExecutorConfig(
+        _eid: EndpointId,
+        _address?: OmniAddress | null | undefined
+    ): Promise<Uln302ExecutorConfig> {
+        throw new Error('BlockedUln302.getExecutorConfig is not implemented')
+    }
+
+    /**
+     * @see {@link IUln302.getAppExecutorConfig}
+     */
+    @AsyncRetriable()
+    override async getAppExecutorConfig(_eid: EndpointId, _address: OmniAddress): Promise<Uln302ExecutorConfig> {
+        throw new Error('BlockedUln302.getAppExecutorConfig is not implemented')
+    }
+
+    /**
+     * @see {@link IUln302.hasAppExecutorConfig}
+     */
+    override async hasAppExecutorConfig(
+        eid: EndpointId,
+        oapp: OmniAddress,
+        _config: Uln302ExecutorConfig
+    ): Promise<boolean> {
+        this.logger.debug(
+            `Skipping check for Executor configs for eid ${eid} (${formatEid(eid)}) and OApp ${oapp} because the message library is BlockedMessageLib`
+        )
+
+        return true
+    }
+}

--- a/packages/protocol-devtools-evm/src/uln302/blockedSdk.ts
+++ b/packages/protocol-devtools-evm/src/uln302/blockedSdk.ts
@@ -12,11 +12,23 @@ import { Uln302 } from './sdk'
 export class BlockedUln302 extends Uln302 {
     @AsyncRetriable()
     override async getAppUlnConfig(
-        _eid: EndpointId,
-        _address: OmniAddress,
+        eid: EndpointId,
+        address: OmniAddress,
         _type: Uln302ConfigType
     ): Promise<Uln302UlnConfig> {
-        throw new Error('BlockedUln302.getAppUlnConfig is not implemented')
+        this.logger.verbose(
+            `Returning blocked config for ULN configs for eid ${eid} (${formatEid(eid)}) and OApp ${address} because the message library is BlockedMessageLib`
+        )
+
+        // Return a config that indicates the library is blocked
+        // Using type(uint8).max for requiredDVNCount to match the contract behavior
+        return {
+            confirmations: BigInt(0),
+            requiredDVNs: [],
+            optionalDVNs: [],
+            optionalDVNThreshold: 0,
+            requiredDVNCount: 255, // type(uint8).max indicates blocked
+        }
     }
 
     /**
@@ -36,22 +48,58 @@ export class BlockedUln302 extends Uln302 {
     }
 
     /**
-     * @see {@link IUln302.getExecutorConfig}
+     * @see {@link IUln302.getUlnConfig}
      */
     @AsyncRetriable()
-    override async getExecutorConfig(
-        _eid: EndpointId,
-        _address?: OmniAddress | null | undefined
-    ): Promise<Uln302ExecutorConfig> {
-        throw new Error('BlockedUln302.getExecutorConfig is not implemented')
+    override async getUlnConfig(
+        eid: EndpointId,
+        address?: OmniAddress,
+        _type?: Uln302ConfigType
+    ): Promise<Uln302UlnConfig> {
+        this.logger.verbose(
+            `Returning blocked config for ULN configs for eid ${eid} (${formatEid(eid)}) and OApp ${address} because the message library is BlockedMessageLib`
+        )
+
+        // Return a config that indicates the library is blocked
+        return {
+            confirmations: BigInt(0),
+            requiredDVNs: [],
+            optionalDVNs: [],
+            optionalDVNThreshold: 0,
+            requiredDVNCount: 255, // type(uint8).max indicates blocked
+        }
     }
 
     /**
      * @see {@link IUln302.getAppExecutorConfig}
      */
     @AsyncRetriable()
-    override async getAppExecutorConfig(_eid: EndpointId, _address: OmniAddress): Promise<Uln302ExecutorConfig> {
-        throw new Error('BlockedUln302.getAppExecutorConfig is not implemented')
+    override async getAppExecutorConfig(eid: EndpointId, address: OmniAddress): Promise<Uln302ExecutorConfig> {
+        this.logger.verbose(
+            `Returning blocked config for Executor configs for eid ${eid} (${formatEid(eid)}) and OApp ${address} because the message library is BlockedMessageLib`
+        )
+
+        // Return a minimal executor config for blocked lib
+        return {
+            executor: '0x0000000000000000000000000000000000000000',
+            maxMessageSize: 0,
+        }
+    }
+
+    /**
+     * @see {@link IUln302.getExecutorConfig}
+     */
+    @AsyncRetriable()
+    override async getExecutorConfig(eid: EndpointId, address?: OmniAddress): Promise<Uln302ExecutorConfig> {
+        this.logger.verbose(
+            `Returning blocked config for Executor configs for eid ${eid} (${formatEid(eid)}) and OApp ${address} because the message library is BlockedMessageLib`
+        )
+
+        // Return a minimal executor config for blocked lib
+        return {
+            executor: '0x0000000000000000000000000000000000000000',
+            maxMessageSize: 0,
+        }
     }
 
     /**

--- a/packages/protocol-devtools-evm/src/uln302/index.ts
+++ b/packages/protocol-devtools-evm/src/uln302/index.ts
@@ -1,3 +1,4 @@
 export * from './factory'
 export * from './sdk'
 export * from './types'
+export * from './blockedSdk'

--- a/packages/protocol-devtools-evm/src/uln302/schema.ts
+++ b/packages/protocol-devtools-evm/src/uln302/schema.ts
@@ -13,6 +13,7 @@ import type { Uln302ExecutorConfigInput, Uln302UlnConfigInput } from './types'
 export const Uln302UlnConfigSchema = Uln302UlnConfigSchemaBase.extend({
     confirmations: BigNumberishBigIntSchema,
     optionalDVNThreshold: z.number(),
+    requiredDVNCount: z.number(),
 }) satisfies z.ZodSchema<Uln302UlnConfig, z.ZodTypeDef, Uln302UlnConfigInput>
 
 /**

--- a/packages/protocol-devtools-evm/src/uln302/sdk.ts
+++ b/packages/protocol-devtools-evm/src/uln302/sdk.ts
@@ -24,6 +24,9 @@ import { Contract } from '@ethersproject/contracts'
 // because it contains all the necessary method fragments
 import { abi } from '@layerzerolabs/lz-evm-sdk-v2/artifacts/contracts/uln/uln302/SendUln302.sol/SendUln302.json'
 
+// A value used to indicate that no DVNs are required. It has to be used instead of 0, because 0 falls back to default value.
+const NIL_DVN_COUNT = (1 << 8) - 1 // type(uint8).max = 255
+
 export class Uln302 extends OmniSDK implements IUln302 {
     constructor(provider: Provider, point: OmniPoint) {
         super({ eid: point.eid, contract: new Contract(point.address, abi).connect(provider) })
@@ -249,7 +252,7 @@ export class Uln302 extends OmniSDK implements IUln302 {
     protected serializeUlnConfig({
         confirmations = BigInt(0),
         requiredDVNs,
-        requiredDVNCount = requiredDVNs.length,
+        requiredDVNCount = requiredDVNs.length > 0 ? requiredDVNs.length : NIL_DVN_COUNT,
         optionalDVNs = [],
         optionalDVNThreshold = 0,
     }: Uln302UlnUserConfig): SerializedUln302UlnConfig {

--- a/packages/protocol-devtools-evm/src/ulnRead/sdk.ts
+++ b/packages/protocol-devtools-evm/src/ulnRead/sdk.ts
@@ -16,6 +16,9 @@ import { Contract } from '@ethersproject/contracts'
 // because it contains all the necessary method fragments
 import { abi } from '@layerzerolabs/lz-evm-sdk-v2/artifacts/contracts/uln/readlib/ReadLib1002.sol/ReadLib1002.json'
 
+// A value used to indicate that no DVNs are required. It has to be used instead of 0, because 0 falls back to default value.
+const NIL_DVN_COUNT = (1 << 8) - 1 // type(uint8).max = 255
+
 export class UlnRead extends OmniSDK implements IUlnRead {
     constructor(provider: Provider, point: OmniPoint) {
         super({ eid: point.eid, contract: new Contract(point.address, abi).connect(provider) })
@@ -126,7 +129,7 @@ export class UlnRead extends OmniSDK implements IUlnRead {
     }: UlnReadUlnUserConfig): SerializedUlnReadUlnConfig {
         return {
             executor,
-            requiredDVNCount: requiredDVNs.length,
+            requiredDVNCount: requiredDVNs.length > 0 ? requiredDVNs.length : NIL_DVN_COUNT,
             optionalDVNCount: optionalDVNs.length,
             optionalDVNThreshold,
             requiredDVNs: requiredDVNs.map(addChecksum).sort(compareBytes32Ascending),

--- a/packages/protocol-devtools-evm/test/integration/nil-dvn-consistency.test.ts
+++ b/packages/protocol-devtools-evm/test/integration/nil-dvn-consistency.test.ts
@@ -1,0 +1,127 @@
+import { MainnetV2EndpointId } from '@layerzerolabs/lz-definitions'
+import { makeZeroAddress, Provider } from '@layerzerolabs/devtools-evm'
+import { Uln302 } from '@/uln302'
+import { UlnRead } from '@/ulnRead'
+import type { Uln302UlnUserConfig, UlnReadUlnUserConfig } from '@layerzerolabs/protocol-devtools'
+import { JsonRpcProvider } from '@ethersproject/providers'
+
+// The NIL_DVN_COUNT constant value
+const NIL_DVN_COUNT = 255
+
+describe('NIL_DVN_COUNT consistency across SDKs', () => {
+    let provider: Provider
+
+    beforeEach(async () => {
+        provider = new JsonRpcProvider()
+    })
+
+    describe('Empty requiredDVNs behavior', () => {
+        it('should be consistent between ULN302 and ULNRead SDKs', () => {
+            // Create SDK instances
+            const uln302Sdk = new Uln302(provider, {
+                eid: MainnetV2EndpointId.ETHEREUM_V2_MAINNET,
+                address: makeZeroAddress(),
+            })
+            const ulnReadSdk = new UlnRead(provider, {
+                eid: MainnetV2EndpointId.ETHEREUM_V2_MAINNET,
+                address: makeZeroAddress(),
+            })
+
+            // ULN302 config with empty DVNs
+            const uln302Config: Uln302UlnUserConfig = {
+                requiredDVNs: [],
+                optionalDVNs: [],
+                optionalDVNThreshold: 0,
+                confirmations: BigInt(0),
+            }
+
+            // ULNRead config with empty DVNs
+            const ulnReadConfig: UlnReadUlnUserConfig = {
+                requiredDVNs: [],
+                optionalDVNs: [],
+                optionalDVNThreshold: 0,
+                executor: makeZeroAddress(),
+            }
+
+            // Serialize both configs
+            const serialized302 = (uln302Sdk as any).serializeUlnConfig(uln302Config)
+            const serializedRead = (ulnReadSdk as any).serializeUlnConfig(ulnReadConfig)
+
+            // Both should use NIL_DVN_COUNT
+            expect(serialized302.requiredDVNCount).toBe(NIL_DVN_COUNT)
+            expect(serializedRead.requiredDVNCount).toBe(NIL_DVN_COUNT)
+
+            // Optional DVN count should still be 0
+            expect(serialized302.optionalDVNCount).toBe(0)
+            expect(serializedRead.optionalDVNCount).toBe(0)
+        })
+
+        it('should handle non-empty arrays consistently', () => {
+            const uln302Sdk = new Uln302(provider, {
+                eid: MainnetV2EndpointId.ETHEREUM_V2_MAINNET,
+                address: makeZeroAddress(),
+            })
+            const ulnReadSdk = new UlnRead(provider, {
+                eid: MainnetV2EndpointId.ETHEREUM_V2_MAINNET,
+                address: makeZeroAddress(),
+            })
+
+            const dvns = [makeZeroAddress(), makeZeroAddress()]
+
+            const uln302Config: Uln302UlnUserConfig = {
+                requiredDVNs: dvns,
+                optionalDVNs: [makeZeroAddress()],
+                optionalDVNThreshold: 1,
+                confirmations: BigInt(15),
+            }
+
+            const ulnReadConfig: UlnReadUlnUserConfig = {
+                requiredDVNs: dvns,
+                optionalDVNs: [makeZeroAddress()],
+                optionalDVNThreshold: 1,
+                executor: makeZeroAddress(),
+            }
+
+            const serialized302 = (uln302Sdk as any).serializeUlnConfig(uln302Config)
+            const serializedRead = (ulnReadSdk as any).serializeUlnConfig(ulnReadConfig)
+
+            // Both should use actual array length
+            expect(serialized302.requiredDVNCount).toBe(2)
+            expect(serializedRead.requiredDVNCount).toBe(2)
+
+            // Optional DVN count should be 1
+            expect(serialized302.optionalDVNCount).toBe(1)
+            expect(serializedRead.optionalDVNCount).toBe(1)
+        })
+    })
+
+    describe('Edge cases', () => {
+        it('should distinguish between empty array (255) and explicit zero override', () => {
+            const uln302Sdk = new Uln302(provider, {
+                eid: MainnetV2EndpointId.ETHEREUM_V2_MAINNET,
+                address: makeZeroAddress(),
+            })
+
+            // Empty array should give 255
+            const emptyConfig: Uln302UlnUserConfig = {
+                requiredDVNs: [],
+                optionalDVNs: [],
+                optionalDVNThreshold: 0,
+                confirmations: BigInt(0),
+            }
+            const serializedEmpty = (uln302Sdk as any).serializeUlnConfig(emptyConfig)
+            expect(serializedEmpty.requiredDVNCount).toBe(NIL_DVN_COUNT)
+
+            // But explicit 0 override should be honored
+            const explicitZeroConfig: Uln302UlnUserConfig = {
+                requiredDVNs: [],
+                requiredDVNCount: 0, // Explicit override to use chain defaults
+                optionalDVNs: [],
+                optionalDVNThreshold: 0,
+                confirmations: BigInt(0),
+            }
+            const serializedZero = (uln302Sdk as any).serializeUlnConfig(explicitZeroConfig)
+            expect(serializedZero.requiredDVNCount).toBe(0)
+        })
+    })
+})

--- a/packages/protocol-devtools-evm/test/uln302/nil-dvn-count.test.ts
+++ b/packages/protocol-devtools-evm/test/uln302/nil-dvn-count.test.ts
@@ -1,0 +1,64 @@
+import { MainnetV2EndpointId } from '@layerzerolabs/lz-definitions'
+import { makeZeroAddress, Provider } from '@layerzerolabs/devtools-evm'
+import { Uln302 } from '@/uln302'
+import type { Uln302UlnUserConfig } from '@layerzerolabs/protocol-devtools'
+import { JsonRpcProvider } from '@ethersproject/providers'
+
+// The NIL_DVN_COUNT constant value
+const NIL_DVN_COUNT = 255
+
+describe('uln302/nil-dvn-count', () => {
+    let provider: Provider, ulnSdk: Uln302
+
+    beforeEach(async () => {
+        provider = new JsonRpcProvider()
+        ulnSdk = new Uln302(provider, { eid: MainnetV2EndpointId.ETHEREUM_V2_MAINNET, address: makeZeroAddress() })
+    })
+
+    describe('serializeUlnConfig with empty DVN arrays', () => {
+        it('should use NIL_DVN_COUNT (255) when requiredDVNs is empty', () => {
+            const config: Uln302UlnUserConfig = {
+                requiredDVNs: [],
+                optionalDVNs: [],
+                optionalDVNThreshold: 0,
+                confirmations: BigInt(0),
+            }
+
+            // Use reflection to access the protected method
+            const serialized = (ulnSdk as any).serializeUlnConfig(config)
+
+            expect(serialized.requiredDVNCount).toBe(NIL_DVN_COUNT)
+            expect(serialized.optionalDVNCount).toBe(0) // Optional DVNs should still use array length
+        })
+
+        it('should use actual array length when requiredDVNs is not empty', () => {
+            const config: Uln302UlnUserConfig = {
+                requiredDVNs: [makeZeroAddress(), makeZeroAddress()],
+                optionalDVNs: [makeZeroAddress()],
+                optionalDVNThreshold: 1,
+                confirmations: BigInt(15),
+            }
+
+            // Use reflection to access the protected method
+            const serialized = (ulnSdk as any).serializeUlnConfig(config)
+
+            expect(serialized.requiredDVNCount).toBe(2) // Should be actual array length
+            expect(serialized.optionalDVNCount).toBe(1)
+        })
+
+        it('should handle requiredDVNCount override correctly', () => {
+            const config: Uln302UlnUserConfig = {
+                requiredDVNs: [],
+                requiredDVNCount: 100, // Explicit override
+                optionalDVNs: [],
+                optionalDVNThreshold: 0,
+                confirmations: BigInt(0),
+            }
+
+            // Use reflection to access the protected method
+            const serialized = (ulnSdk as any).serializeUlnConfig(config)
+
+            expect(serialized.requiredDVNCount).toBe(100) // Should use the override
+        })
+    })
+})

--- a/packages/protocol-devtools-evm/test/uln302/sdk.test.ts
+++ b/packages/protocol-devtools-evm/test/uln302/sdk.test.ts
@@ -58,6 +58,7 @@ describe('uln302/sdk', () => {
                         optionalDVNThreshold: 0,
                         optionalDVNs: dvns,
                         requiredDVNs: dvns,
+                        requiredDVNCount: dvns.length,
                     }
 
                     const ulnConfigSorted: Uln302UlnConfig = {
@@ -85,6 +86,7 @@ describe('uln302/sdk', () => {
                         optionalDVNThreshold: 0,
                         optionalDVNs: dvns,
                         requiredDVNs: dvns,
+                        requiredDVNCount: dvns.length,
                     }
 
                     const ulnConfigSorted: Uln302UlnConfig = {
@@ -133,6 +135,7 @@ describe('uln302/sdk', () => {
                         confirmations: BigInt(0),
                         optionalDVNThreshold: 0,
                         optionalDVNs: [],
+                        requiredDVNCount: dvns.length,
                     }
 
                     // Let's check that both the sorted and the unsorted config produce the same transaction
@@ -171,6 +174,7 @@ describe('uln302/sdk', () => {
                 optionalDVNThreshold: fc.integer({ min: 0, max: dvns.length }),
                 optionalDVNs: fc.constant(dvns),
                 requiredDVNs: fc.constant(dvns),
+                requiredDVNCount: fc.constant(dvns.length),
             })
         )
 
@@ -245,6 +249,7 @@ describe('uln302/sdk', () => {
                         optionalDVNs: [],
                         optionalDVNThreshold: 0,
                         confirmations: BigInt(0),
+                        requiredDVNCount: dvns.length,
                     }
 
                     getAppUlnConfigSpy.mockReset()

--- a/packages/protocol-devtools-evm/test/ulnRead/nil-dvn-count.test.ts
+++ b/packages/protocol-devtools-evm/test/ulnRead/nil-dvn-count.test.ts
@@ -1,0 +1,49 @@
+import { MainnetV2EndpointId } from '@layerzerolabs/lz-definitions'
+import { makeZeroAddress, Provider } from '@layerzerolabs/devtools-evm'
+import { UlnRead } from '@/ulnRead'
+import type { UlnReadUlnUserConfig } from '@layerzerolabs/protocol-devtools'
+import { JsonRpcProvider } from '@ethersproject/providers'
+
+// The NIL_DVN_COUNT constant value
+const NIL_DVN_COUNT = 255
+
+describe('ulnRead/nil-dvn-count', () => {
+    let provider: Provider, ulnSdk: UlnRead
+
+    beforeEach(async () => {
+        provider = new JsonRpcProvider()
+        ulnSdk = new UlnRead(provider, { eid: MainnetV2EndpointId.ETHEREUM_V2_MAINNET, address: makeZeroAddress() })
+    })
+
+    describe('serializeUlnConfig with empty DVN arrays', () => {
+        it('should use NIL_DVN_COUNT (255) when requiredDVNs is empty', () => {
+            const config: UlnReadUlnUserConfig = {
+                requiredDVNs: [],
+                optionalDVNs: [],
+                optionalDVNThreshold: 0,
+                executor: makeZeroAddress(),
+            }
+
+            // Use reflection to access the protected method
+            const serialized = (ulnSdk as any).serializeUlnConfig(config)
+
+            expect(serialized.requiredDVNCount).toBe(NIL_DVN_COUNT)
+            expect(serialized.optionalDVNCount).toBe(0) // Optional DVNs should still use array length
+        })
+
+        it('should use actual array length when requiredDVNs is not empty', () => {
+            const config: UlnReadUlnUserConfig = {
+                requiredDVNs: [makeZeroAddress(), makeZeroAddress()],
+                optionalDVNs: [makeZeroAddress()],
+                optionalDVNThreshold: 1,
+                executor: makeZeroAddress(),
+            }
+
+            // Use reflection to access the protected method
+            const serialized = (ulnSdk as any).serializeUlnConfig(config)
+
+            expect(serialized.requiredDVNCount).toBe(2) // Should be actual array length
+            expect(serialized.optionalDVNCount).toBe(1)
+        })
+    })
+})

--- a/packages/protocol-devtools-solana/src/endpointv2/schema.ts
+++ b/packages/protocol-devtools-solana/src/endpointv2/schema.ts
@@ -14,10 +14,10 @@ export const SetConfigSchema = z.union([
     z.object({
         configType: z.union([z.literal(SetConfigType.RECEIVE_ULN), z.literal(SetConfigType.SEND_ULN)]),
         config: Uln302UlnConfigSchema.transform(
-            ({ confirmations, requiredDVNs, optionalDVNs, optionalDVNThreshold }) => ({
+            ({ confirmations, requiredDVNs, optionalDVNs, optionalDVNThreshold, requiredDVNCount }) => ({
                 confirmations: Number(confirmations),
                 optionalDvnCount: optionalDVNs.length,
-                requiredDvnCount: requiredDVNs.length,
+                requiredDvnCount: requiredDVNCount,
                 requiredDvns: requiredDVNs.map((dvn) => new PublicKey(dvn)),
                 optionalDvns: optionalDVNs.map((dvn) => new PublicKey(dvn)),
                 optionalDvnThreshold: optionalDVNThreshold,

--- a/packages/protocol-devtools-solana/src/endpointv2/sdk.ts
+++ b/packages/protocol-devtools-solana/src/endpointv2/sdk.ts
@@ -548,6 +548,10 @@ export class EndpointV2 extends OmniSDK implements IEndpointV2 {
         throw new TypeError(`isRegisteredLibrary() not implemented on Solana Endpoint SDK`)
     }
 
+    async isBlockedLibrary(_uln: OmniAddress): Promise<boolean> {
+        throw new TypeError(`isBlockedLibrary() not implemented on Solana Endpoint SDK`)
+    }
+
     async registerLibrary(): Promise<OmniTransaction> {
         throw new TypeError(`registerLibrary() not implemented on Solana Endpoint SDK`)
     }

--- a/packages/protocol-devtools-solana/src/uln302/schema.ts
+++ b/packages/protocol-devtools-solana/src/uln302/schema.ts
@@ -9,10 +9,12 @@ export const Uln302UlnConfigInputSchema: z.ZodSchema<Uln302UlnConfig, z.ZodTypeD
         optionalDvnThreshold: UIntNumberSchema,
         requiredDvns: z.array(PublicKeyBase58Schema),
         optionalDvns: z.array(PublicKeyBase58Schema),
+        requiredDvnCount: UIntNumberSchema,
     })
-    .transform(({ confirmations, optionalDvnThreshold, requiredDvns, optionalDvns }) => ({
+    .transform(({ confirmations, optionalDvnThreshold, requiredDvns, optionalDvns, requiredDvnCount }) => ({
         confirmations,
         optionalDVNThreshold: optionalDvnThreshold,
         requiredDVNs: requiredDvns,
         optionalDVNs: optionalDvns,
+        requiredDVNCount: requiredDvnCount,
     }))

--- a/packages/protocol-devtools-solana/src/uln302/sdk.ts
+++ b/packages/protocol-devtools-solana/src/uln302/sdk.ts
@@ -226,6 +226,7 @@ export class Uln302 extends OmniSDK implements IUln302 {
     protected serializeUlnConfig({
         confirmations = BigInt(0),
         requiredDVNs,
+        requiredDVNCount = requiredDVNs.length,
         optionalDVNs = [],
         optionalDVNThreshold = 0,
     }: Uln302UlnUserConfig): SerializedUln302UlnConfig {
@@ -234,7 +235,7 @@ export class Uln302 extends OmniSDK implements IUln302 {
             optionalDVNThreshold,
             requiredDVNs: serializeDVNs(requiredDVNs),
             optionalDVNs: serializeDVNs(optionalDVNs),
-            requiredDVNCount: requiredDVNs.length,
+            requiredDVNCount,
             optionalDVNCount: optionalDVNs.length,
         }
     }

--- a/packages/protocol-devtools-solana/src/uln302/sdk.ts
+++ b/packages/protocol-devtools-solana/src/uln302/sdk.ts
@@ -226,7 +226,6 @@ export class Uln302 extends OmniSDK implements IUln302 {
     protected serializeUlnConfig({
         confirmations = BigInt(0),
         requiredDVNs,
-        requiredDVNCount = requiredDVNs.length,
         optionalDVNs = [],
         optionalDVNThreshold = 0,
     }: Uln302UlnUserConfig): SerializedUln302UlnConfig {
@@ -235,7 +234,7 @@ export class Uln302 extends OmniSDK implements IUln302 {
             optionalDVNThreshold,
             requiredDVNs: serializeDVNs(requiredDVNs),
             optionalDVNs: serializeDVNs(optionalDVNs),
-            requiredDVNCount,
+            requiredDVNCount: requiredDVNs.length,
             optionalDVNCount: optionalDVNs.length,
         }
     }

--- a/packages/protocol-devtools/src/endpointv2/types.ts
+++ b/packages/protocol-devtools/src/endpointv2/types.ts
@@ -38,6 +38,7 @@ export interface IEndpointV2 extends IOmniSDK {
 
     isRegisteredLibrary(uln: OmniAddress): Promise<boolean>
     registerLibrary(uln: OmniAddress): Promise<OmniTransaction>
+    isBlockedLibrary(uln: OmniAddress): Promise<boolean>
 
     getSendLibrary(sender: OmniAddress, dstEid: EndpointId): Promise<OmniAddress | undefined>
     getReceiveLibrary(

--- a/packages/ua-devtools/src/oapp/config.ts
+++ b/packages/ua-devtools/src/oapp/config.ts
@@ -106,7 +106,7 @@ export const configureSendLibraries: OAppConfigurator = withOAppLogger(
                 const isDefaultLibrary = await endpointSdk.isDefaultSendLibrary(from.address, to.eid)
                 const currentSendLibrary = await endpointSdk.getSendLibrary(from.address, to.eid)
 
-                if (!isDefaultLibrary && currentSendLibrary === config.sendLibrary) {
+                if (!isDefaultLibrary && currentSendLibrary?.toLowerCase() === config.sendLibrary.toLowerCase()) {
                     logger.verbose(
                         `Current sendLibrary is not default library and is already set to ${config.sendLibrary} for ${formatOmniVector({ from, to })}, skipping`
                     )

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4216,6 +4216,9 @@ importers:
 
   packages/metadata-tools:
     devDependencies:
+      '@ethersproject/address':
+        specifier: ~5.7.0
+        version: 5.7.0
       '@layerzerolabs/devtools-evm-hardhat':
         specifier: ~4.0.0
         version: link:../devtools-evm-hardhat


### PR DESCRIPTION
Long time coming changes:
- Support no required DVNs (NIL_DVN_COUNT) - only optional DVNs on EVM and Solana
- Support no block confirmations (NIL_BLOCK_CONFIRMATIONS) on EVM
- Support Blocked Message Library on EVM

Out of scope of this PR:
- Block Message Lib support on non-EVMs
- Changing simple config interface to a map vs an array

## New possibilities

1. If you leave required DVNs empty it will now set it to empty array in ULN config, instead of using default required DVNs. Eg. now you can use requiredDVNs = [], and optionalDVNs = [X, Y]; previously you had to use at least one required DVN otherwise requiredDVN would fall back to the default
2. Support NO BLOCK CONFIRMATIONS, I think it works in the way where DVN doesn't wait for any block confirmations before verifying on destination chain; To use it: import NIL_BLOCK_CONFIRMATIONS from metadata package and use it in your simple config as block confirmation value. Make sure to pass NIL_BLOCK_CONFIRMATIONS as bigint, because it is too big for standard JavaScript Number type
3. Support bigint in addition to number in block confirmations - can allow bigger block confirmations values
4. Support Blocked Message Library -  instead of block confirmation being a number or bigint, you can now also pass an array like: `[number, 'BLOCK_SEND_AND_RECEIVE']` or you can import `MSG_LIB_BLOCK_SEND_AND_RECEIVE` from metadata and use: `[number, MSG_LIB_BLOCK_SEND_AND_RECEIVE]` to indicate that you want to use Blocked Message Library on that specific pathway. Blocked Message Library `MSG_LIB_BLOCK_SEND_AND_RECEIVE` option disables particular pathway, it blocks sending and receiving. There are also other options supported: `MSG_LIB_BLOCK_SEND_ONLY` and `MSG_LIB_BLOCK_RECEIVE_ONLY`.

## Backwards compatibility

✅  - old tests unmodified except snapshot has now requiredDVNCount, which doesn't break anything. If anyone faces problems with requiredDVNCount unsupported we can point them to upgrade to:
- @layerzerolabs/protocol-devtools@1.1.7 
- @layerzerolabs/protocol-devtools-evm@3.0.8

after https://github.com/LayerZero-Labs/devtools/pull/1512 is merged and packages are published.

## Testing

Added tests, but as well tested on a partner that has three optional DVNs and no required DVNs:
- https://layerzeroscan.com/tx/0xaf8278878952203225ae4f53f523bbe77e0fab210e63021cd0976512252466a0
- https://layerzeroscan.com/tx/0x03fd5c8e7faa21fdaba68c33f89d450a6c4d0d602f2c49997e960c96d40a5c43

If you want test yourself:

- clone devtools, pick feat/simple-no-req-dvns branch
- go to some examples in devtools, eg devtools/examples/oft and deploy some mock contracts on testnet
- modify your layerzero.config.ts to use simple config and experiment with new options

