### PR TITLE
chore: git ignore deployments in examples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@ logs
 pnpm-debug.log*
 pnpm-error.log*
 
+# Ignore deployments in examples folder when testing
+examples/deployments
+
 # Dependency directories
 node_modules/
 


### PR DESCRIPTION
This only affects when examples are run in the monorepo itself - which only affects maintainers' work.
This does not affect examples themselves when inited via the CLI.