### PR TITLE
INT-406: fix move CLI version checks

### DIFF
--- a/.changeset/wet-colts-peel.md
+++ b/.changeset/wet-colts-peel.md
@@ -1,0 +1,5 @@
+---
+"@layerzerolabs/devtools-move": patch
+---
+
+fix move CLI version checks

--- a/packages/devtools-move/jest/config.test.ts
+++ b/packages/devtools-move/jest/config.test.ts
@@ -1,0 +1,36 @@
+import { expect } from 'chai'
+import { isVersionGreaterOrEqualTo, isVersionLessThanOrEqualTo } from '../tasks/move/utils/config'
+
+describe('tasks/move/utils/config', () => {
+    describe('isVersionGreaterOrEqualTo', () => {
+        it('works', () => {
+            expect(isVersionGreaterOrEqualTo('6.0.1', '6.0.1')).to.equal(true)
+            expect(isVersionGreaterOrEqualTo('6.0.1', '6.0.0')).to.equal(true)
+            expect(isVersionGreaterOrEqualTo('6.0.1', '5.0.0')).to.equal(true)
+            expect(isVersionGreaterOrEqualTo('7.5.0', '6.0.1')).to.equal(true)
+            expect(isVersionGreaterOrEqualTo('6.0.1', '7.0.0')).to.equal(false)
+            expect(isVersionGreaterOrEqualTo('5.0.0', '6.0.1')).to.equal(false)
+            expect(isVersionGreaterOrEqualTo('5.0.0', '7.0.0')).to.equal(false)
+            expect(isVersionGreaterOrEqualTo('7.0.0', '6.0.1')).to.equal(true)
+            expect(isVersionGreaterOrEqualTo('7.0.0', '5.0.0')).to.equal(true)
+            expect(isVersionGreaterOrEqualTo('7.0.0', '7.0.0')).to.equal(true)
+            expect(isVersionGreaterOrEqualTo('7.0.0', '8.0.0')).to.equal(false)
+        })
+    })
+
+    describe('isVersionLessThanOrEqualTo', () => {
+        it('works', () => {
+            expect(isVersionLessThanOrEqualTo('6.0.1', '6.0.1')).to.equal(true)
+            expect(isVersionLessThanOrEqualTo('6.0.1', '6.0.0')).to.equal(false)
+            expect(isVersionLessThanOrEqualTo('6.0.1', '5.0.0')).to.equal(false)
+            expect(isVersionLessThanOrEqualTo('7.5.0', '6.0.1')).to.equal(false)
+            expect(isVersionLessThanOrEqualTo('6.0.1', '7.0.0')).to.equal(true)
+            expect(isVersionLessThanOrEqualTo('5.0.0', '6.0.1')).to.equal(true)
+            expect(isVersionLessThanOrEqualTo('5.0.0', '7.0.0')).to.equal(true)
+            expect(isVersionLessThanOrEqualTo('7.0.0', '6.0.1')).to.equal(false)
+            expect(isVersionLessThanOrEqualTo('7.0.0', '5.0.0')).to.equal(false)
+            expect(isVersionLessThanOrEqualTo('7.0.0', '7.0.0')).to.equal(true)
+            expect(isVersionLessThanOrEqualTo('7.0.0', '8.0.0')).to.equal(true)
+        })
+    })
+})

--- a/packages/devtools-move/jest/config.test.ts
+++ b/packages/devtools-move/jest/config.test.ts
@@ -1,5 +1,5 @@
 import { expect } from 'chai'
-import { isVersionGreaterOrEqualTo, isVersionLessThanOrEqualTo } from '../tasks/move/utils/config'
+import { isVersionGreaterOrEqualTo, isVersionLessThanOrEqualTo, getAptosCLICommand } from '../tasks/move/utils/config'
 
 describe('tasks/move/utils/config', () => {
     describe('isVersionGreaterOrEqualTo', () => {
@@ -31,6 +31,12 @@ describe('tasks/move/utils/config', () => {
             expect(isVersionLessThanOrEqualTo('7.0.0', '5.0.0')).to.equal(false)
             expect(isVersionLessThanOrEqualTo('7.0.0', '7.0.0')).to.equal(true)
             expect(isVersionLessThanOrEqualTo('7.0.0', '8.0.0')).to.equal(true)
+        })
+    })
+
+    describe('warning message format', () => {
+        it('contains the correct professional warning text', async () => {
+            await getAptosCLICommand('aptos', 'mainnet')
         })
     })
 })

