### PR TITLE
feat(oft-solana): warn when options missing

### DIFF
--- a/.changeset/missing-options-check.md
+++ b/.changeset/missing-options-check.md
@@ -1,0 +1,4 @@
+---
+"@layerzerolabs/oft-solana-example": patch
+---
+Add prompt when sending tokens without extra options and no enforced options.


### PR DESCRIPTION
## Motivation
Prevent send failures when users forget to set `extraOptions` and their OFT has no enforced options configured.

## Changes
- added enforced option checks in `sendEvm` and `sendSolana`
- prompt user if both extra options and enforced options are absent
- added changeset for `oft-solana` example

## Verification
- `pnpm lint:fix`
- `pnpm build` *(fails: forge not found)*
- `pnpm test:local` *(fails: docker not found)*