### PR TITLE
[INT-361]: call is enforced for gnosis safe batch txs

### DIFF
--- a/.changeset/tiny-trainers-love.md
+++ b/.changeset/tiny-trainers-love.md
@@ -1,0 +1,5 @@
+---
+"@layerzerolabs/devtools-evm": patch
+---
+
+Add fix so call is enforced instead of delegatecall for gnosis safe batch tx signing

--- a/packages/devtools-evm/src/signer/sdk.ts
+++ b/packages/devtools-evm/src/signer/sdk.ts
@@ -97,6 +97,10 @@ export class GnosisOmniSignerEVM<TSafeConfig extends ConnectSafeConfig> extends 
     }
 
     async signAndSendBatch(transactions: OmniTransaction[]): Promise<OmniTransactionResponse> {
+        if (transactions.length === 0) {
+            throw new Error('/signAndSendBatch received 0 transactions')
+        }
+
         const safeTransaction = await this.#createSafeTransaction(transactions)
         return this.#proposeSafeTransaction(safeTransaction)
     }

--- a/packages/devtools-evm/src/signer/sdk.ts
+++ b/packages/devtools-evm/src/signer/sdk.ts
@@ -11,8 +11,6 @@ import {
     type OmniTransaction,
     type OmniPoint,
 } from '@layerzerolabs/devtools'
-import assert from 'assert'
-
 import { ethers } from 'ethers'
 
 export abstract class OmniSignerEVMBase extends OmniSignerBase implements OmniSigner {
@@ -99,10 +97,7 @@ export class GnosisOmniSignerEVM<TSafeConfig extends ConnectSafeConfig> extends 
     }
 
     async signAndSendBatch(transactions: OmniTransaction[]): Promise<OmniTransactionResponse> {
-        assert(transactions.length > 0, `signAndSendBatch received 0 transactions`)
-
         const safeTransaction = await this.#createSafeTransaction(transactions)
-
         return this.#proposeSafeTransaction(safeTransaction)
     }
 
@@ -141,7 +136,8 @@ export class GnosisOmniSignerEVM<TSafeConfig extends ConnectSafeConfig> extends 
         return safeSdk.createTransaction({
             safeTransactionData: transactions.map((transaction) => this.#serializeTransaction(transaction)),
             options: { nonce },
-        })
+            onlyCalls: true,
+        } as any)
     }
 
     #serializeTransaction(transaction: OmniTransaction): MetaTransactionData {

--- a/packages/devtools-evm/test/signer/sdk.test.ts
+++ b/packages/devtools-evm/test/signer/sdk.test.ts
@@ -283,6 +283,7 @@ describe('signer/ethers', () => {
                                     operation: OperationType.Call,
                                 })),
                                 options: { nonce },
+                                onlyCalls: true,
                             })
 
                             expect(apiKit.getNextNonce).toHaveBeenCalledWith(safeAddress)


### PR DESCRIPTION
So this entire time `LZ_ENABLE_EXPERIMENTAL_BATCHED_SEND` was available which lets users send batch safe txs. 

When testing it out, I ran into issue `Operation DELEGATE_CALL is not allowed`

Quick one liner fix to enforce only Calls and retried everything and it seemed to work: 
Successful multisig batch proposal + signing when running the wire command to update config: https://app.safe.global/transactions/tx?id=multisig_0x1fBd62569885EDc6b757f6C27699F30aB6b0A05a_0x26fd7e96c35a7562ce9d50a85fe16c1419b209858fe90634b0a721c989da2903&safe=bnb:0x1fBd62569885EDc6b757f6C27699F30aB6b0A05a

output when command was run: 
`LZ_ENABLE_EXPERIMENTAL_BATCHED_SEND=1 npx hardhat lz:oapp:wire --oapp-config layerzero.config.ts --safe --log-level debug`

