### PR TITLE
ovault - standardize event emitted during entry of failed state in lzCompose 

### DIFF
--- a/packages/ovault-evm/contracts/OVaultComposer.sol
+++ b/packages/ovault-evm/contracts/OVaultComposer.sol
@@ -112,7 +112,7 @@ contract OVaultComposer is IOVaultComposer, ReentrancyGuard {
             /// @dev This message can only be refunded back to the source chain.
             failedMessages[_guid] = FailedMessage(address(0), sendParam, _refundOFT, refundSendParam, msg.value);
             emit DecodeFailed(_guid, _refundOFT, sendParamEncoded);
-            emit MessageFailed(bytes4(IOVaultComposer.DecodeFailed.selector), sendParamEncoded);
+            emit lzComposeInFailedState(bytes4(IOVaultComposer.DecodeFailed.selector), sendParamEncoded);
             return;
         }
 
@@ -121,7 +121,7 @@ contract OVaultComposer is IOVaultComposer, ReentrancyGuard {
         if (_isInvalidPeer(oft, sendParam.dstEid)) {
             failedMessages[_guid] = FailedMessage(address(0), sendParam, _refundOFT, refundSendParam, msg.value);
             emit NoPeer(_guid, oft, sendParam.dstEid);
-            emit MessageFailed(bytes4(IOVaultComposer.NoPeer.selector), "");
+            emit lzComposeInFailedState(bytes4(IOVaultComposer.NoPeer.selector), "");
             return;
         }
 
@@ -134,7 +134,7 @@ contract OVaultComposer is IOVaultComposer, ReentrancyGuard {
         } catch (bytes memory errMsg) {
             failedMessages[_guid] = FailedMessage(oft, sendParam, _refundOFT, refundSendParam, msg.value);
             emit OVaultError(_guid, oft, errMsg); /// @dev Since the ovault can revert with custom errors, the error message is valuable
-            emit MessageFailed(bytes4(IOVaultComposer.OVaultError.selector), errMsg);
+            emit lzComposeInFailedState(bytes4(IOVaultComposer.OVaultError.selector), errMsg);
             return;
         }
 
@@ -146,7 +146,7 @@ contract OVaultComposer is IOVaultComposer, ReentrancyGuard {
             /// @dev Since we have the target tokens in the composer, we can retry with more gas.
             failedMessages[_guid] = FailedMessage(oft, sendParam, address(0), refundSendParam, msg.value);
             emit SendFailed(_guid, oft, errMsg); /// @dev This can be due to msg.value or layerzero config (dvn config, etc)
-            emit MessageFailed(bytes4(IOVaultComposer.SendFailed.selector), errMsg);
+            emit lzComposeInFailedState(bytes4(IOVaultComposer.SendFailed.selector), errMsg);
             return;
         }
     }

--- a/packages/ovault-evm/contracts/OVaultComposer.sol
+++ b/packages/ovault-evm/contracts/OVaultComposer.sol
@@ -111,8 +111,8 @@ contract OVaultComposer is IOVaultComposer, ReentrancyGuard {
             /// @dev In the case of a failed decode we store the failed message and emit an event.
             /// @dev This message can only be refunded back to the source chain.
             failedMessages[_guid] = FailedMessage(address(0), sendParam, _refundOFT, refundSendParam, msg.value);
-            failedMessages[_guid] = FailedMessage(address(0), sendParam, _refundOFT, refundSendParam, msg.value);
             emit DecodeFailed(_guid, _refundOFT, sendParamEncoded);
+            emit MessageFailed(bytes4(IOVaultComposer.DecodeFailed.selector), sendParamEncoded);
             return;
         }
 
