### PR TITLE
fix(io-devtools): avoid wrapping calldata logs

### DIFF
--- a/.changeset/improve-calldata-copy.md
+++ b/.changeset/improve-calldata-copy.md
@@ -1,0 +1,4 @@
+---
+"@layerzerolabs/io-devtools": patch
+---
+Improve Record printer to avoid wrapping values for easier calldata copying.

--- a/packages/io-devtools/src/swag/components/record.tsx
+++ b/packages/io-devtools/src/swag/components/record.tsx
@@ -19,14 +19,13 @@ export const RecordList: React.FC<{ data: RecordData[]; columns?: number }> = ({
 
 export const Record: React.FC<{ data: RecordData; columns?: number }> = ({
   data = {},
-  columns = process.stdout.columns ?? 80,
+  columns: _columns = process.stdout.columns ?? 80,
 }) => {
   const padding = 1;
   const labels = Object.keys(data);
   const labelLengths = labels.map(({ length }) => length);
   const maxLabelLength = Math.max(1, ...labelLengths);
   const labelColumnWidth = maxLabelLength + 2 * padding;
-  const valueColumnWidth = Math.max(10, columns - labelColumnWidth);
 
   return (
     <Box
@@ -44,13 +43,11 @@ export const Record: React.FC<{ data: RecordData; columns?: number }> = ({
               </Text>
             </Box>
 
-            <Box width={valueColumnWidth}>
+            <Box>
               {value == null ? (
-                <Text wrap="wrap" color="gray">
-                  -
-                </Text>
+                <Text color="gray">-</Text>
               ) : (
-                <Text wrap="wrap">{String(value)}</Text>
+                <Text>{String(value)}</Text>
               )}
             </Box>
           </Box>


### PR DESCRIPTION
## Motivation
The Record component used by `printRecords` wrapped values to fit the terminal width. This broke calldata logs into multiple lines, making them hard to copy.

## What changed
- Removed fixed width and wrapping from `Record` value cells.
- Adjusted parameter name to avoid unused variable lint error.
- Added changeset for `@layerzerolabs/io-devtools` patch release.

## How to verify
- `pnpm lint:fix`
- `pnpm build --filter ./packages/io-devtools`
- `pnpm test:local --filter ./packages/io-devtools` *(fails: docker not available)*