```
 Signing... ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ 0/3
verbose: [signAndSendFlow] Sending the transactions
debug:   [sign & send] Signing 3 transactions
warn:    [sign & send] You are using experimental batched transaction sending
debug:   [sign & send] Signing 2 transactions for BSC_V2_MAINNET
debug:   [sign & send] Creating signer for BSC_V2_MAINNET
debug:   [sign & send] Signing 1 transaction for ETHEREUM_V2_MAINNET
debug:   [sign & send] Creating signer for ETHEREUM_V2_MAINNET
debug:   [sign & send] Signing a batch of 2 transactions for BSC_V2_MAINNET
debug:   [sign & send] Signing a batch of 1 transaction for ETHEREUM_V2_MAINNET
debug:   [sign & send] Signed a batch of 1 transaction for ETHEREUM_V2_MAINNET, got hash 0xe1641f242974a027d4be5d704c8581f07b20ddc5130ef9d1af390880433351ae
Signing... ██████████████████████████████████████████████████░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ 1/3
debug:   [sign & send] Successfully signed 3 transactions for ETHEREUM_V2_MAINNET
debug:   [sign & send] Signed a batch of 2 transactions for BSC_V2_MAINNET, got hash 0x26fd7e96c35a7562ce9d50a85fe16c1419b209858fe90634b0a721c989da2903
Signing... ████████████████████████████████████████████████████████████████████████████████████████████████████░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ 2/3
verbose: [signAndSendFlow] Sent the transactions
debug:   [signAndSendFlow] Successfully sent the following transactions:

[
        {
                "transaction": {
                        "point": {
                                "eid": 30101,
                                "address": "0xe989cC3d5b10E05a30a0700E461C4E87F3cE37b9"
                        },
                        "data": "0xb98bd070000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000759600000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000060000000000000000000000000000000000000000000000000000000000000001600030100110100000000000000000000000000015f9000000000000000000000",
                        "description": "Setting enforced options to [\n\t{\n\t\t\"eid\": 30102,\n\t\t\"option\": {\n\t\t\t\"msgType\": 1,\n\t\t\t\"options\": \"0x00030100110100000000000000000000000000015f90\"\n\t\t}\n\t}\n]"
                },
                "receipt": {
                        "transactionHash": "0xe1641f242974a027d4be5d704c8581f07b20ddc5130ef9d1af390880433351ae"
                }
        },
        {
                "transaction": {
                        "point": {
                                "eid": 30102,
                                "address": "0x9858A4a57d3Ae72EE77b9a4F41CBFf410c8cd8b3"
                        },
                        "data": "0x3400288b0000000000000000000000000000000000000000000000000000000000007595000000000000000000000000e989cc3d5b10e05a30a0700e461c4e87f3ce37b9",
                        "description": "Setting peer for eid 30101 (ETHEREUM_V2_MAINNET) to address 0x000000000000000000000000e989cc3d5b10e05a30a0700e461c4e87f3ce37b9"
                },
                "receipt": {
                        "transactionHash": "0x26fd7e96c35a7562ce9d50a85fe16c1419b209858fe90634b0a721c989da2903"
                }
        },
        {
                "transaction": {
                        "point": {
                                "eid": 30102,
                                "address": "0x9858A4a57d3Ae72EE77b9a4F41CBFf410c8cd8b3"
                        },
                        "data": "0xb98bd070000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000759500000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000060000000000000000000000000000000000000000000000000000000000000001600030100110100000000000000000000000000015f9000000000000000000000",
                        "description": "Setting enforced options to [\n\t{\n\t\t\"eid\": 30101,\n\t\t\"option\": {\n\t\t\t\"msgType\": 1,\n\t\t\t\"options\": \"0x00030100110100000000000000000000000000015f90\"\n\t\t}\n\t}\n]"
                },
                "receipt": {
                        "transactionHash": "0x26fd7e96c35a7562ce9d50a85fe16c1419b209858fe90634b0a721c989da2903"
                }
        }
]
debug:   [signAndSendFlow] Failed to send the following transactions:

[]
debug:   [signAndSendFlow] Did not send the following transactions:

[]
```