--- a/packages/devtools-move/jest/config.test.ts
+++ b/packages/devtools-move/jest/config.test.ts
@@ -1,5 +1,5 @@
 import { expect } from 'chai'
-import { isVersionGreaterOrEqualTo, isVersionLessThanOrEqualTo, getAptosCLICommand } from '../tasks/move/utils/config'
+import { isVersionGreaterOrEqualTo, isVersionLessThanOrEqualTo } from '../tasks/move/utils/config'
 
 describe('tasks/move/utils/config', () => {
     describe('isVersionGreaterOrEqualTo', () => {
@@ -31,12 +31,6 @@ describe('tasks/move/utils/config', () => {
             expect(isVersionLessThanOrEqualTo('7.0.0', '5.0.0')).to.equal(false)
             expect(isVersionLessThanOrEqualTo('7.0.0', '7.0.0')).to.equal(true)
             expect(isVersionLessThanOrEqualTo('7.0.0', '8.0.0')).to.equal(true)
-        })
-    })
-
-    describe('warning message format', () => {
-        it('contains the correct professional warning text', async () => {
-            await getAptosCLICommand('aptos', 'mainnet')
         })
     })
 })

--- a/packages/devtools-move/package.json
+++ b/packages/devtools-move/package.json
@@ -30,7 +30,8 @@
     "clean": "rm -rf dist",
     "dev": "$npm_execpath tsup --watch",
     "lint": "$npm_execpath eslint '**/*.{js,ts,json}'",
