### PR TITLE
Aptos framework rev patch

### DIFF
--- a/.changeset/slimy-dancers-flash.md
+++ b/.changeset/slimy-dancers-flash.md
@@ -1,0 +1,7 @@
+---
+"@layerzerolabs/oft-adapter-aptos-move-example": patch
+"@layerzerolabs/oapp-aptos-example": patch
+"@layerzerolabs/oft-aptos-move-example": patch
+---
+
+Patch rev for aptos framework to feb commit hash to reflect time of testing

--- a/examples/oapp-aptos-move/Move.toml
+++ b/examples/oapp-aptos-move/Move.toml
@@ -62,7 +62,8 @@ dvn = "0x100002"
 [dependencies.AptosFramework]
 git = "https://github.com/aptos-labs/aptos-framework.git"
 # Note: rev is set to a stable commit hash of the aptos-framework package that we have tested our code with.
-# https://github.com/aptos-labs/aptos-framework/commit/99f5e915b6d231d0ffbc1aff282d36148d2a8b24
+# https://github.com/aptos-labs/aptos-framework/commit/99f5e915b6d231d0ffbc1aff282d36148d2a8b24 @ Feb 4
+
 rev = "99f5e915b6d231d0ffbc1aff282d36148d2a8b24"
 subdir = "aptos-framework"
 

--- a/examples/oapp-aptos-move/Move.toml
+++ b/examples/oapp-aptos-move/Move.toml
@@ -62,6 +62,7 @@ dvn = "0x100002"
 [dependencies.AptosFramework]
 git = "https://github.com/aptos-labs/aptos-framework.git"
 # Note: rev is set to a stable commit hash of the aptos-framework package that we have tested our code with.
+# https://github.com/aptos-labs/aptos-framework/commit/99f5e915b6d231d0ffbc1aff282d36148d2a8b24
 rev = "99f5e915b6d231d0ffbc1aff282d36148d2a8b24"
 subdir = "aptos-framework"
 

--- a/examples/oapp-aptos-move/Move.toml
+++ b/examples/oapp-aptos-move/Move.toml
@@ -62,7 +62,7 @@ dvn = "0x100002"
 [dependencies.AptosFramework]
 git = "https://github.com/aptos-labs/aptos-framework.git"
 # Note: rev is set to a stable commit hash of the aptos-framework package that we have tested our code with.
-rev = "acea17645546fa9f6bc5ea80a8398b1691822e1a"
+rev = "99f5e915b6d231d0ffbc1aff282d36148d2a8b24"
 subdir = "aptos-framework"
 
 # Note: For using Aptos CLI version <= 3.5.0 (the version supported by Movement), use the following dependencies:

--- a/examples/oft-adapter-aptos-move/Move.toml
+++ b/examples/oft-adapter-aptos-move/Move.toml
@@ -64,7 +64,8 @@ dvn = "0x100002"
 [dependencies.AptosFramework]
 git = "https://github.com/aptos-labs/aptos-framework.git"
 # Note: rev is set to a stable commit hash of the aptos-framework package that we have tested our code with.
-# https://github.com/aptos-labs/aptos-framework/commit/99f5e915b6d231d0ffbc1aff282d36148d2a8b24
+# https://github.com/aptos-labs/aptos-framework/commit/99f5e915b6d231d0ffbc1aff282d36148d2a8b24 @ Feb 4
+
 rev = "99f5e915b6d231d0ffbc1aff282d36148d2a8b24"
 subdir = "aptos-framework"
 

--- a/examples/oft-adapter-aptos-move/Move.toml
+++ b/examples/oft-adapter-aptos-move/Move.toml
@@ -64,6 +64,7 @@ dvn = "0x100002"
 [dependencies.AptosFramework]
 git = "https://github.com/aptos-labs/aptos-framework.git"
 # Note: rev is set to a stable commit hash of the aptos-framework package that we have tested our code with.
+# https://github.com/aptos-labs/aptos-framework/commit/99f5e915b6d231d0ffbc1aff282d36148d2a8b24
 rev = "99f5e915b6d231d0ffbc1aff282d36148d2a8b24"
 subdir = "aptos-framework"
 

--- a/examples/oft-adapter-aptos-move/Move.toml
+++ b/examples/oft-adapter-aptos-move/Move.toml
@@ -64,7 +64,7 @@ dvn = "0x100002"
 [dependencies.AptosFramework]
 git = "https://github.com/aptos-labs/aptos-framework.git"
 # Note: rev is set to a stable commit hash of the aptos-framework package that we have tested our code with.
-rev = "acea17645546fa9f6bc5ea80a8398b1691822e1a"
+rev = "99f5e915b6d231d0ffbc1aff282d36148d2a8b24"
 subdir = "aptos-framework"
 
 # Note: For using Aptos CLI version <= 3.5.0 (the version supported by Movement), use the following dependencies:

--- a/examples/oft-aptos-move/Move.toml
+++ b/examples/oft-aptos-move/Move.toml
@@ -65,7 +65,8 @@ dvn = "0x100002"
 [dependencies.AptosFramework]
 git = "https://github.com/aptos-labs/aptos-framework.git"
 # Note: rev is set to a stable commit hash of the aptos-framework package that we have tested our code with.
-# https://github.com/aptos-labs/aptos-framework/commit/99f5e915b6d231d0ffbc1aff282d36148d2a8b24
+# https://github.com/aptos-labs/aptos-framework/commit/99f5e915b6d231d0ffbc1aff282d36148d2a8b24 @ Feb 4
+
 rev = "99f5e915b6d231d0ffbc1aff282d36148d2a8b24"
 subdir = "aptos-framework"
 

--- a/examples/oft-aptos-move/Move.toml
+++ b/examples/oft-aptos-move/Move.toml
@@ -65,6 +65,7 @@ dvn = "0x100002"
 [dependencies.AptosFramework]
 git = "https://github.com/aptos-labs/aptos-framework.git"
 # Note: rev is set to a stable commit hash of the aptos-framework package that we have tested our code with.
+# https://github.com/aptos-labs/aptos-framework/commit/99f5e915b6d231d0ffbc1aff282d36148d2a8b24
 rev = "99f5e915b6d231d0ffbc1aff282d36148d2a8b24"
 subdir = "aptos-framework"
 

--- a/examples/oft-aptos-move/Move.toml
+++ b/examples/oft-aptos-move/Move.toml
@@ -65,7 +65,7 @@ dvn = "0x100002"
 [dependencies.AptosFramework]
 git = "https://github.com/aptos-labs/aptos-framework.git"
 # Note: rev is set to a stable commit hash of the aptos-framework package that we have tested our code with.
-rev = "acea17645546fa9f6bc5ea80a8398b1691822e1a"
+rev = "99f5e915b6d231d0ffbc1aff282d36148d2a8b24"
 subdir = "aptos-framework"
 
 # Note: For using Aptos CLI version <= 3.5.0 (the version supported by Movement), use the following dependencies:


### PR DESCRIPTION
`aptos-framework`'s latest commit from the `mainnet` branch can introduce breaking changes, as such the branch `mainnet@latest` only supports `aptos-cli v7` and breaks on older `aptos-cli` versions. We use `aptos-cli v6` (6.0.1) 

Using `aptos-framework`'s branch mainnnet @ latest` breaks our CLI and local builds:
https://github.com/LayerZero-Labs/devtools/actions/runs/16329839557/job/46214753285#step:8:2786

Our tooling was testing heavily in February of this year, which is why we're commit-tagging at Feb 4 <https://github.com/aptos-labs/aptos-framework/commit/99f5e915b6d231d0ffbc1aff282d36148d2a8b24>