### PR TITLE
docs: example READMEs specs + examples/oft README revamp

### DIFF
--- a/docs/EXAMPLES_DEVELOPMENT.md
+++ b/docs/EXAMPLES_DEVELOPMENT.md
@@ -1,0 +1,90 @@
+This document is intended for the maintainers of the examples that are in `/examples` in this repo. It is also meant as a guide for coding agents for the purposes of reviewing or editing.
+
+Currently, this document will only detail the structure for the READMEs of the examples.
+
+## Structure for examples' READMEs
+
+1. **Header**
+   - Goal: Branding + promote docs site + entrypoint
+   - Contents: LayerZero logo + links to docs and dev site
+
+2. **Example Title**
+   - Goal: What the example will teach
+   - Contents: Title and 1–2 sentence description (possibly goal-oriented)
+
+3. **Prerequisite Knowledge**
+   - Goal: What to understand before running the example
+   - Contents: Short list (≤3 items) like OApp, OFT
+
+4. **Requirements**
+   - Goal: What needs to be installed
+   - Contents: Tools + exact versions
+
+5. **Scaffold this example**
+   - Goal: How to init the example
+   - Contents: `npx create-lz-oapp@latest --example <example>`
+
+6. **Helper Tasks (inline notice)**
+   - Goal: Know that helper tasks exist
+   - Contents: Statement + link to helper section
+
+7. **Setup**
+   - Goal: What to configure before running
+   - Contents: .env instructions, deployer account setup
+
+8. **Build**
+   - Goal: How to build contracts/programs/modules
+   - Contents: Build command(s)
+
+9. **Deploy**
+   - Goal: How to deploy contracts/programs/modules
+   - Contents: Deploy command + minting instructions (if needed)
+
+10. **Wiring / Configuring OApps**
+    - Goal: How to wire OApps for cross-chain use
+    - Contents: LZ config, init step, wiring step
+
+11. **Sending Message/OFT/ONFT**
+    - Goal: How to trigger cross-chain action
+    - Contents: Command to send message/OFT/ONFT, both/all directions
+
+12. **Next Steps**
+    - Goal: What to know after initial deployment
+    - Contents: Links to Production Checklist, Security Stack, Message Options
+
+13. **Production Deployment Checklist**
+    - Goal: What’s needed for production readiness
+    - Contents: Gas profiling, DVN config, confirmation count
+
+14. **Appendix**
+    - Goal: Mark end of main build steps
+    - Contents: Supplementary instructions and optional configurations
+
+    14.1. **Running tests**
+       - Goal: How to test the contracts/programs
+       - Contents: Test commands
+
+    14.2. **Adding other chains**
+       - Goal: How to add additional networks
+       - Contents: How to add chains + example config (e.g. modify `hardhat.config.ts`)
+
+    14.3. **Using Multisigs**
+       - Goal: How to deploy if using a multisig
+       - Contents: Command param diffs + multi-VM notes
+
+    14.4. **LayerZero Hardhat Helper Tasks (detailed)**
+       - Goal: Know all available helpers
+       - Contents: Link to docs + list of built-in and local helper tasks
+
+    14.5. **Contract/Program Verification**
+       - Goal: How to verify
+       - Contents: Links to verification docs (per VM)
+
+    14.6. **Troubleshooting**
+       - Goal: How to debug errors/issues
+       - Contents: Link to global page + example-specific fixes
+
+
+
+
+Any sections that don't appear in the above list should be considered for removal.

--- a/examples/oft/README.md
+++ b/examples/oft/README.md
@@ -1,38 +1,305 @@
 <p align="center">
   <a href="https://layerzero.network">
-    <img alt="LayerZero" style="width: 400px" src="https://docs.layerzero.network/img/LayerZero_Logo_White.svg"/>
+    <img alt="LayerZero" style="width: 400px" src="https://docs.layerzero.network/img/LayerZero_Logo_Black.svg"/>
   </a>
 </p>
 
 <p align="center">
-  <a href="https://layerzero.network" style="color: #a77dff">Homepage</a> | <a href="https://docs.layerzero.network/" style="color: #a77dff">Docs</a> | <a href="https://layerzero.network/developers" style="color: #a77dff">Developers</a>
+ <a href="https://docs.layerzero.network/" style="color: #a77dff">LayerZero Docs</a>
 </p>
 
