### PR TITLE
fix bug in cli version check

### DIFF
--- a/packages/devtools-move/tasks/move/utils/config.ts
+++ b/packages/devtools-move/tasks/move/utils/config.ts
@@ -356,11 +356,15 @@ function greaterThanOrEqualTo(installed: string, required: string): boolean {
     const requiredParts = required.split('.').map(Number)
 
     for (let i = 0; i < 3; i++) {
-        if (installedParts[i] < requiredParts[i]) {
+        if (installedParts[i] > requiredParts[i]) {
+            return true
+        }
+        else if (installedParts[i] < requiredParts[i]){
+
             return false
         }
     }
-    // all parts are greater than or equal to the required version
+    // all parts are equal to the required version
     return true
 }
 
@@ -372,7 +376,11 @@ function lessThanOrEqualTo(installed: string, required: string): boolean {
         if (installedParts[i] > requiredParts[i]) {
             return false
         }
+        else if (installedParts[i] < requiredParts[i]){
+
+            return true
+        }
     }
-    // all parts are less than or equal to the required version
+    // all parts are equal to the required version
     return true
 }


### PR DESCRIPTION
Fixes this bug which wrongly calculates the CLI version for move-packages. 

Acc. to prev logic v7.5.0 was older than v6.0.1
![image](https://github.com/user-attachments/assets/8c8810df-7fb1-433e-a620-a10d8d99ed93)