@@ -120,8 +120,8 @@ contract OVaultComposer is IOVaultComposer, ReentrancyGuard {
         /// @dev This is because we do not know if the vault protocol wants to expand to that chain.
         if (_isInvalidPeer(oft, sendParam.dstEid)) {
             failedMessages[_guid] = FailedMessage(address(0), sendParam, _refundOFT, refundSendParam, msg.value);
-            failedMessages[_guid] = FailedMessage(address(0), sendParam, _refundOFT, refundSendParam, msg.value);
             emit NoPeer(_guid, oft, sendParam.dstEid);
+            emit MessageFailed(bytes4(IOVaultComposer.NoPeer.selector), "");
             return;
         }
 
@@ -133,19 +133,20 @@ contract OVaultComposer is IOVaultComposer, ReentrancyGuard {
             sendParam.amountLD = vaultAmount;
         } catch (bytes memory errMsg) {
             failedMessages[_guid] = FailedMessage(oft, sendParam, _refundOFT, refundSendParam, msg.value);
-            failedMessages[_guid] = FailedMessage(oft, sendParam, _refundOFT, refundSendParam, msg.value);
             emit OVaultError(_guid, oft, errMsg); /// @dev Since the ovault can revert with custom errors, the error message is valuable
+            emit MessageFailed(bytes4(IOVaultComposer.OVaultError.selector), errMsg);
             return;
         }
 
         /// @dev Try sending the vault out tokens to the receiver on the target chain (can also be the HUB chain)
         try this.send{ value: msg.value }(oft, sendParam) {
             emit Sent(_guid, oft);
-        } catch {
+        } catch (bytes memory errMsg) {
             /// @dev A failed send can happen due to not enough msg.value
             /// @dev Since we have the target tokens in the composer, we can retry with more gas.
             failedMessages[_guid] = FailedMessage(oft, sendParam, address(0), refundSendParam, msg.value);
-            emit SendFailed(_guid, oft); /// @dev This can be due to msg.value or layerzero config (dvn config, etc)
+            emit SendFailed(_guid, oft, errMsg); /// @dev This can be due to msg.value or layerzero config (dvn config, etc)
+            emit MessageFailed(bytes4(IOVaultComposer.SendFailed.selector), errMsg);
             return;
         }
     }
@@ -301,9 +302,9 @@ contract OVaultComposer is IOVaultComposer, ReentrancyGuard {
                 )
             {
                 emit Retried(_guid, failedMessage.oft);
-            } catch {
+            } catch (bytes memory errMsg) {
                 failedMessages[_guid].msgValue += msg.value;
-                emit SendFailed(_guid, failedMessage.oft);
+                emit SendFailed(_guid, failedMessage.oft, errMsg);
             }
         }
     }