-<h1 align="center">Omnichain Fungible Token (OFT) Example</h1>
+<h1 align="center">EVM-to-EVM Omnichain Fungible Token (OFT) Example</h1>
+
+<p align="center">Template project for a cross-chain token (<a href="https://docs.layerzero.network/v2/concepts/applications/oft-standard">OFT</a>) powered by the LayerZero protocol. This example's config involves EVM chains, but the same OFT can be extended to involve other VM chains such as Solana, Aptos and Hyperliquid.</p>
+
+## Prerequisite Knowledge
+
+- [What is an OFT (Omnichain Fungible Token) ?](https://docs.layerzero.network/v2/concepts/applications/oft-standard)
+- [What is an OApp (Omnichain Application) ?](https://docs.layerzero.network/v2/concepts/applications/oapp-standard)
+
+## Requirements
+
+- `Node.js` - ` >=18.16.0`
+- `pnpm` (recommended) - or another package manager of your choice (npm, yarn)
+-  `forge` (optional) - `>=0.2.0` for testing, and if not using Hardhat for compilation
+
+## Scaffold this example
+
+Create your local copy of this example:
+
+```bash
+pnpm dlx create-lz-oapp@latest --example oft
+```
+
+Note that `create-lz-oapp` will also automatically run the dependencies install step for you.
+
+
+## Helper Tasks
+
+Throughout this walkthrough, helper tasks will be used. For the full list of available helper tasks, refer to the [LayerZero Hardhat Helper Tasks section](#layerzero-hardhat-helper-tasks). All commands can be run at the project root.
+
+## Setup
+
+- Copy `.env.example` into a new `.env`
+- Set up your deployer address/account via the `.env`
+  - You can specify either `MNEMONIC` or `PRIVATE_KEY`:
+
+    ```
+    MNEMONIC="test test test test test test test test test test test junk"
+    or...
+    PRIVATE_KEY="0xabc...def"
+    ```
+- Fund this deployer address/account with the native tokens of the chains you want to deploy to. This example by default will deploy to the following chains' testnets: **Optimism**, **Avalanche**, and **Arbitrum**.
+
+## Build
+
+#### Compiling your contracts
+
+This project supports both `hardhat` and `forge` compilation. By default, the `compile` command will execute both:
+
+```bash
+pnpm compile
+```
+
+If you prefer one over the other, you can use the tooling-specific commands:
+
+```bash
+pnpm compile:forge
+pnpm compile:hardhat
+```
+
+## Deploy
+
+
+To deploy your contracts to your desired blockchains, run the following command:
+
+```bash
+pnpm hardhat lz:deploy --tags MyOFTMock
+```
+
+> :information_source: MyOFTMock will be used as it provides a public mint function which we require for testing
+
+Select all the chains you want to deploy the OFT to.
+
+## Enable Messaging
+
+The OFT standard builds on top of the OApp standard, which enables generic message-passing between chains. After deploying the OFT on the respective chains, you enable messaging by running the [wiring](https://docs.layerzero.network/v2/concepts/glossary#wire--wiring) task.
+
+> :information_source: This example uses the [Simple Config Generator](https://docs.layerzero.network/v2/developers/evm/technical-reference/simple-config), which is recommended over manual configuration.
+
+Run the wiring task:
+
+```bash
+pnpm hardhat lz:oapp:wire --oapp-config layerzero.config.ts
+```
+
+Submit all the transactions to complete wiring. After all transactions confirm, your OApps are wired and can send messages to each other.
+
+
+## Sending OFTs
+
+With your OFTs wired, you can now send them cross chain.
+
+First, via the mock contract, let's mint on **Optimism Sepolia**:
+
+```
+cast send <OFT_ADDRESS> "mint(address,uint256)" <RECIPIENT_ADDRESS> <AMOUNT> --private-key <PRIVATE_KEY> --rpc-url <OPTIMISM_SEPOLIA_RPC_URL>
+
+```
+
+Send 1 OFT from **Optimism Sepolia** to **Avalanche Fuji**:
+
+```bash
+npx hardhat lz:oft:send --src-eid 40232 --dst-eid 40106 --amount 1 --to <EVM_ADDRESS>
+```
+
+> :information_source: `40232` and `40106` are the Endpoint IDs of Optimism Sepolia and Avalanche Fuji respectively. View the list of chains and their Endpoint IDs on the [Deployed Endpoints](https://docs.layerzero.network/v2/deployments/deployed-contracts) page.
+
+Upon a successful send, the script will provide you with the link to the message on LayerZero Scan.
+
+Once the message is delivered, you will be able to click on the destination transaction hash to verify that the OFT was sent.
+
+Congratulations, you have now sent an OFT cross-chain!
+
+> If you run into any issues, refer to [Troubleshooting](#troubleshooting).
+
+## Next Steps
+
+Now that you've gone through a simplified walkthrough, here are what you can do next.
+
+- If you are planning to deploy to production, go through the [Production Deployment Checklist](#production-deployment-checklist).
+- Read on [DVNs / Security Stack](https://docs.layerzero.network/v2/concepts/modular-security/security-stack-dvns)
+- Read on [Message Execution Options](https://docs.layerzero.network/v2/concepts/technical-reference/options-reference)
+
+
+## Production Deployment Checklist
+
+<!-- TODO: move to docs page, then just link -->
+
+Before deploying, ensure the following:
+
+- (required) you are not using `MyOFTMock`, which has a public `_mint` function
+- (recommended) you have profiled the gas usage of `lzReceive` on your destination chains
+<!-- TODO: mention https://docs.layerzero.network/v2/developers/evm/technical-reference/integration-checklist#set-security-and-executor-configurations after it has been updated to reference the CLI -->
+
+### Profiling `lzReceive` and `lzCompose` Gas Usage
+
+The optimal values you should specify for the `gas` parameter in the LZ Config depends on the destination chain, and requires profiling. This section walks through how to estimate the optimal `gas` value.
+
+This guide explains how to use the `pnpm` commands to estimate gas usage for LayerZero's `lzReceive` and `lzCompose` functions. These commands wrap Foundry scripts for easier invocation and allow you to pass the required arguments dynamically.
+
+### Available Commands
+
+1. **`gas:lzReceive`**
+
+   This command profiles the `lzReceive` function for estimating gas usage across multiple runs.
+
+   ```json
+   "gas:lzReceive": "forge script scripts/GasProfiler.s.sol:GasProfilerScript --via-ir --sig 'run_lzReceive(string,address,uint32,address,uint32,address,bytes,uint256,uint256)'"
+   ```
+
+2. **`gas:lzCompose`**
+
+   This command profiles the `lzCompose` function for estimating gas usage across multiple runs.
+
+   ```json
+   "gas:lzCompose": "forge script scripts/GasProfiler.s.sol:GasProfilerScript --via-ir --sig 'run_lzCompose(string,address,uint32,address,uint32,address,address,bytes,uint256,uint256)'"
+   ```
+
+### Usage Examples
+
+#### `lzReceive`
+
+To estimate the gas for the `lzReceive` function:
+
+```bash
+pnpm gas:lzReceive
+  <rpcUrl> \
+  <endpointAddress> \
+  <srcEid> \
+  <sender> \
+  <dstEid> \
+  <receiver> \
+  <message> \
+  <msg.value> \
+  <numOfRuns>
+```
+
+Where:
+
+- `rpcUrl`: The RPC URL for the target blockchain (e.g., Optimism, Arbitrum, etc.).
+- `endpointAddress`: The deployed LayerZero EndpointV2 contract address.
+- `srcEid`: The source endpoint ID (uint32).
+- `sender`: The sender's address (OApp).
+- `dstEid`: The destination endpoint ID (uint32).
+- `receiver`: The address intended to receive the message (OApp).
+- `message`: The message payload as a `bytes` array.
+- `msg.value`: The amount of Ether sent with the message (in wei).
+- `numOfRuns`: The number of test runs to execute.
+
+#### `lzCompose`
+
+To estimate the gas for the `lzCompose` function:
+
+```bash
+pnpm gas:lzCompose
+  <rpcUrl> \
+  <endpointAddress> \
+  <srcEid> \
+  <sender> \
+  <dstEid> \
+  <receiver> \
+  <composer> \
+  <composeMsg> \
+  <msg.value> \
+  <numOfRuns>
+```
+
+Where:
+
+- `rpcUrl`: The RPC URL for the target blockchain (e.g., Optimism, Arbitrum, etc.).
+- `endpointAddress`: The deployed LayerZero EndpointV2 contract address.
+- `srcEid`: The source endpoint ID (uint32).
+- `sender`: The originating OApp address.
+- `dstEid`: The destination endpoint ID (uint32).
+- `receiver`: The address intended to receive the message (OApp).
+- `composer`: The LayerZero Composer contract address.
+- `composeMsg`: The compose message payload as a `bytes` array.
+- `msgValue`: The amount of Ether sent with the message (in wei).
+- `numOfRuns`: The number of test runs to execute.
+
+### Notes
+
+- Modify `numOfRuns` based on the level of accuracy or performance you require for gas profiling.
+- Log outputs will provide metrics such as the **average**, **median**, **minimum**, and **maximum** gas usage across all successful runs.
+
+This approach simplifies repetitive tasks and ensures consistent testing across various configurations.
 
 <p align="center">
-  <a href="https://docs.layerzero.network/v2/developers/evm/oft/quickstart" style="color: #a77dff">Quickstart</a> | <a href="https://docs.layerzero.network/contracts/oapp-configuration" style="color: #a77dff">Configuration</a> | <a href="https://docs.layerzero.network/contracts/options" style="color: #a77dff">Message Execution Options</a> | <a href="https://docs.layerzero.network/v2/developers/evm/technical-reference/deployed-contracts" style="color: #a77dff">Endpoint, MessageLib, & Executor Addresses</a> | <a
-href="https://docs.layerzero.network/v2/developers/evm/technical-reference/dvn-addresses" style="color: #a77dff">DVN Addresses</a>
+  Join our <a href="https://layerzero.network/community" style="color: #a77dff">community</a>! | Follow us on <a href="https://x.com/LayerZero_Labs" style="color: #a77dff">X (formerly Twitter)</a>
 </p>
 
-<p align="center">Template project for getting started with LayerZero's <code>OFT</code> contract standard.</p>
 
-<p align="left">
+# Appendix
 
-- [So What is an Omnichain Fungible Token?](#so-what-is-an-omnichain-fungible-token)
-- [Available Helpers in this Repo](#layerzero-hardhat-helper-tasks)
+## Running Tests
 
-</p>
+Similar to the contract compilation, we support both `hardhat` and `forge` tests. By default, the `test` command will execute both:
 
-## So what is an Omnichain Fungible Token?
+```bash
+pnpm test
+```
 
-The Omnichain Fungible Token (OFT) Standard is an ERC20 token that can be transferred across multiple blockchains without asset wrapping or middlechains.
+If you prefer one over the other, you can use the tooling-specific commands:
 
-<img alt="LayerZero" style="" src="https://docs.layerzero.network/assets/images/oft_mechanism_light-922b88c364b5156e26edc6def94069f1.jpg#gh-light-mode-only"/>
+```bash
+pnpm test:forge
+pnpm test:hardhat
+```
 
-This standard works by combining the LayerZero OApp Contract Standard with the ERC20 [`_burn`](https://github.com/LayerZero-Labs/LayerZero-v2/blob/main/packages/layerzero-v2/evm/oapp/contracts/oft/OFT.sol#L80) method, to initiate omnichain send transfers on the source chain, sending a message via the LayerZero protocol, and delivering a function call to the destination contract to [`_mint`](https://github.com/LayerZero-Labs/LayerZero-v2/blob/main/packages/layerzero-v2/evm/oapp/contracts/oft/OFT.sol#L96) the same number of tokens burned, creating a unified supply across all networks connected.
+## Adding other chains
 
-Read more about what you can do with OFTs by reading the [OFT Quickstart](https://docs.layerzero.network/v2/developers/evm/oft/quickstart) in the LayerZero Documentation.
+<!-- TODO: host this section in docs and just link. Potentially under the Simple Config Generator section -->
+
+If you're adding another EVM chain, first, add it to the `hardhat.config.ts`. Adding non-EVM chains do not require modifying the `hardhat.config.ts`.
+
+<!-- TODO: mention how to add Solana -->
+
+Then, modify `layerzero.config.ts` with the following changes:
+
+  - declare a new contract object (specifying the `eid` and `contractName`)
+  - decide whether to use an existing EVM enforced options variable or declare a new one
+  - create a new entry in the `pathways` variable
+  - add the new contract into the `contracts` key of the `return` of the `export default` function 
+
+After applying the desired changes, make sure you re-run the wiring task:
+
+```bash
+npx hardhat lz:oapp:wire --oapp-config layerzero.config.ts
+```
+
+## Using Multisigs
+
+The wiring task supports the usage of Safe Multisigs.
+
+To use a Safe multisig as the signer for these transactions, add the following to each network in your `hardhat.config.ts` and add the `--safe` flag to `lz:oapp:wire --safe`:
+
+```typescript
+// hardhat.config.ts
+
+networks: {
+  // Include configurations for other networks as needed
+  fuji: {
+    /* ... */
+    // Network-specific settings
+    safeConfig: {
+      safeUrl: 'http://something', // URL of the Safe API, not the Safe itself
+      safeAddress: 'address'
+    }
+  }
+}
+```
+
 
 ## LayerZero Hardhat Helper Tasks
 
@@ -45,7 +312,7 @@ LayerZero Devtools provides several helper hardhat tasks to easily deploy, verif
 
 Deploys your contract to any of the available networks in your [`hardhat.config.ts`](./hardhat.config.ts) when given a deploy tag (by default contract name) and returns a list of available networks to select for the deployment. For specifics around all deployment options, please refer to the [Deploying Contracts](https://docs.layerzero.network/v2/developers/evm/create-lz-oapp/deploying) section of the documentation. LayerZero's `lz:deploy` utilizes `hardhat-deploy`.
 
-```yml
+```typescript
 'arbitrum-sepolia': {
     eid: EndpointId.ARBSEP_V2_TESTNET,
     url: process.env.RPC_URL_ARBSEP_TESTNET,
@@ -56,6 +323,12 @@ Deploys your contract to any of the available networks in your [`hardhat.config.
     url: process.env.RPC_URL_BASE_TESTNET,
     accounts,
 },
+```
+
+More information about available CLI arguments can be found using the `--help` flag:
+
+```bash
+npx hardhat lz:deploy --help
 ```
 
 </details>
@@ -75,7 +348,7 @@ npx hardhat lz:oapp:config:init --contract-name CONTRACT_NAME --oapp-config FILE
 
 This will create a `layerzero.config.ts` in your working directory populated with your contract name and connections for every pathway possible between your hardhat networks:
 
-```yml
+```typescript
 import { EndpointId } from '@layerzerolabs/lz-definitions'
 
 const arbsepContract = {
@@ -173,23 +446,6 @@ npx hardhat lz:oapp:wire --oapp-config YOUR_LAYERZERO_CONFIG_FILE
 
 Whenever you make changes to the configuration, run `lz:oapp:wire` again. The task will check your current configuration, and only apply NEW changes.
 
-To use a Gnosis Safe multisig as the signer for these transactions, add the following to each network in your `hardhat.config.ts` and add the `--safe` flag to `lz:oapp:wire --safe`:
-
-```yml
-// hardhat.config.ts
-
-networks: {
-  // Include configurations for other networks as needed
-  fuji: {
-    /* ... */
-    // Network-specific settings
-    safeConfig: {
-      safeUrl: 'http://something', // URL of the Safe API, not the Safe itself
-      safeAddress: 'address'
-    }
-  }
-}
-```
 
 </details>
 <details>
@@ -285,230 +541,9 @@ Returns the LayerZero Executor config for each network in your `hardhat.config.t
 
 </details>
 
-## Developing Contracts
-
-#### Installing dependencies
-
-We recommend using `pnpm` as a package manager (but you can of course use a package manager of your choice):
-
-```bash
-pnpm install
-```
-
-#### Compiling your contracts
-
-This project supports both `hardhat` and `forge` compilation. By default, the `compile` command will execute both:
-
-```bash
-pnpm compile
-```
-
-If you prefer one over the other, you can use the tooling-specific commands:
-
-```bash
-pnpm compile:forge
-pnpm compile:hardhat
-```
-
-Or adjust the `package.json` to for example remove `forge` build:
-
-```diff
-- "compile": "$npm_execpath run compile:forge && $npm_execpath run compile:hardhat",
-- "compile:forge": "forge build",
-- "compile:hardhat": "hardhat compile",
-+ "compile": "hardhat compile"
-```
-
-#### Running tests
-
-Similarly to the contract compilation, we support both `hardhat` and `forge` tests. By default, the `test` command will execute both:
-
-```bash
-pnpm test
-```
-
-If you prefer one over the other, you can use the tooling-specific commands:
-
-```bash
-pnpm test:forge
-pnpm test:hardhat
-```
-
-Or adjust the `package.json` to for example remove `hardhat` tests:
-
-```diff
-- "test": "$npm_execpath test:forge && $npm_execpath test:hardhat",
-- "test:forge": "forge test",
-- "test:hardhat": "$npm_execpath hardhat test"
-+ "test": "forge test"
-```
-
-## Deploying Contracts
-
-Set up deployer wallet/account:
-
-- Rename `.env.example` -> `.env`
-- Choose your preferred means of setting up your deployer wallet/account:
-
-```
-MNEMONIC="test test test test test test test test test test test junk"
-or...
-PRIVATE_KEY="0xabc...def"
-```
-
-- Fund this address with the corresponding chain's native tokens you want to deploy to.
-
-To deploy your contracts to your desired blockchains, run the following command in your project's folder:
-
-```bash
-npx hardhat lz:deploy
-```
-
-More information about available CLI arguments can be found using the `--help` flag:
-
-```bash
-npx hardhat lz:deploy --help
-```
-
-By following these steps, you can focus more on creating innovative omnichain solutions and less on the complexities of cross-chain communication.
-
-<br></br>
-
-## Estimating `lzReceive` and `lzCompose` Gas Usage
-
-This guide explains how to use the `pnpm` commands to estimate gas usage for LayerZero's `lzReceive` and `lzCompose` functions. These commands wrap Foundry scripts for easier invocation and allow you to pass the required arguments dynamically.
-
-### Available Commands
-
-1. **`gas:lzReceive`**
-
-   This command profiles the `lzReceive` function for estimating gas usage across multiple runs.
-
-   ```json
-   "gas:lzReceive": "forge script scripts/GasProfiler.s.sol:GasProfilerScript --via-ir --sig 'run_lzReceive(string,address,uint32,address,uint32,address,bytes,uint256,uint256)'"
-   ```
-
-2. **`gas:lzCompose`**
-
-   This command profiles the `lzCompose` function for estimating gas usage across multiple runs.
-
-   ```json
-   "gas:lzCompose": "forge script scripts/GasProfiler.s.sol:GasProfilerScript --via-ir --sig 'run_lzCompose(string,address,uint32,address,uint32,address,address,bytes,uint256,uint256)'"
-   ```
-
-### Usage Examples
-
-#### `lzReceive`
-
-To estimate the gas for the `lzReceive` function:
-
-```bash
-pnpm gas:lzReceive
-  <rpcUrl> \
-  <endpointAddress> \
-  <srcEid> \
-  <sender> \
-  <dstEid> \
-  <receiver> \
-  <message> \
-  <msg.value> \
-  <numOfRuns>
-
-pnpm gas:lzCompose <RPC_URL> <DST_ENDPOINT_ADDRESS> <srcEid> <SenderOApp> <dstEid> <ReceiverOApp> <composer> <composeMsg> <msg.value> <numOfRuns>
-```
-
-Where:
-
-- `rpcUrl`: The RPC URL for the target blockchain (e.g., Optimism, Arbitrum, etc.).
-- `endpointAddress`: The deployed LayerZero EndpointV2 contract address.
-- `srcEid`: The source endpoint ID (uint32).
-- `sender`: The sender's address (OApp).
-- `dstEid`: The destination endpoint ID (uint32).
-- `receiver`: The address intended to receive the message (OApp).
-- `message`: The message payload as a `bytes` array.
-- `msg.value`: The amount of Ether sent with the message (in wei).
-- `numOfRuns`: The number of test runs to execute.
-
-#### `lzCompose`
-
-To estimate the gas for the `lzCompose` function:
-
-```bash
-pnpm gas:lzCompose
-  <rpcUrl> \
-  <endpointAddress> \
-  <srcEid> \
-  <sender> \
-  <dstEid> \
-  <receiver> \
-  <composer> \
-  <composeMsg> \
-  <msg.value> \
-  <numOfRuns>
-```
-
-Where:
-
-- `rpcUrl`: The RPC URL for the target blockchain (e.g., Optimism, Arbitrum, etc.).
-- `endpointAddress`: The deployed LayerZero EndpointV2 contract address.
-- `srcEid`: The source endpoint ID (uint32).
-- `sender`: The originating OApp address.
-- `dstEid`: The destination endpoint ID (uint32).
-- `receiver`: The address intended to receive the message (OApp).
-- `composer`: The LayerZero Composer contract address.
-- `composeMsg`: The compose message payload as a `bytes` array.
-- `msgValue`: The amount of Ether sent with the message (in wei).
-- `numOfRuns`: The number of test runs to execute.
-
-### Notes
-
-- Modify `numOfRuns` based on the level of accuracy or performance you require for gas profiling.
-- Log outputs will provide metrics such as the **average**, **median**, **minimum**, and **maximum** gas usage across all successful runs.
-
-This approach simplifies repetitive tasks and ensures consistent testing across various configurations.
-
-## Connecting Contracts
-
-This example uses the [Simple Config Generator](https://docs.layerzero.network/v2/developers/evm/technical-reference/simple-config), which is recommended over manual configuration.
-
-### Generate [LZ Config](https://docs.layerzero.network/v2/concepts/glossary#lz-config) file based on hardhat.config.ts
-
-Fill out your `layerzero.config.ts` with the contracts you want to connect. You can generate the default [LZ Config](https://docs.layerzero.network/v2/concepts/glossary#lz-config) file for your declared hardhat networks (in `hardhat.config.ts`) by running:
-
-```bash
-npx hardhat lz:oapp:config:init --contract-name [YOUR_CONTRACT_NAME] --oapp-config [CONFIG_NAME]
-```
-
-### Customize values in the LZ Config
-
-> [!NOTE]
-> You may need to change the contract name if you're deploying multiple OApp contracts on different chains (e.g., OFT and OFT Adapter).
-
-<br>
-
-```typescript
-const optimismContract: OmniPointHardhat = {
-  eid: EndpointId.OPTSEP_V2_TESTNET,
-  contractName: "MyOFTAdapter",
-};
-
-const avalancheContract: OmniPointHardhat = {
-  eid: EndpointId.AVALANCHE_V2_TESTNET,
-  contractName: "MyOFT",
-};
-```
-
-### Apply configurations
-
-After applying the desired settings, run:
-
-```bash
-npx hardhat lz:oapp:wire --oapp-config layerzero.config.ts
-```
-
-Congratulations! Your contracts are now wired and can begin sending messages to each other.
-
 ### Manual Configuration
+
+<!-- TODO: link to docs, remove from here -->
 
 This section only applies if you would like to configure manually instead of using the Simple Config Generator.
 
@@ -557,7 +592,7 @@ connections: [
           executor: contractsConfig.ethereum.executor,
         },
         ulnConfig: {
-          // The number of block confirmations to wait on BSC before emitting the message from the source chain.
+          // The number of block confirmations to wait on Ethereum before emitting the message from the source chain.
           confirmations: BigInt(15),
           // The address of the DVNs you will pay to verify a sent message on the source chain ).
           // The destination tx will wait until ALL `requiredDVNs` verify the message.
@@ -628,6 +663,15 @@ connections: [
 ];
 ```
 
-<p align="center">
-  Join our <a href="https://layerzero.network/community" style="color: #a77dff">community</a>! | Follow us on <a href="https://x.com/LayerZero_Labs" style="color: #a77dff">X (formerly Twitter)</a>
-</p>
+### Contract Verification
+
+You can verify EVM chain contracts using the LayerZero helper package:
+
+```bash
+pnpm dlx @layerzerolabs/verify-contract -n <NETWORK_NAME> -u <API_URL> -k <API_KEY> --contracts <CONTRACT_NAME> 
+```
+
+
+### Troubleshooting
+
+Refer to [Debugging Messages](https://docs.layerzero.network/v2/developers/evm/troubleshooting/debugging-messages) or [Error Codes & Handling](https://docs.layerzero.network/v2/developers/evm/troubleshooting/error-messages).


### PR DESCRIPTION
## This PR

- introduces a new specs document for Examples, which will initially contain the structure for READMEs
- revamps `examples/oft/README/md` based on the new specs