### PR TITLE
Use simple-config for lzapp-migration example

### DIFF
--- a/.changeset/simple-config-migration.md
+++ b/.changeset/simple-config-migration.md
@@ -1,0 +1,6 @@
+---
+"@layerzerolabs/metadata-tools": minor
+"@layerzerolabs/lzapp-migration-example": patch
+---
+feat: support EndpointV1 ULN addresses in `metadata-tools` and update the
+lzapp-migration example to use the metadata-based simple config

--- a/examples/lzapp-migration/README.md
+++ b/examples/lzapp-migration/README.md
@@ -93,12 +93,10 @@ networks: {
         eid: EndpointId.SEPOLIA_TESTNET,
 ```
 
-In `layerzero.config.ts`, for the pathway from Sepolia to Solana, we have specified the following:
-
-- `sendLibrary`: `0x6862b19f6e42a810946B9C782E6ebE26Ad266C84` (SendUln301)
-- `receiveLibraryConfig.receiveLibrary`: `0x5937A5fe272fbA38699A1b75B3439389EEFDb399` (ReceiveUln301)
-
-To view the list of ULN addresses on all networks, refer to https://docs.layerzero.network/v2/developers/evm/technical-reference/deployed-contracts
+`layerzero.config.ts` now uses `generateConnectionsConfig` from
+`@layerzerolabs/metadata-tools` to automatically populate ULN libraries and DVN
+addresses based on metadata. Simply provide the pathway details and the Solana
+OFT store address.
 
 ## Developing Contracts
 

--- a/examples/lzapp-migration/layerzero.config.ts
+++ b/examples/lzapp-migration/layerzero.config.ts
@@ -1,130 +1,32 @@
 import { EndpointId } from '@layerzerolabs/lz-definitions'
 import { ExecutorOptionType } from '@layerzerolabs/lz-v2-utilities'
+import { TwoWayConfig, generateConnectionsConfig } from '@layerzerolabs/metadata-tools'
 
-import type { OAppOmniGraphHardhat, OmniPointHardhat } from '@layerzerolabs/toolbox-hardhat'
+import type { OAppEnforcedOption, OmniPointHardhat } from '@layerzerolabs/toolbox-hardhat'
 
-// Note:  Do not use address for EVM OmniPointHardhat contracts.  Contracts are loaded using hardhat-deploy.
 const sepoliaContract: OmniPointHardhat = {
-    eid: EndpointId.SEPOLIA_TESTNET, /// EndpointV1
-    contractName: 'MyEndpointV1OFTV2Mock', // Update this if trying out the other contracts
+    eid: EndpointId.SEPOLIA_TESTNET,
+    contractName: 'MyEndpointV1OFTV2Mock',
 }
 
 const solanaContract: OmniPointHardhat = {
     eid: EndpointId.SOLANA_V2_TESTNET,
-    address: '', // NOTE: update this with the OFTStore address.
+    address: '',
 }
 
-// The values here are for development purposes. E.g. confirmations are set to 1. For production, they should be reviewed and edited accordingly.
-const config: OAppOmniGraphHardhat = {
-    contracts: [
-        {
-            contract: sepoliaContract,
-        },
-        {
-            contract: solanaContract,
-        },
-    ],
-    connections: [
-        {
-            from: sepoliaContract,
-            to: solanaContract,
-            config: {
-                sendLibrary: '0x6862b19f6e42a810946B9C782E6ebE26Ad266C84', // SendULN301 on Ethereum Sepolia
-                receiveLibraryConfig: {
-                    receiveLibrary: '0x5937A5fe272fbA38699A1b75B3439389EEFDb399', // ReceiveULN301 on Ethereum Sepolia
-                    gracePeriod: BigInt(0),
-                },
-                sendConfig: {
-                    executorConfig: {
-                        maxMessageSize: 200,
-                        executor: '0x718B92b5CB0a5552039B593faF724D182A881eDA',
-                    },
-                    ulnConfig: {
-                        confirmations: BigInt(15),
-                        requiredDVNs: ['0x8eebf8b423b73bfca51a1db4b7354aa0bfca9193'], // LayerZero Labs DVN
-                        optionalDVNs: [],
-                        optionalDVNThreshold: 0,
-                    },
-                },
-                receiveConfig: {
-                    ulnConfig: {
-                        confirmations: BigInt(32),
-                        requiredDVNs: ['0x8eebf8b423b73bfca51a1db4b7354aa0bfca9193'],
-                        optionalDVNs: [],
-                        optionalDVNThreshold: 0,
-                    },
-                },
-            },
-        },
-        {
-            from: solanaContract,
-            to: sepoliaContract,
-            // TODO Here are some default settings that have been found to work well sending to Sepolia.
-            // You need to either enable these enforcedOptions or pass in extraOptions when calling send().
-            // Having neither will cause a revert when calling send().
-            // We suggest performing additional profiling to ensure they are correct for your use case.
-            config: {
-                sendLibrary: '7a4WjyR8VZ7yZz5XJAKm39BUGn5iT9CKcv2pmG9tdXVH',
-                receiveLibraryConfig: {
-                    receiveLibrary: '7a4WjyR8VZ7yZz5XJAKm39BUGn5iT9CKcv2pmG9tdXVH',
-                    gracePeriod: BigInt(0),
-                },
-                // Optional Send Configuration
-                // @dev Controls how the `from` chain sends messages to the `to` chain.
-                sendConfig: {
-                    executorConfig: {
-                        maxMessageSize: 10000,
-                        // The configured Executor address.  Note, this is the executor PDA not the program ID.
-                        executor: 'AwrbHeCyniXaQhiJZkLhgWdUCteeWSGaSN1sTfLiY7xK',
-                    },
-                    ulnConfig: {
-                        // // The number of block confirmations to wait before emitting the message from the source chain.
-                        confirmations: BigInt(32),
-                        // The address of the DVNs you will pay to verify a sent message on the source chain ).
-                        // The destination tx will wait until ALL `requiredDVNs` verify the message.
-                        requiredDVNs: [
-                            '4VDjp6XQaxoZf5RGwiPU9NR1EXSZn2TP4ATMmiSzLfhb', // LayerZero
-                        ],
-                        // The address of the DVNs you will pay to verify a sent message on the source chain ).
-                        // The destination tx will wait until the configured threshold of `optionalDVNs` verify a message.
-                        optionalDVNs: [],
-                        // The number of `optionalDVNs` that need to successfully verify the message for it to be considered Verified.
-                        optionalDVNThreshold: 0,
-                    },
-                },
-                // Optional Receive Configuration
-                // @dev Controls how the `from` chain receives messages from the `to` chain.
-                receiveConfig: {
-                    ulnConfig: {
-                        // The number of block confirmations to expect from the `to` chain.
-                        confirmations: BigInt(15),
-                        // The address of the DVNs your `receiveConfig` expects to receive verifications from on the `from` chain ).
-                        // The `from` chain's OApp will wait until the configured threshold of `requiredDVNs` verify the message.
-                        requiredDVNs: [
-                            '4VDjp6XQaxoZf5RGwiPU9NR1EXSZn2TP4ATMmiSzLfhb', // LayerZero
-                        ],
-                        // The address of the DVNs you will pay to verify a sent message on the source chain ).
-                        // The destination tx will wait until the configured threshold of `optionalDVNs` verify a message.
-                        optionalDVNs: [],
-                        // The number of `optionalDVNs` that need to successfully verify the message for it to be considered Verified.
-                        optionalDVNThreshold: 0,
-                    },
-                },
-                enforcedOptions: [
-                    {
-                        msgType: 1,
-                        optionType: ExecutorOptionType.LZ_RECEIVE,
-                        gas: 200000,
-                    },
-                    {
-                        msgType: 2,
-                        optionType: ExecutorOptionType.LZ_RECEIVE,
-                        gas: 200000,
-                    },
-                ],
-            },
-        },
-    ],
-}
+const SOLANA_ENFORCED_OPTIONS: OAppEnforcedOption[] = [
+    { msgType: 1, optionType: ExecutorOptionType.LZ_RECEIVE, gas: 200000 },
+    { msgType: 2, optionType: ExecutorOptionType.LZ_RECEIVE, gas: 200000 },
+]
 
-export default config
+const pathways: TwoWayConfig[] = [
+    [sepoliaContract, solanaContract, [['LayerZero Labs'], []], [15, 32], [undefined, SOLANA_ENFORCED_OPTIONS]],
+]
+
+export default async function () {
+    const connections = await generateConnectionsConfig(pathways)
+    return {
+        contracts: [{ contract: sepoliaContract }, { contract: solanaContract }],
+        connections,
+    }
+}

--- a/examples/lzapp-migration/lzapp.config.ts
+++ b/examples/lzapp-migration/lzapp.config.ts
@@ -1,10 +1,11 @@
 import { EndpointId } from '@layerzerolabs/lz-definitions'
+import { TwoWayConfig, generateConnectionsConfig } from '@layerzerolabs/metadata-tools'
 
-import type { OAppOmniGraphHardhat, OmniPointHardhat } from '@layerzerolabs/toolbox-hardhat'
+import type { OmniPointHardhat } from '@layerzerolabs/toolbox-hardhat'
 
 const sepoliaContract: OmniPointHardhat = {
-    eid: EndpointId.SEPOLIA_TESTNET, /// EndpointV1
-    contractName: 'LzApp', // Update this if trying out the other contracts, i.e. MyLzApp
+    eid: EndpointId.SEPOLIA_TESTNET,
+    contractName: 'LzApp',
 }
 
 const arbSepoliaContract: OmniPointHardhat = {
@@ -12,80 +13,14 @@ const arbSepoliaContract: OmniPointHardhat = {
     contractName: 'MyOApp',
 }
 
-// The values here are for development purposes. E.g. confirmations are set to 1. For production, they should be reviewed and edited accordingly.
-const config: OAppOmniGraphHardhat = {
-    contracts: [
-        {
-            contract: sepoliaContract,
-        },
-        {
-            contract: arbSepoliaContract,
-        },
-    ],
-    connections: [
-        {
-            from: arbSepoliaContract,
-            to: sepoliaContract,
-            config: {
-                sendLibrary: '0x4f7cd4DA19ABB31b0eC98b9066B9e857B1bf9C0E',
-                receiveLibraryConfig: {
-                    receiveLibrary: '0x75Db67CDab2824970131D5aa9CECfC9F69c69636',
-                    gracePeriod: BigInt(0),
-                },
-                sendConfig: {
-                    executorConfig: {
-                        maxMessageSize: 10000,
-                        executor: '0x5Df3a1cEbBD9c8BA7F8dF51Fd632A9aef8308897',
-                    },
-                    ulnConfig: {
-                        confirmations: BigInt(1),
-                        requiredDVNs: ['0x53f488e93b4f1b60e8e83aa374dbe1780a1ee8a8'], // LayerZero Labs DVN for Arbitrum Sepolia
-                        optionalDVNs: [],
-                        optionalDVNThreshold: 0,
-                    },
-                },
-                receiveConfig: {
-                    ulnConfig: {
-                        confirmations: BigInt(1),
-                        requiredDVNs: ['0x53f488e93b4f1b60e8e83aa374dbe1780a1ee8a8'], // LayerZero Labs DVN for Arbitrum Sepolia
-                        optionalDVNs: [],
-                        optionalDVNThreshold: 0,
-                    },
-                },
-            },
-        },
-        {
-            from: sepoliaContract,
-            to: arbSepoliaContract,
-            config: {
-                sendLibrary: '0x6862b19f6e42a810946B9C782E6ebE26Ad266C84',
-                receiveLibraryConfig: {
-                    receiveLibrary: '0x5937A5fe272fbA38699A1b75B3439389EEFDb399',
-                    gracePeriod: BigInt(0),
-                },
-                sendConfig: {
-                    executorConfig: {
-                        maxMessageSize: 10000,
-                        executor: '0x718B92b5CB0a5552039B593faF724D182A881eDA',
-                    },
-                    ulnConfig: {
-                        confirmations: BigInt(1),
-                        requiredDVNs: ['0x8eebf8b423b73bfca51a1db4b7354aa0bfca9193'], // LayerZero Labs DVN on Ethereum Sepolia
-                        optionalDVNs: [],
-                        optionalDVNThreshold: 0,
-                    },
-                },
-                receiveConfig: {
-                    ulnConfig: {
-                        confirmations: BigInt(1),
-                        requiredDVNs: ['0x8eebf8b423b73bfca51a1db4b7354aa0bfca9193'], // LayerZero Labs DVN on Ethereum Sepolia
-                        optionalDVNs: [],
-                        optionalDVNThreshold: 0,
-                    },
-                },
-            },
-        },
-    ],
-}
+const pathways: TwoWayConfig[] = [
+    [sepoliaContract, arbSepoliaContract, [['LayerZero Labs'], []], [1, 1], [undefined, undefined]],
+]
 
-export default config
+export default async function () {
+    const connections = await generateConnectionsConfig(pathways)
+    return {
+        contracts: [{ contract: sepoliaContract }, { contract: arbSepoliaContract }],
+        connections,
+    }
+}


### PR DESCRIPTION
## Motivation
- simplify the `lzapp-migration` example configuration
- add EPV1 support in metadata-tools so addresses can be loaded from metadata

## What Changed
- updated `lzapp-migration` configs to generate connections via metadata
- adjusted README to mention the new approach
- extended metadata-tools to read ULN301 libraries and local metadata files
- added changeset for versioning

## Verification
- `pnpm lint:fix --filter "./packages/metadata-tools" --filter "./examples/lzapp-migration"`
- `pnpm --filter "./packages/metadata-tools" build`
- `LZ_METADATA_URL=file://$(pwd)/../cache/metadata/deployments.json pnpm --filter "./packages/metadata-tools" test`