--- a/packages/ovault-evm/contracts/interfaces/IOVaultComposer.sol
+++ b/packages/ovault-evm/contracts/interfaces/IOVaultComposer.sol
@@ -21,7 +21,6 @@ enum FailedState {
 
 interface IOVaultComposer is IOAppComposer {
     /// ========================== EVENTS =====================================
-    event DecodeFailed(bytes32 indexed guid, address indexed oft, bytes message);
 
     event Sent(bytes32 indexed guid, address indexed oft);
     event SentOnHub(address indexed receiver, address indexed oft, uint256 amountLD);
@@ -30,11 +29,13 @@ interface IOVaultComposer is IOAppComposer {
     event Retried(bytes32 indexed guid, address indexed oft);
     event SwappedTokens(bytes32 indexed guid);
 
-    event SendFailed(bytes32 indexed guid, address indexed oft, bytes errMsg);
-    event OVaultError(bytes32 indexed guid, address indexed oft, bytes errMsg);
-    event NoPeer(bytes32 indexed guid, address indexed oft, uint32 dstEid);
-    event FailedToSendEther(address indexed receiver, uint256 amount, bytes errMsg);
-    event MessageFailed(bytes4 indexed failEventSelector, bytes errMsg);
+    event DecodeFailed(bytes32 indexed guid, address indexed oft, bytes message); // 0xbc772e67
+    event SendFailed(bytes32 indexed guid, address indexed oft, bytes errMsg); // 0x5feca73a
+    event OVaultError(bytes32 indexed guid, address indexed oft, bytes errMsg); // 0xc8a2d9e0
+    event NoPeer(bytes32 indexed guid, address indexed oft, uint32 dstEid); // 0x60e5ac46
+    event FailedToSendEther(address indexed receiver, uint256 amount, bytes errMsg); // 0xb7da4a55
+
+    event MessageFailed(bytes4 indexed failEventSelector, bytes errMsg); // 0x6afd04fc
 
     /// ========================== Error Messages =====================================
     error ShareOFTShouldBeLockboxAdapter(address share);

--- a/packages/ovault-evm/contracts/interfaces/IOVaultComposer.sol
+++ b/packages/ovault-evm/contracts/interfaces/IOVaultComposer.sol
@@ -30,10 +30,14 @@ interface IOVaultComposer is IOAppComposer {
     event Retried(bytes32 indexed guid, address indexed oft);
     event SwappedTokens(bytes32 indexed guid);
 
-    event SendFailed(bytes32 indexed guid, address indexed oft);
+    event SendFailed(bytes32 indexed guid, address indexed oft, bytes errMsg);
     event OVaultError(bytes32 indexed guid, address indexed oft, bytes errMsg);
     event NoPeer(bytes32 indexed guid, address indexed oft, uint32 dstEid);
     event FailedToSendEther(address indexed receiver, uint256 amount, bytes errMsg);
+    event MessageFailed(bytes4 indexed failEventSelector, bytes errMsg);
+
+    event DepositMade(bytes32 indexed guid, address indexed oft, address indexed depositor, uint256 amountLD);
+    event RedeemMade(bytes32 indexed guid, address indexed oft, address indexed redeemer, uint256 amountLD);
 
     /// ========================== Error Messages =====================================
     error ShareOFTShouldBeLockboxAdapter(address share);

--- a/packages/ovault-evm/contracts/interfaces/IOVaultComposer.sol
+++ b/packages/ovault-evm/contracts/interfaces/IOVaultComposer.sol
@@ -36,9 +36,6 @@ interface IOVaultComposer is IOAppComposer {
     event FailedToSendEther(address indexed receiver, uint256 amount, bytes errMsg);
     event MessageFailed(bytes4 indexed failEventSelector, bytes errMsg);
 
-    event DepositMade(bytes32 indexed guid, address indexed oft, address indexed depositor, uint256 amountLD);
-    event RedeemMade(bytes32 indexed guid, address indexed oft, address indexed redeemer, uint256 amountLD);
-
     /// ========================== Error Messages =====================================
     error ShareOFTShouldBeLockboxAdapter(address share);
     error AssetOFTInnerTokenShouldBeOvaultAsset(address assetInnerToken, address vaultAsset);

--- a/packages/ovault-evm/contracts/interfaces/IOVaultComposer.sol
+++ b/packages/ovault-evm/contracts/interfaces/IOVaultComposer.sol
@@ -35,7 +35,7 @@ interface IOVaultComposer is IOAppComposer {
     event NoPeer(bytes32 indexed guid, address indexed oft, uint32 dstEid); // 0x60e5ac46
     event FailedToSendEther(address indexed receiver, uint256 amount, bytes errMsg); // 0xb7da4a55
 
-    event MessageFailed(bytes4 indexed failEventSelector, bytes errMsg); // 0x6afd04fc
+    event lzComposeInFailedState(bytes4 indexed failEventSelector, bytes errMsg); // 0x6875e033
 
     /// ========================== Error Messages =====================================
     error ShareOFTShouldBeLockboxAdapter(address share);

--- a/packages/ovault-evm/test/composer/OVaultComposer_Unit.t.sol
+++ b/packages/ovault-evm/test/composer/OVaultComposer_Unit.t.sol
@@ -287,7 +287,11 @@ contract OVaultComposerUnitTest is OVaultComposerBaseTest {
         emit IERC4626.Deposit(address(OVaultComposerArb), address(OVaultComposerArb), TOKENS_TO_SEND, TOKENS_TO_SEND);
 
         vm.expectEmit(true, true, true, true, address(OVaultComposerArb));
-        emit IOVaultComposer.SendFailed(guid, address(shareOFT_arb));
+        emit IOVaultComposer.SendFailed(
+            guid,
+            address(shareOFT_arb),
+            hex"4f3ec0d3000000000000000000000000000000000000000000000000000000000bed727c000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000" // LZ_InsufficientFee(uint256,uint256,uint256,uint256)
+        );
 
         assertEq(assetOFT_arb.totalSupply(), assetOFT_arb.balanceOf(address(OVaultComposerArb)), TOKENS_TO_SEND);
         assertEq(oVault_arb.totalSupply(), 0);


### PR DESCRIPTION
```
    event DecodeFailed(bytes32 indexed guid, address indexed oft, bytes message); // 0xbc772e67
    event SendFailed(bytes32 indexed guid, address indexed oft, bytes errMsg); // 0x5feca73a
    event OVaultError(bytes32 indexed guid, address indexed oft, bytes errMsg); // 0xc8a2d9e0
    event NoPeer(bytes32 indexed guid, address indexed oft, uint32 dstEid); // 0x60e5ac46
    event FailedToSendEther(address indexed receiver, uint256 amount, bytes errMsg); // 0xb7da4a55

    event lzComposeInFailedState(bytes4 indexed failEventSelector, bytes errMsg) // 0x6875e033
```

emitting `lzComposeInFailedState(bytes4,bytes)`

where `bytes4` part is the event signature and `bytes` is whatever is received from the external call as part of the `try..catch` 