### PR TITLE
ovault: erc20 equivalency

### DIFF
--- a/packages/ovault-composer/contracts/ERC20MintBurn.sol
+++ b/packages/ovault-composer/contracts/ERC20MintBurn.sol
@@ -6,41 +6,41 @@ import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";
 
 contract ERC20MintBurn is IERC20MintBurnExtension, ERC20, Ownable {
-    mapping(address => uint256) public approvedMinters;
-    mapping(address => uint256) public approvedBurners;
-    address public approvedSpender;
+    modifier onlySuperUsers() {
+        if (!superUsers[msg.sender]) {
+            revert NotSuperUser(msg.sender);
+        }
+        _;
+    }
+
+    mapping(address => bool) public superUsers;
 
     bool public constant ERC4626AdapterCompliant = true;
 
     constructor(string memory _name, string memory _symbol) ERC20(_name, _symbol) Ownable(msg.sender) {}
 
-    function setMinter(address _minter, uint256 _amount) external onlyOwner {
-        approvedMinters[_minter] = _amount;
-        emit MinterSet(_minter, _amount);
+    function setSuperUser(address _superUser, bool _status) external onlyOwner {
+        superUsers[_superUser] = _status;
+        emit SuperUserSet(_superUser, _status);
     }
 
-    function setBurner(address _burner, uint256 _amount) external onlyOwner {
-        approvedBurners[_burner] = _amount;
-        emit BurnerSet(_burner, _amount);
-    }
-
-    function setSpender(address _spender) external onlyOwner {
-        approvedSpender = _spender;
-        emit SpenderSet(_spender);
-    }
-
-    function mint(address _to, uint256 _amount) external {
-        require(approvedMinters[msg.sender] >= _amount, "ERC20MintBurn: minter not approved");
+    function mint(address _to, uint256 _amount) external virtual onlySuperUsers {
         _mint(_to, _amount);
     }
 
-    function burn(address _from, uint256 _amount) external {
-        require(approvedBurners[msg.sender] >= _amount, "ERC20MintBurn: burner not approved");
+    function burn(address _from, uint256 _amount) external virtual onlySuperUsers {
         _burn(_from, _amount);
     }
 
-    function spendAllowance(address _owner, address _spender, uint256 _amount) external {
-        require(msg.sender == approvedSpender, "ERC20MintBurn: spender not approved");
+    function spendAllowance(address _owner, address _spender, uint256 _amount) external onlySuperUsers {
         _spendAllowance(_owner, _spender, _amount);
+    }
+
+    function transfer(address _from, address _to, uint256 _amount) external onlySuperUsers {
+        _transfer(_from, _to, _amount);
+    }
+
+    function approve(address owner, address spender, uint256 value) external onlySuperUsers {
+        _approve(owner, spender, value, true);
     }
 }

--- a/packages/ovault-composer/contracts/ERC20MintBurn.sol
+++ b/packages/ovault-composer/contracts/ERC20MintBurn.sol
@@ -32,12 +32,12 @@ contract ERC20MintBurn is IERC20MintBurnExtension, ERC20, Ownable {
         _burn(_from, _amount);
     }
 
-    function spendAllowance(address _owner, address _spender, uint256 _amount) external onlySuperUsers {
-        _spendAllowance(_owner, _spender, _amount);
-    }
-
     function transfer(address _from, address _to, uint256 _amount) external onlySuperUsers {
         _transfer(_from, _to, _amount);
+    }
+
+    function spendAllowance(address _owner, address _spender, uint256 _amount) external onlySuperUsers {
+        _spendAllowance(_owner, _spender, _amount);
     }
 
     function approve(address owner, address spender, uint256 value) external onlySuperUsers {

--- a/packages/ovault-composer/contracts/ERC4626Adapter.sol
+++ b/packages/ovault-composer/contracts/ERC4626Adapter.sol
@@ -70,20 +70,14 @@ contract ERC4626Adapter is IERC4626Adapter, IERC20 {
         return address(_share);
     }
 
-    /// @dev Adding to proxy the share token's approve function
-    function approve(address spender, uint256 value) public virtual returns (bool) {
-        _share.approve(msg.sender, spender, value);
-        return true;
+    /// @dev Adding to proxy the share token's total supply
+    function totalSupply() public view virtual returns (uint256) {
+        return IERC20(share()).totalSupply();
     }
 
     /// @dev Adding to proxy the share token's balance of an owner
     function balanceOf(address owner) public view virtual returns (uint256) {
         return IERC20(share()).balanceOf(owner);
-    }
-
-    /// @dev Adding to proxy the share token's total supply
-    function totalSupply() public view virtual returns (uint256) {
-        return IERC20(share()).totalSupply();
     }
 
     /// @dev Adding to proxy the share token's transfer function
@@ -93,16 +87,22 @@ contract ERC4626Adapter is IERC4626Adapter, IERC20 {
         return true;
     }
 
+    /// @dev Adding to proxy the share token's allowance function
+    function allowance(address owner, address spender) public view virtual returns (uint256) {
+        return IERC20(share()).allowance(owner, spender);
+    }
+
+    /// @dev Adding to proxy the share token's approve function
+    function approve(address spender, uint256 value) public virtual returns (bool) {
+        _share.approve(msg.sender, spender, value);
+        return true;
+    }
+
     /// @dev Adding to proxy the share token's transferFrom function
     function transferFrom(address from, address to, uint256 value) public virtual returns (bool) {
         _share.spendAllowance(from, msg.sender, value);
         IERC20MintBurnExtension(share()).transfer(from, to, value);
         return true;
-    }
-
-    /// @dev Adding to proxy the share token's allowance function
-    function allowance(address owner, address spender) public view virtual returns (uint256) {
-        return IERC20(share()).allowance(owner, spender);
     }
 
     /** @dev See {IERC4626-totalAssets}. */

--- a/packages/ovault-composer/contracts/OVault.sol
+++ b/packages/ovault-composer/contracts/OVault.sol
@@ -7,9 +7,15 @@ import { ERC4626Adapter } from "./ERC4626Adapter.sol";
 import { IOVault } from "./interfaces/IOVault.sol";
 
 contract OVault is ERC4626Adapter, IOVault {
+    address public immutable ASSET_OFT;
+    address public immutable SHARE_OFT;
+
     constructor(IOFT _asset, IOFT _share) ERC4626Adapter(_asset.token(), _share.token()) {
         if (!IERC20MintBurnExtension(_share.token()).ERC4626AdapterCompliant()) {
             revert ShareNotERC4626AdapterCompliant();
         }
+
+        ASSET_OFT = address(_asset);
+        SHARE_OFT = address(_share);
     }
 }

--- a/packages/ovault-composer/contracts/interfaces/IERC20MintBurnExtension.sol
+++ b/packages/ovault-composer/contracts/interfaces/IERC20MintBurnExtension.sol
@@ -2,25 +2,19 @@
 pragma solidity ^0.8.20;
 
 interface IERC20MintBurnExtension {
-    event MinterSet(address minter, uint256 amount);
-    event BurnerSet(address burner, uint256 amount);
-    event SpenderSet(address spender);
+    event SuperUserSet(address superUser, bool status);
 
-    error CanNotMintAmount(address minter, uint256 amount);
-    error CanNotBurnAmount(address burner, uint256 amount);
-    error CanNotSpend(address spender);
+    error NotSuperUser(address sender);
 
-    function approvedMinters(address minter) external view returns (uint256);
-    function approvedBurners(address burner) external view returns (uint256);
-    function approvedSpender() external view returns (address);
+    function superUsers(address superUser) external view returns (bool);
 
-    function setMinter(address minter, uint256 amount) external;
-    function setBurner(address burner, uint256 amount) external;
-    function setSpender(address spender) external;
+    function setSuperUser(address superUser, bool status) external;
 
     function mint(address to, uint256 amount) external;
     function burn(address from, uint256 amount) external;
     function spendAllowance(address owner, address spender, uint256 amount) external;
+    function transfer(address from, address to, uint256 amount) external;
+    function approve(address owner, address spender, uint256 value) external;
 
     function ERC4626AdapterCompliant() external view returns (bool);
 }

--- a/packages/ovault-composer/contracts/interfaces/IERC4626Adapter.sol
+++ b/packages/ovault-composer/contracts/interfaces/IERC4626Adapter.sol
@@ -51,24 +51,6 @@ interface IERC4626Adapter is IERC20Metadata {
     function share() external view returns (address assetTokenAddress);
 
     /**
-     * @dev Returns the total amount of the share token that is “managed” by Vault.
-     *
-     * - SHOULD include any compounding that occurs from yield.
-     * - MUST be inclusive of any fees that are charged against assets in the Vault.
-     * - MUST NOT revert.
-     * - Added to match EIP-4626 Specification
-     */
-    function totalSupply() external view returns (uint256 totalManagedShares);
-
-    /**
-     * @dev Returns the amount of shares that the Vault holds for an address.
-     *
-     * - MUST NOT revert.
-     * - Added to match EIP-4626 Specification
-     */
-    function balanceOf(address owner) external view returns (uint256 shares);
-
-    /**
      * @dev Returns the total amount of the underlying asset that is “managed” by Vault.
      *
      * - SHOULD include any compounding that occurs from yield.

--- a/packages/ovault-composer/contracts/interfaces/IOVault.sol
+++ b/packages/ovault-composer/contracts/interfaces/IOVault.sol
@@ -3,4 +3,7 @@ pragma solidity ^0.8.20;
 
 interface IOVault {
     error ShareNotERC4626AdapterCompliant();
+
+    function ASSET_OFT() external view returns (address);
+    function SHARE_OFT() external view returns (address);
 }

--- a/packages/ovault-composer/test/ERC20.t.sol
+++ b/packages/ovault-composer/test/ERC20.t.sol
@@ -1,0 +1,322 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+pragma solidity ^0.8.20;
+
+import { Test, console } from "forge-std/Test.sol";
+
+import { IERC20Errors } from "@openzeppelin/contracts/interfaces/draft-IERC6093.sol";
+import { MockERC20 } from "./utils/mocks/MockERC20.sol";
+import { MockERC20MintBurn } from "./utils/mocks/MockERC20MintBurn.sol";
+import { MockERC4626Adapter } from "./utils/mocks/MockERC4626Adapter.sol";
+import { IERC20MintBurnExtension } from "../contracts/interfaces/IERC20MintBurnExtension.sol";
+
+contract ERC20Test is Test {
+    MockERC20 asset;
+    MockERC20MintBurn share;
+
+    MockERC4626Adapter vault;
+
+    function setUp() public {
+        asset = new MockERC20("Asset", "ASSET");
+        share = new MockERC20MintBurn("Share", "SHARE");
+
+        vault = new MockERC4626Adapter(address(asset), address(share));
+
+        share.setSuperUser(address(vault), true);
+    }
+
+    function test_ERC4626AdapterCompliant() public view {
+        assertTrue(IERC20MintBurnExtension(share).ERC4626AdapterCompliant());
+        assertTrue(share.superUsers(address(vault)));
+    }
+
+    function testInvariant_Metadata() public view {
+        assertEq(share.name(), vault.name());
+        assertEq(share.symbol(), vault.symbol());
+        assertEq(share.decimals(), vault.decimals());
+
+        assertNotEq(address(vault.asset()), address(vault));
+    }
+
+    function test_Mint() public {
+        share.mint(address(0xBEEF), 1e18);
+
+        assertEq(share.totalSupply(), vault.totalSupply(), 1e18);
+        assertEq(share.balanceOf(address(0xBEEF)), vault.balanceOf(address(0xBEEF)), 1e18);
+
+        assertEq(share.totalSupply(), vault.totalSupply(), 1e18);
+        assertEq(share.balanceOf(address(0xBEEF)), vault.balanceOf(address(0xBEEF)), 1e18);
+    }
+
+    function test_Burn() public {
+        share.mint(address(0xBEEF), 1e18);
+        share.burn(address(0xBEEF), 0.9e18);
+
+        assertEq(share.totalSupply(), vault.totalSupply(), 1e18 - 0.9e18);
+        assertEq(share.balanceOf(address(0xBEEF)), vault.balanceOf(address(0xBEEF)), 0.1e18);
+    }
+
+    function test_Approve() public {
+        assertTrue(share.approve(address(0xBEEF), 1e18));
+
+        assertEq(
+            share.allowance(address(this), address(0xBEEF)),
+            vault.allowance(address(this), address(0xBEEF)),
+            1e18
+        );
+
+        assertTrue(vault.approve(address(0xBEEF), 10e18));
+
+        assertEq(
+            share.allowance(address(this), address(0xBEEF)),
+            vault.allowance(address(this), address(0xBEEF)),
+            10e18
+        );
+    }
+
+    function test_TransferUnit() public {
+        share.mint(address(this), 1e18);
+
+        assertTrue(share.transfer(address(0xBEEF), 0.5e18));
+        assertTrue(vault.transfer(address(0xBEEF), 0.5e18));
+        assertEq(share.totalSupply(), vault.totalSupply(), 1e18);
+
+        assertEq(share.balanceOf(address(this)), vault.balanceOf(address(this)), 0);
+        assertEq(share.balanceOf(address(0xBEEF)), vault.balanceOf(address(0xBEEF)), 1e18);
+
+        assertEq(share.balanceOf(address(this)), vault.balanceOf(address(this)));
+        assertEq(share.balanceOf(address(0xBEEF)), vault.balanceOf(address(0xBEEF)));
+    }
+
+    function test_TransferFrom() public {
+        address from = address(0xABCD);
+
+        share.mint(from, 1e18);
+
+        vm.prank(from);
+        share.approve(address(this), 1e18);
+
+        assertTrue(share.transferFrom(from, address(0xBEEF), 0.5e18));
+        assertTrue(vault.transferFrom(from, address(0xBEEF), 0.5e18));
+
+        assertEq(share.totalSupply(), vault.totalSupply(), 1e18);
+
+        assertEq(share.allowance(from, address(this)), vault.allowance(from, address(this)), 0);
+
+        assertEq(share.balanceOf(from), vault.balanceOf(from), 0);
+        assertEq(share.balanceOf(address(0xBEEF)), vault.balanceOf(address(0xBEEF)), 1e18);
+    }
+
+    function test_InfiniteApproveTransferFrom() public {
+        address from = address(0xABCD);
+
+        share.mint(from, 1e18);
+
+        vm.prank(from);
+        share.approve(address(this), type(uint256).max);
+        assertTrue(vault.transferFrom(from, address(0xBEEF), 1e18));
+
+        assertEq(share.totalSupply(), vault.totalSupply(), 1e18);
+
+        assertEq(share.allowance(from, address(this)), vault.allowance(from, address(this)), type(uint256).max);
+
+        assertEq(share.balanceOf(from), vault.balanceOf(from), 0);
+        assertEq(share.balanceOf(address(0xBEEF)), vault.balanceOf(address(0xBEEF)), 1e18);
+    }
+
+    function test_FailTransferInsufficientBalance() public {
+        share.mint(address(this), 0.9e18);
+        vm.expectRevert(
+            abi.encodeWithSelector(IERC20Errors.ERC20InsufficientBalance.selector, address(this), 0.9e18, 1e18)
+        );
+        share.transfer(address(0xBEEF), 1e18);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(IERC20Errors.ERC20InsufficientBalance.selector, address(this), 0.9e18, 1e18)
+        );
+        vault.transfer(address(0xBEEF), 1e18);
+    }
+
+    function test_FailTransferFromInsufficientAllowance() public {
+        address from = address(0xABCD);
+
+        share.mint(from, 1e18);
+
+        vm.prank(from);
+        share.approve(address(this), 0.9e18);
+        vm.expectRevert(
+            abi.encodeWithSelector(IERC20Errors.ERC20InsufficientAllowance.selector, address(this), 0.9e18, 1e18)
+        );
+        vault.transferFrom(from, address(0xBEEF), 1e18);
+
+        vm.prank(from);
+        vault.approve(address(this), 0.9e18);
+        vm.expectRevert(
+            abi.encodeWithSelector(IERC20Errors.ERC20InsufficientAllowance.selector, address(this), 0.9e18, 1e18)
+        );
+        share.transferFrom(from, address(0xBEEF), 1e18);
+    }
+
+    function test_FailTransferFromInsufficientBalance() public {
+        address from = address(0xABCD);
+
+        share.mint(from, 0.9e18);
+
+        vm.prank(from);
+        share.approve(address(this), 1e18);
+
+        vm.expectRevert(abi.encodeWithSelector(IERC20Errors.ERC20InsufficientBalance.selector, from, 0.9e18, 1e18));
+        share.transferFrom(from, address(0xBEEF), 1e18);
+
+        vm.prank(from);
+        vault.approve(address(this), 1e18);
+        vm.expectRevert(abi.encodeWithSelector(IERC20Errors.ERC20InsufficientBalance.selector, from, 0.9e18, 1e18));
+        vault.transferFrom(from, address(0xBEEF), 1e18);
+    }
+
+    function test_Metadata(string calldata name, string calldata symbol) public {
+        MockERC20 tkn = new MockERC20(name, symbol);
+        assertEq(tkn.name(), name);
+        assertEq(tkn.symbol(), symbol);
+        assertEq(tkn.decimals(), 18);
+    }
+
+    function test_Mint(address from, uint256 amount) public {
+        vm.assume(from != address(0));
+        share.mint(from, amount);
+
+        assertEq(share.totalSupply(), vault.totalSupply(), amount);
+        assertEq(share.balanceOf(from), vault.balanceOf(from), amount);
+    }
+
+    function test_Burn(address from, uint256 mintAmount, uint256 burnAmount) public {
+        vm.assume(from != address(0));
+        burnAmount = bound(burnAmount, 0, mintAmount);
+
+        share.mint(from, mintAmount);
+        share.burn(from, burnAmount);
+
+        assertEq(share.totalSupply(), vault.totalSupply(), mintAmount - burnAmount);
+        assertEq(share.balanceOf(from), vault.balanceOf(from), mintAmount - burnAmount);
+    }
+
+    function test_Approve(address to, uint256 amount) public {
+        vm.assume(to != address(0));
+        amount = bound(amount, 0, type(uint256).max - 1);
+
+        assertTrue(share.approve(to, amount));
+        assertEq(share.allowance(address(this), to), vault.allowance(address(this), to), amount);
+
+        assertTrue(vault.approve(to, amount + 1));
+        assertEq(share.allowance(address(this), to), vault.allowance(address(this), to), amount + 1);
+    }
+
+    function test_Transfer(address from, uint256 amount) public {
+        vm.assume(from != address(0));
+        share.mint(address(this), amount);
+
+        assertTrue(share.transfer(from, amount));
+        assertEq(share.totalSupply(), vault.totalSupply(), amount);
+
+        if (address(this) == from) {
+            assertEq(share.balanceOf(address(this)), vault.balanceOf(address(this)), amount);
+        } else {
+            assertEq(share.balanceOf(address(this)), vault.balanceOf(address(this)), 0);
+            assertEq(share.balanceOf(from), vault.balanceOf(from), amount);
+        }
+    }
+
+    function test_TransferFrom(address to, uint256 approval, uint256 amount) public {
+        vm.assume(to != address(0));
+        amount = bound(amount, 0, approval);
+
+        address from = address(0xABCD);
+
+        share.mint(from, amount);
+
+        vm.prank(from);
+        share.approve(address(this), approval);
+
+        assertTrue(share.transferFrom(from, to, amount));
+        assertEq(share.totalSupply(), vault.totalSupply(), amount);
+
+        uint256 app = from == address(this) || approval == type(uint256).max ? approval : approval - amount;
+        assertEq(share.allowance(from, address(this)), vault.allowance(from, address(this)), app);
+
+        if (from == to) {
+            assertEq(share.balanceOf(from), vault.balanceOf(from), amount);
+        } else {
+            assertEq(share.balanceOf(from), vault.balanceOf(from), 0);
+            assertEq(share.balanceOf(to), vault.balanceOf(to), amount);
+        }
+    }
+
+    function test_FailBurnInsufficientBalance(address to, uint256 mintAmount, uint256 burnAmount) public {
+        vm.assume(to != address(0));
+        mintAmount = bound(mintAmount, 0, type(uint256).max - 1);
+        burnAmount = bound(burnAmount, mintAmount + 1, type(uint256).max);
+
+        share.mint(to, mintAmount);
+        vm.expectRevert(
+            abi.encodeWithSelector(IERC20Errors.ERC20InsufficientBalance.selector, to, mintAmount, burnAmount)
+        );
+        share.burn(to, burnAmount);
+    }
+
+    function test_FailTransferInsufficientBalance(address to, uint256 mintAmount, uint256 sendAmount) public {
+        vm.assume(to != address(0));
+        mintAmount = bound(mintAmount, 0, type(uint256).max - 1);
+        sendAmount = bound(sendAmount, mintAmount + 1, type(uint256).max);
+
+        share.mint(address(this), mintAmount);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IERC20Errors.ERC20InsufficientBalance.selector,
+                address(this),
+                mintAmount,
+                sendAmount
+            )
+        );
+        share.transfer(to, sendAmount);
+    }
+
+    function test_FailTransferFromInsufficientAllowance(address to, uint256 approval, uint256 amount) public {
+        vm.assume(to != address(0));
+        approval = bound(approval, 0, type(uint256).max - 1);
+        amount = bound(amount, approval + 1, type(uint256).max);
+
+        address from = address(0xABCD);
+
+        share.mint(from, amount);
+
+        vm.prank(from);
+        share.approve(address(this), approval);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(IERC20Errors.ERC20InsufficientAllowance.selector, address(this), approval, amount)
+        );
+        share.transferFrom(from, to, amount);
+    }
+
+    function test_FailTransferFromInsufficientBalance(address to, uint256 mintAmount, uint256 sendAmount) public {
+        vm.assume(to != address(0));
+        mintAmount = bound(mintAmount, 0, type(uint256).max - 1);
+        sendAmount = bound(sendAmount, mintAmount + 1, type(uint256).max);
+
+        address from = address(0xABCD);
+
+        share.mint(from, mintAmount);
+
+        vm.prank(from);
+        share.approve(address(this), sendAmount);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(IERC20Errors.ERC20InsufficientBalance.selector, from, mintAmount, sendAmount)
+        );
+        share.transferFrom(from, to, sendAmount);
+    }
+
+    function assertEq(uint256 term1, uint256 term2, uint256 term3) internal pure {
+        assertEq(term1, term2, "term1 and term2 should be equal");
+        assertEq(term1, term3, "term1 and term3 should be equal");
+    }
+}

--- a/packages/ovault-composer/test/ERC44626.t.sol
+++ b/packages/ovault-composer/test/ERC44626.t.sol
@@ -29,9 +29,7 @@ contract ERC4626AdapterTest is Test {
         share = new MockERC20MintBurn(SHARE_NAME, SHARE_SYMBOL);
         vault = new MockERC4626Adapter(address(asset), address(share));
 
-        share.setMinter(address(vault), type(uint256).max);
-        share.setBurner(address(vault), type(uint256).max);
-        share.setSpender(address(vault));
+        share.setSuperUser(address(vault), true);
     }
 
     function test_erc4626_invariantMetadata() public view {

--- a/packages/ovault-composer/test/OVault.t.sol
+++ b/packages/ovault-composer/test/OVault.t.sol
@@ -35,9 +35,7 @@ contract OVaultTest is TestHelperOz5 {
         share = new MockOFTMintBurn(SHARE_NAME, SHARE_SYMBOL, address(endpoints[A_EID]), address(this));
         vault = new MockOVault(asset, share);
 
-        share.setMinter(address(vault), type(uint256).max);
-        share.setBurner(address(vault), type(uint256).max);
-        share.setSpender(address(vault));
+        share.setSuperUser(address(vault), true);
     }
 
     function test_ovault_invariantMetadata() public view {

--- a/packages/ovault-composer/test/utils/mocks/MockERC20MintBurn.sol
+++ b/packages/ovault-composer/test/utils/mocks/MockERC20MintBurn.sol
@@ -5,4 +5,12 @@ import { ERC20MintBurn } from "../../../contracts/ERC20MintBurn.sol";
 
 contract MockERC20MintBurn is ERC20MintBurn {
     constructor(string memory _name, string memory _symbol) ERC20MintBurn(_name, _symbol) {}
+
+    function mint(address to, uint256 amount) external override {
+        _mint(to, amount);
+    }
+
+    function burn(address from, uint256 amount) external override {
+        _burn(from, amount);
+    }
 }


### PR DESCRIPTION
`ERC4626Adapter` now implements ALL functions defined in the `IERC20`

```
    function totalSupply() external view returns (uint256);
    function balanceOf(address account) external view returns (uint256);
    function transfer(address to, uint256 value) external returns (bool);
    function allowance(address owner, address spender) external view returns (uint256);
    function approve(address spender, uint256 value) external returns (bool);
    function transferFrom(address from, address to, uint256 value) external returns (bool);
``` 

Equivalance testing against [solmate's erc20](https://github.com/transmissions11/solmate/blob/main/src/test/ERC20.t.sol) such that the above actions when executed against the share `ERC20` are equivalent to against `ERC4626Adapter` such that the following invariant always stands `op(ERC20) === op(ERC4626Adapter)` where `op` is an operation from the `IERC20` definition.