### PR TITLE
Update lzapp migration example for v1 receive executor config

### DIFF
--- a/examples/lzapp-migration/layerzero.config.ts
+++ b/examples/lzapp-migration/layerzero.config.ts
@@ -95,6 +95,7 @@ const config: OAppOmniGraphHardhat = {
                 // Optional Receive Configuration
                 // @dev Controls how the `from` chain receives messages from the `to` chain.
                 receiveConfig: {
+                    executorConfig: '0x718B92b5CB0a5552039B593faF724D182A881eDA',
                     ulnConfig: {
                         // The number of block confirmations to expect from the `to` chain.
                         confirmations: BigInt(15),

--- a/examples/lzapp-migration/lzapp.config.ts
+++ b/examples/lzapp-migration/lzapp.config.ts
@@ -45,6 +45,7 @@ const config: OAppOmniGraphHardhat = {
                     },
                 },
                 receiveConfig: {
+                    executorConfig: '0x718B92b5CB0a5552039B593faF724D182A881eDA',
                     ulnConfig: {
                         confirmations: BigInt(1),
                         requiredDVNs: ['0x53f488e93b4f1b60e8e83aa374dbe1780a1ee8a8'], // LayerZero Labs DVN for Arbitrum Sepolia


### PR DESCRIPTION
## Summary
- support receive-side executor config for LayerZero v1 chains
- wire in receive executor config for v1 eids
- update example configs with executorConfig values

## Testing
- `pnpm lint` *(fails: getaddrinfo ENOTFOUND registry.npmjs.org)*
- `pnpm test` *(fails: toolbox-foundry build error)*