### PR TITLE
feat(tronbox): add wiring package and example

### DIFF
--- a/.changeset/tronbox-example.md
+++ b/.changeset/tronbox-example.md
@@ -1,0 +1,5 @@
+---
+"@layerzerolabs/devtools-tronbox": minor
+---
+
+Add Tronbox wiring utilities and example showing custom OApp factory.

--- a/examples/oft-tronbox/README.md
+++ b/examples/oft-tronbox/README.md
@@ -1,0 +1,3 @@
+# Tronbox OFT Example
+
+This example demonstrates how to augment the devtools OApp factory with custom wiring for Tron via Tronbox. The `createTronOAppFactory` helper shows how to create a `TronWeb` instance based on an endpoint id and integrate it with the common OApp factory.

--- a/examples/oft-tronbox/package.json
+++ b/examples/oft-tronbox/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@layerzerolabs/oft-tronbox-example",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {},
+  "devDependencies": {
+    "@layerzerolabs/devtools": "~0.4.8",
+    "@layerzerolabs/devtools-tronbox": "workspace:*",
+    "@layerzerolabs/ua-devtools": "~3.0.6",
+    "tronweb": "^5.3.0",
+    "ts-node": "^10.9.2",
+    "typescript": "^5.3.3"
+  }
+}

--- a/examples/oft-tronbox/tasks/index.ts
+++ b/examples/oft-tronbox/tasks/index.ts
@@ -1,0 +1,1 @@
+import './wire'

--- a/examples/oft-tronbox/tasks/wire.ts
+++ b/examples/oft-tronbox/tasks/wire.ts
@@ -1,0 +1,19 @@
+import { createOAppFactory } from '@layerzerolabs/ua-devtools'
+import { createTronWebFactory } from '@layerzerolabs/devtools-tronbox'
+
+// Example of customizing the OApp factory to use Tronbox's TronWeb
+export const createTronOAppFactory = (privateKey: string) => {
+    const tronFactory = createTronWebFactory(
+        () => 'https://api.shasta.trongrid.io',
+        () => privateKey
+    )
+
+    return createOAppFactory(async (point) => {
+        const tronWeb = await tronFactory(point.eid)
+        // Here you would load contract artifacts using tronWeb
+        // and return an IOApp-compatible SDK.
+        // For demonstration we just return the TronWeb instance as-is.
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        return tronWeb as unknown as any
+    })
+}

--- a/examples/oft-tronbox/tsconfig.json
+++ b/examples/oft-tronbox/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": ["tasks"],
+  "compilerOptions": {
+    "module": "commonjs",
+    "types": ["node"],
+    "paths": {
+      "@/*": ["./tasks/*"]
+    }
+  }
+}

--- a/packages/devtools-tronbox/README.md
+++ b/packages/devtools-tronbox/README.md
@@ -1,0 +1,3 @@
+# @layerzerolabs/devtools-tronbox
+
+Utilities for wiring LayerZero devtools with the Tronbox framework. This package exposes helpers for creating `TronWeb` instances based on endpoint ids so Tron contracts can participate in the common devtools workflows.

--- a/packages/devtools-tronbox/jest.config.ts
+++ b/packages/devtools-tronbox/jest.config.ts
@@ -1,0 +1,16 @@
+import type { Config } from 'jest'
+
+const config: Config = {
+    cache: false,
+    reporters: [['github-actions', { silent: false }], 'default'],
+    testEnvironment: 'node',
+    moduleNameMapper: {
+        '^@/(.*)$': '<rootDir>/src/$1',
+    },
+    transform: {
+        '^.+\\.(t|j)sx?$': '@swc/jest',
+    },
+    testTimeout: 30000,
+}
+
+export default config