-    "lint:fix": "eslint --fix '**/*.{js,ts,json}'"
+    "lint:fix": "eslint --fix '**/*.{js,ts,json}'",
+    "test": "jest"
   },
   "dependencies": {
     "@types/chai": "^4.3.11",

--- a/packages/devtools-move/package.json
+++ b/packages/devtools-move/package.json
@@ -31,7 +31,7 @@
     "dev": "$npm_execpath tsup --watch",
     "lint": "$npm_execpath eslint '**/*.{js,ts,json}'",
     "lint:fix": "eslint --fix '**/*.{js,ts,json}'",
-    "test": "jest"
+    "test": "INITIA_CHAIN_ID=\"initiation-2\" jest"
   },
   "dependencies": {
     "@types/chai": "^4.3.11",

--- a/packages/devtools-move/tasks/move/utils/config.ts
+++ b/packages/devtools-move/tasks/move/utils/config.ts
@@ -321,7 +321,7 @@ export async function getAptosCLICommand(chain: string, stage: string): Promise<
         console.log('Aptos chain detected')
         const MIN_VERSION = '6.0.1'
 
-        if (greaterThanOrEqualTo(version, MIN_VERSION)) {
+        if (isVersionGreaterOrEqualTo(version, MIN_VERSION)) {
             console.log(`🚀 Aptos CLI version ${version} is compatible.`)
         } else {
             throw new Error(`❌ Aptos CLI version too old. Required: ${MIN_VERSION} or newer, Found: ${version}`)
@@ -329,7 +329,7 @@ export async function getAptosCLICommand(chain: string, stage: string): Promise<
     } else if (chain === 'movement') {
         const MAX_VERSION = '3.5.0'
 
-        if (lessThanOrEqualTo(version, MAX_VERSION)) {
+        if (isVersionLessThanOrEqualTo(version, MAX_VERSION)) {
             console.log(`🚀 Aptos CLI version ${version} is compatible.`)
         } else {
             throw new Error(`❌ Aptos CLI version too new. Required: ${MAX_VERSION} or older, Found: ${version}`)
@@ -351,28 +351,34 @@ export async function checkInitiaCLIVersion(): Promise<void> {
     }
 }
 
-function greaterThanOrEqualTo(installed: string, required: string): boolean {
+export function isVersionGreaterOrEqualTo(installed: string, required: string): boolean {
     const installedParts = installed.split('.').map(Number)
     const requiredParts = required.split('.').map(Number)
 
     for (let i = 0; i < 3; i++) {
-        if (installedParts[i] < requiredParts[i]) {
+        if (installedParts[i] > requiredParts[i]) {
+            return true
+        } else if (installedParts[i] < requiredParts[i]) {
             return false
         }
     }
-    // all parts are greater than or equal to the required version
+
+    // all parts are equal to the required version
     return true
 }
 
-function lessThanOrEqualTo(installed: string, required: string): boolean {
+export function isVersionLessThanOrEqualTo(installed: string, required: string): boolean {
     const installedParts = installed.split('.').map(Number)
     const requiredParts = required.split('.').map(Number)
 
     for (let i = 0; i < 3; i++) {
         if (installedParts[i] > requiredParts[i]) {
             return false
+        } else if (installedParts[i] < requiredParts[i]) {
+            return true
         }
     }
-    // all parts are less than or equal to the required version
+
+    // all parts are equal to the required version
     return true
 }

--- a/packages/devtools-move/tasks/move/utils/config.ts
+++ b/packages/devtools-move/tasks/move/utils/config.ts
@@ -323,6 +323,11 @@ export async function getAptosCLICommand(chain: string, stage: string): Promise<
 
         if (isVersionGreaterOrEqualTo(version, MIN_VERSION)) {
             console.log(`🚀 Aptos CLI version ${version} is compatible.`)
+            if (version !== MIN_VERSION) {
+                console.log(
+                    `\x1b[33m⚠️  Warning: You are deploying to Aptos chain but your Aptos CLI version is set to "${version}".\n\n\tOur recommended and tested version is ${MIN_VERSION}. Using other versions is at your own risk and may result in unexpected behavior.\x1b[0m`
+                )
+            }
         } else {
             throw new Error(`❌ Aptos CLI version too old. Required: ${MIN_VERSION} or newer, Found: ${version}`)
         }
@@ -331,6 +336,11 @@ export async function getAptosCLICommand(chain: string, stage: string): Promise<
 
         if (isVersionLessThanOrEqualTo(version, MAX_VERSION)) {
             console.log(`🚀 Aptos CLI version ${version} is compatible.`)
+            if (version !== '3.5.0') {
+                console.log(
+                    `\x1b[33m⚠️  Warning: You are deploying to Movement chain but your Aptos CLI version is set to "${version}".\n\n\tOur recommended and tested version is 3.5.0. Using other versions is at your own risk and may result in unexpected behavior.\x1b[0m`
+                )
+            }
         } else {
             throw new Error(`❌ Aptos CLI version too new. Required: ${MAX_VERSION} or older, Found: ${version}`)
         }

--- a/packages/devtools-move/tasks/move/utils/config.ts
+++ b/packages/devtools-move/tasks/move/utils/config.ts
@@ -314,6 +314,22 @@ async function getInitiaVersion(): Promise<string> {
     })
 }
 
+async function promptVersionWarningConfirmation(): Promise<void> {
+    const { shouldContinue } = await inquirer.prompt([
+        {
+            type: 'confirm',
+            name: 'shouldContinue',
+            message: 'Are you sure you want to continue?',
+            default: false,
+        },
+    ])
+
+    if (!shouldContinue) {
+        console.log('❌ Operation cancelled.')
+        process.exit(1)
+    }
+}
+
 export async function getAptosCLICommand(chain: string, stage: string): Promise<string> {
     const aptosCommand = 'aptos'
     const version = await getAptosVersion(aptosCommand)
@@ -327,6 +343,7 @@ export async function getAptosCLICommand(chain: string, stage: string): Promise<
                 console.log(
                     `\x1b[33m⚠️  Warning: You are deploying to Aptos chain but your Aptos CLI version is set to "${version}".\n\n\tOur recommended and tested version is ${MIN_VERSION}. Using other versions is at your own risk and may result in unexpected behavior.\x1b[0m`
                 )
+                await promptVersionWarningConfirmation()
             }
         } else {
             throw new Error(`❌ Aptos CLI version too old. Required: ${MIN_VERSION} or newer, Found: ${version}`)
@@ -340,6 +357,7 @@ export async function getAptosCLICommand(chain: string, stage: string): Promise<
                 console.log(
                     `\x1b[33m⚠️  Warning: You are deploying to Movement chain but your Aptos CLI version is set to "${version}".\n\n\tOur recommended and tested version is 3.5.0. Using other versions is at your own risk and may result in unexpected behavior.\x1b[0m`
                 )
+                await promptVersionWarningConfirmation()
             }
         } else {
             throw new Error(`❌ Aptos CLI version too new. Required: ${MAX_VERSION} or older, Found: ${version}`)


### PR DESCRIPTION
Based on: https://github.com/LayerZero-Labs/devtools/pull/1592

The version check for the CLI was wrong, as flagged by the original PR creator it was showing that 7.5.0 isn't greater or equal than 6.0.2.

This PR fixes the problem and also adds tests and enables running them in CI.