### PR TITLE
chore: only check if target peer is not set on early exit due to config

### DIFF
--- a/packages/ovault-composer/contracts/interfaces/IOVaultComposer.sol
+++ b/packages/ovault-composer/contracts/interfaces/IOVaultComposer.sol
@@ -27,6 +27,7 @@ interface IOVaultComposer is IOAppComposer {
     event Refunded(bytes32 indexed guid, address indexed oft);
     event Retried(bytes32 indexed guid, address indexed oft);
     event GenericError(bytes32 indexed guid, address indexed oft, bytes errMsg);
+    event NoPeer(bytes32 indexed guid, address indexed oft, uint32 dstEid);
 
     /// ========================== Error Messages =====================================
     error InvalidAdapterMesh();
@@ -53,8 +54,6 @@ interface IOVaultComposer is IOAppComposer {
         uint256 _amount,
         SendParam calldata _sendParam
     ) external returns (uint256 vaultAmount);
-
-    function validateTargetOFTConfig(address _oft, SendParam memory _sendParam) external view;
 
     function refund(bytes32 guid, bytes memory extraOptions) external payable;
     function retry(bytes32 guid, bytes memory extraOptions) external payable;

--- a/packages/ovault-composer/test/composer/OVaultComposer_Unit.t.sol
+++ b/packages/ovault-composer/test/composer/OVaultComposer_Unit.t.sol
@@ -92,7 +92,7 @@ contract OVaultComposerUnitTest is OVaultComposerBaseTest {
         assetOFT_arb.mint(address(OVaultComposerArb), TOKENS_TO_SEND);
 
         SendParam memory internalSendParam = SendParam(
-            OVaultComposerArb.COMPOSER_EID(),
+            OVaultComposerArb.HUB_EID(),
             addressToBytes32(userA),
             TOKENS_TO_SEND,
             0,
@@ -183,9 +183,8 @@ contract OVaultComposerUnitTest is OVaultComposerBaseTest {
         bytes memory composePayload = abi.encode(internalSendParam);
         bytes memory composeMsg = _createComposePayload(ETH_EID, composePayload, TOKENS_TO_SEND, userA);
 
-        bytes memory errMsg = abi.encodeWithSelector(IOAppCore.NoPeer.selector, BAD_EID);
-        vm.expectEmit(address(OVaultComposerArb));
-        emit IOVaultComposer.GenericError(guid, address(shareOFT_arb), errMsg);
+        vm.expectEmit(true, true, true, true, address(OVaultComposerArb));
+        emit IOVaultComposer.NoPeer(guid, address(shareOFT_arb), BAD_EID);
 
         assertEq(assetOFT_arb.totalSupply(), assetOFT_arb.balanceOf(address(OVaultComposerArb)), TOKENS_TO_SEND);
         assertEq(shareOFT_arb.totalSupply(), 0);


### PR DESCRIPTION
Replacing the `quoteSend()` lz check with `oft.peers(dstEid)` since the other things that can go wrong with `quoteSend()` are like 
1. dvn config (protocol issue that should be fixed)
2. rate limiter consumption (temp issue)
3. etc

Since the protocol has peer set for that EID we know that they want to goto that network 