--- a/packages/devtools-tronbox/package.json
+++ b/packages/devtools-tronbox/package.json
@@ -1,0 +1,60 @@
+{
+  "name": "@layerzerolabs/devtools-tronbox",
+  "version": "0.1.0",
+  "description": "Developer utilities for Tronbox wiring",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/LayerZero-Labs/devtools.git",
+    "directory": "packages/devtools-tronbox"
+  },
+  "license": "MIT",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "require": "./dist/index.js",
+      "import": "./dist/index.mjs"
+    },
+    "./package.json": "./package.json"
+  },
+  "main": "dist/index.js",
+  "module": "dist/index.mjs",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "prebuild": "tsc -noEmit",
+    "build": "$npm_execpath tsup --clean",
+    "clean": "rm -rf dist",
+    "dev": "$npm_execpath tsup --watch",
+    "lint": "$npm_execpath eslint '**/*.{js,ts,json}'",
+    "lint:fix": "eslint --fix '**/*.{js,ts,json}'",
+    "test": "jest --ci"
+  },
+  "dependencies": {
+    "p-memoize": "~4.0.4",
+    "tronweb": "^5.3.0"
+  },
+  "devDependencies": {
+    "@layerzerolabs/devtools": "~0.4.8",
+    "@layerzerolabs/io-devtools": "~0.1.16",
+    "@layerzerolabs/lz-definitions": "^3.0.75",
+    "@swc/core": "^1.4.0",
+    "@swc/jest": "^0.2.36",
+    "@types/jest": "^29.5.12",
+    "jest": "^29.7.0",
+    "ts-node": "^10.9.2",
+    "tslib": "~2.6.2",
+    "tsup": "~8.0.1",
+    "typescript": "^5.3.3"
+  },
+  "peerDependencies": {
+    "@layerzerolabs/devtools": "~0.4.8",
+    "@layerzerolabs/io-devtools": "~0.1.16",
+    "@layerzerolabs/lz-definitions": "^3.0.75",
+    "tronweb": "^5.3.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/devtools-tronbox/src/connection/factory.ts
+++ b/packages/devtools-tronbox/src/connection/factory.ts
@@ -1,0 +1,33 @@
+import TronWeb from 'tronweb'
+import pMemoize from 'p-memoize'
+import { formatEid, type RpcUrlFactory } from '@layerzerolabs/devtools'
+import { EndpointId } from '@layerzerolabs/lz-definitions'
+import type { TronWebFactory, PrivateKeyFactory } from './types'
+
+export const defaultRpcUrlFactory: RpcUrlFactory = (eid) => {
+    switch (eid) {
+        case EndpointId.TRON_MAINNET:
+            return 'https://api.trongrid.io'
+        case EndpointId.TRON_TESTNET:
+            return 'https://api.shasta.trongrid.io'
+    }
+    throw new Error(`Could not find a default Tron RPC URL for eid ${eid} (${formatEid(eid)})`)
+}
+
+export const createRpcUrlFactory =
+    (overrides: Partial<Record<EndpointId, string | null>> = {}): RpcUrlFactory =>
+    (eid) =>
+        overrides[eid] ?? defaultRpcUrlFactory(eid)
+
+export const createTronWebFactory = (
+    urlFactory: RpcUrlFactory = defaultRpcUrlFactory,
+    privateKeyFactory?: PrivateKeyFactory
+): TronWebFactory =>
+    pMemoize(async (eid) => {
+        const fullHost = await urlFactory(eid)
+        const privateKey = privateKeyFactory ? await privateKeyFactory(eid) : undefined
+        return new TronWeb({
+            fullHost,
+            ...(privateKey ? { privateKey } : {}),
+        })
+    })

--- a/packages/devtools-tronbox/src/connection/index.ts
+++ b/packages/devtools-tronbox/src/connection/index.ts
@@ -1,0 +1,2 @@
+export * from './factory'
+export * from './types'

--- a/packages/devtools-tronbox/src/connection/types.ts
+++ b/packages/devtools-tronbox/src/connection/types.ts
@@ -1,0 +1,5 @@
+import type { EndpointBasedFactory } from '@layerzerolabs/devtools'
+import type TronWeb from 'tronweb'
+
+export type TronWebFactory = EndpointBasedFactory<TronWeb>
+export type PrivateKeyFactory = EndpointBasedFactory<string>

--- a/packages/devtools-tronbox/src/index.ts
+++ b/packages/devtools-tronbox/src/index.ts
@@ -1,0 +1,1 @@
+export * from './connection'

--- a/packages/devtools-tronbox/test/connection.test.ts
+++ b/packages/devtools-tronbox/test/connection.test.ts
@@ -1,0 +1,10 @@
+import { createTronWebFactory } from '../src'
+import { EndpointId } from '@layerzerolabs/lz-definitions'
+
+describe('connection/factory', () => {
+    it('creates a TronWeb instance', async () => {
+        const factory = createTronWebFactory(() => 'http://localhost')
+        const instance = await factory(EndpointId.TRON_TESTNET)
+        expect(instance).toHaveProperty('trx')
+    })
+})

--- a/packages/devtools-tronbox/tsconfig.json
+++ b/packages/devtools-tronbox/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../tsconfig.json",
+  "exclude": ["dist", "node_modules"],
+  "include": ["src", "test", "*.config.ts"],
+  "compilerOptions": {
+    "experimentalDecorators": true,
+    "target": "ES2020",
+    "module": "commonjs",
+    "types": ["node", "jest"],
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  }
+}

--- a/packages/devtools-tronbox/tsup.config.ts
+++ b/packages/devtools-tronbox/tsup.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from 'tsup'
+
+export default defineConfig({
+    entry: ['src/index.ts'],
+    outDir: './dist',
+    clean: true,
+    dts: true,
+    sourcemap: true,
+    splitting: false,
+    treeshake: true,
+    format: ['cjs', 'esm'],
+})


### PR DESCRIPTION
## Motivation
Introduce Tron support through a small devtools package and sample usage.

## What changed
- new `devtools-tronbox` package exposing `createTronWebFactory`
- new `oft-tronbox` example demonstrating custom OApp factory wiring
- added changeset for new package release

## How to verify
- `pnpm lint:fix`
- `pnpm build --filter ./packages/devtools-tronbox`
- `pnpm test --filter ./packages/devtools-tronbox`
