### PR TITLE
Not reaching latest version when looking up msg libs

### DIFF
--- a/examples/lzapp-migration/tasks/common/taskHelper.ts
+++ b/examples/lzapp-migration/tasks/common/taskHelper.ts
@@ -440,7 +440,7 @@ export async function getLibraryIndex(
 
         const endpointContract = new Contract(endpointDeployment.address, endpointDeployment.abi, signer)
 
-        const MAX_ITERATIONS = await endpointContract.latestVersion() // Adjust based on expected number of libraries
+        const MAX_ITERATIONS = await endpointContract.latestVersion()
 
         for (let i = 0; i <= MAX_ITERATIONS; i++) {
             const currentLibraryAddress = await endpointContract.libraryLookup(i)

--- a/examples/lzapp-migration/tasks/common/taskHelper.ts
+++ b/examples/lzapp-migration/tasks/common/taskHelper.ts
@@ -440,9 +440,9 @@ export async function getLibraryIndex(
 
         const endpointContract = new Contract(endpointDeployment.address, endpointDeployment.abi, signer)
 
-        const MAX_ITERATIONS = 6 // Adjust based on expected number of libraries
+        const MAX_ITERATIONS = await endpointContract.latestVersion() // Adjust based on expected number of libraries
 
-        for (let i = 0; i < MAX_ITERATIONS; i++) {
+        for (let i = 0; i <= MAX_ITERATIONS; i++) {
             const currentLibraryAddress = await endpointContract.libraryLookup(i)
             if (currentLibraryAddress === libraryAddress) {
                 return i


### PR DESCRIPTION
Fixed issue with not reaching latest version when attempting to get uln301 msg libs

In BSC testnet, the uln301 versions are 8 and 9.

Hardcoding that to 6 causes issues for partners during uln301 testing.