### PR TITLE
DEVREL-608 fix: uint64 casting in _toSD

### DIFF
--- a/.changeset/happy-bottles-cover.md
+++ b/.changeset/happy-bottles-cover.md
@@ -1,0 +1,5 @@
+---
+"@layerzerolabs/oft-evm": minor
+---
+
+Implements OpenZeppelin SafeCast toUint64() to prevent silent truncation of funds when shared decimals is changed and reduces the decimalConversionRate.

--- a/.changeset/happy-bottles-cover.md
+++ b/.changeset/happy-bottles-cover.md
@@ -2,4 +2,4 @@
 "@layerzerolabs/oft-evm": minor
 ---
 
-Implements OpenZeppelin SafeCast toUint64() to prevent silent truncation of funds when shared decimals is changed and reduces the decimalConversionRate.
+Implements custom overflow checking to prevent silent truncation of funds when shared decimals is changed and reduces the decimalConversionRate. OpenZeppelin's SafeCast toUint64() is not used in this implementation.

--- a/packages/oft-evm/contracts/OFTCore.sol
+++ b/packages/oft-evm/contracts/OFTCore.sol
@@ -357,6 +357,9 @@ abstract contract OFTCore is IOFT, OApp, OAppPreCrimeSimulator, OAppOptionsType3
      * @dev Internal function to convert an amount from local decimals into shared decimals.
      * @param _amountLD The amount in local decimals.
      * @return amountSD The amount in shared decimals.
+     *
+     * @dev Reverts if the _amountLD in shared decimals overflows uint64.
+     * @dev eg. uint(2**64 + 123) with a conversion rate of 1 wraps around modulo 2**64 to uint(123).
      */
     function _toSD(uint256 _amountLD) internal view virtual returns (uint64 amountSD) {
         uint256 _amountSD = _amountLD / decimalConversionRate;

--- a/packages/oft-evm/contracts/OFTCore.sol
+++ b/packages/oft-evm/contracts/OFTCore.sol
@@ -3,6 +3,7 @@
 pragma solidity ^0.8.20;
 
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import { SafeCast } from "@openzeppelin/contracts/utils/math/SafeCast.sol";
 
 import { OApp, Origin } from "@layerzerolabs/oapp-evm/contracts/oapp/OApp.sol";
 import { OAppOptionsType3 } from "@layerzerolabs/oapp-evm/contracts/oapp/libs/OAppOptionsType3.sol";
@@ -21,6 +22,7 @@ import { OFTComposeMsgCodec } from "./libs/OFTComposeMsgCodec.sol";
 abstract contract OFTCore is IOFT, OApp, OAppPreCrimeSimulator, OAppOptionsType3 {
     using OFTMsgCodec for bytes;
     using OFTMsgCodec for bytes32;
+    using SafeCast for uint256;
 
     // @notice Provides a conversion rate when swapping between denominations of SD and LD
     //      - shareDecimals == SD == shared Decimals
@@ -359,7 +361,7 @@ abstract contract OFTCore is IOFT, OApp, OAppPreCrimeSimulator, OAppOptionsType3
      * @return amountSD The amount in shared decimals.
      */
     function _toSD(uint256 _amountLD) internal view virtual returns (uint64 amountSD) {
-        return uint64(_amountLD / decimalConversionRate);
+        return (_amountLD / decimalConversionRate).toUint64();
     }
 
     /**

--- a/packages/oft-evm/contracts/OFTCore.sol
+++ b/packages/oft-evm/contracts/OFTCore.sol
@@ -359,13 +359,11 @@ abstract contract OFTCore is IOFT, OApp, OAppPreCrimeSimulator, OAppOptionsType3
      * @return amountSD The amount in shared decimals.
      *
      * @dev Reverts if the _amountLD in shared decimals overflows uint64.
-     * @dev eg. uint(2**64 + 123) with a conversion rate of 1 wraps around modulo 2**64 to uint(123).
+     * @dev eg. uint(2**64 + 123) with a conversion rate of 1 wraps around 2**64 to uint(123).
      */
     function _toSD(uint256 _amountLD) internal view virtual returns (uint64 amountSD) {
         uint256 _amountSD = _amountLD / decimalConversionRate;
-        if (_amountSD > type(uint64).max) {
-            revert AmountSDOverflowed(_amountSD);
-        }
+        if (_amountSD > type(uint64).max) revert AmountSDOverflowed(_amountSD);
         return uint64(_amountSD);
     }
 

--- a/packages/oft-evm/contracts/OFTCore.sol
+++ b/packages/oft-evm/contracts/OFTCore.sol
@@ -13,7 +13,6 @@ import { OAppPreCrimeSimulator } from "@layerzerolabs/oapp-evm/contracts/precrim
 import { IOFT, SendParam, OFTLimit, OFTReceipt, OFTFeeDetail, MessagingReceipt, MessagingFee } from "./interfaces/IOFT.sol";
 import { OFTMsgCodec } from "./libs/OFTMsgCodec.sol";
 import { OFTComposeMsgCodec } from "./libs/OFTComposeMsgCodec.sol";
-import { Vm } from "forge-std/Vm.sol";
 
 /**
  * @title OFTCore

--- a/packages/oft-evm/contracts/interfaces/IOFT.sol
+++ b/packages/oft-evm/contracts/interfaces/IOFT.sol
@@ -54,6 +54,7 @@ interface IOFT {
     // Custom error messages
     error InvalidLocalDecimals();
     error SlippageExceeded(uint256 amountLD, uint256 minAmountLD);
+    error AmountSDOverflowed(uint256 amountSD);
 
     // Events
     event OFTSent(

--- a/packages/oft-evm/test/OFT.t.sol
+++ b/packages/oft-evm/test/OFT.t.sol
@@ -345,7 +345,7 @@ contract OFTTest is TestHelperOz5 {
     }
 
     function test_toSD(uint256 amountLD) public {
-        vm.assume(amountLD <= type(uint64).max); // avoid reverting due to overflow
+        vm.assume(amountLD / aOFT.asOFTMock().decimalConversionRate() <= type(uint64).max); // avoid SafeCast overflow
         assertEq(amountLD / aOFT.asOFTMock().decimalConversionRate(), aOFT.asOFTMock().toSD(amountLD));
     }
 
@@ -601,6 +601,7 @@ contract OFTTest is TestHelperOz5 {
 
     function test_oft_build_msg(uint32 dstEid, bytes32 to, uint256 amountToSendLD, bytes memory composeMsg) public {
         vm.assume(composeMsg.length > 0); // ensure there is a composed payload
+        vm.assume(amountToSendLD / aOFT.asOFTMock().decimalConversionRate() <= type(uint64).max); // avoid SafeCast overflow
         uint256 minAmountToCreditLD = aOFT.asOFTMock().removeDust(amountToSendLD);
 
         // params for buildMsgAndOptions
@@ -630,6 +631,7 @@ contract OFTTest is TestHelperOz5 {
     }
 
     function test_oft_build_msg_no_compose_msg(uint32 dstEid, bytes32 to, uint256 amountToSendLD) public {
+        vm.assume(amountToSendLD / aOFT.asOFTMock().decimalConversionRate() <= type(uint64).max); // avoid SafeCast overflow
         uint256 minAmountToCreditLD = aOFT.asOFTMock().removeDust(amountToSendLD);
 
         // params for buildMsgAndOptions
@@ -751,6 +753,7 @@ contract OFTTest is TestHelperOz5 {
     }
 
     function test_oapp_inspector_inspect(uint32 dstEid, address user, uint256 amountToSendLD) public {
+        vm.assume(amountToSendLD / aOFT.asOFTMock().decimalConversionRate() <= type(uint64).max); // avoid SafeCast overflow
         bytes32 to = addressToBytes32(user);
         uint256 minAmountToCreditLD = aOFT.asOFTMock().removeDust(amountToSendLD);
 
@@ -782,6 +785,7 @@ contract OFTTest is TestHelperOz5 {
     }
 
     function test_quoteOFT(uint256 _amountToSendLD) public virtual {
+        vm.assume(_amountToSendLD / aOFT.asOFTMock().decimalConversionRate() <= type(uint64).max); // avoid SafeCast overflow
         bytes32 to = addressToBytes32(userA);
         uint256 minAmountToCreditLD = aOFT.asOFTMock().removeDust(_amountToSendLD);
         SendParam memory sendParam = SendParam(B_EID, to, _amountToSendLD, minAmountToCreditLD, "", "", "");

--- a/packages/oft-evm/test/OFT.t.sol
+++ b/packages/oft-evm/test/OFT.t.sol
@@ -349,6 +349,16 @@ contract OFTTest is TestHelperOz5 {
         assertEq(amountLD / aOFT.asOFTMock().decimalConversionRate(), aOFT.asOFTMock().toSD(amountLD));
     }
 
+    function test_toSD_overflow() public {
+        // Create an amount that will cause overflow when converted to shared decimals
+        uint256 justOverMaxAmount = (uint256(type(uint64).max) + 1) * aOFT.asOFTMock().decimalConversionRate();
+        uint256 expectedOverflowValue = justOverMaxAmount / aOFT.asOFTMock().decimalConversionRate();
+        
+        // Expect the AmountSDOverflowed error with the overflow value
+        vm.expectRevert(abi.encodeWithSelector(IOFT.AmountSDOverflowed.selector, expectedOverflowValue));
+        aOFT.asOFTMock().toSD(justOverMaxAmount);
+    }
+
     function test_oft_debit() public virtual {
         uint256 amountToSendLD = 1 ether;
         uint256 minAmountToCreditLD = 1 ether;


### PR DESCRIPTION
## In this PR:

### **Security Enhancement: SafeCast Implementation for `_toSD()` Function**

#### **Core Changes**

**File: `packages/oft-evm/contracts/OFTCore.sol`**
- **Enhanced `_toSD()` function** with SafeCast overflow protection
- **Before**: `return uint64(_amountLD / decimalConversionRate);` - Silent truncation on overflow
- **After**: `return (_amountLD / decimalConversionRate).toUint64();` - Explicit revert on overflow

#### **Impact**
- **Prevents silent overflow**: Large amounts that exceed uint64 limits now revert with clear error messages instead of being silently truncated
- **Stops loss of funds when overriding shared decimals**: Incorrect shared decimal usage previously would overflow and trigger a cross-chain message that burnt funds on source chain, but delivered the truncated value. This fixes that problem by reverting on source send.

<img width="1363" height="758" alt="Screenshot 2025-07-18 at 12 36 59 PM" src="https://github.com/user-attachments/assets/2f06b722-873b-4343-99b7-54dd5c18d2b0" />



#### **Test Updates**

**File: `packages/oft-evm/test/OFT.t.sol`**
Updated fuzzing constraints in multiple test functions to work with the new overflow protection:

- ✅ `test_oft_build_msg()` - Added SafeCast overflow assumption
- ✅ `test_oft_build_msg_no_compose_msg()` - Added SafeCast overflow assumption  
- ✅ `test_oapp_inspector_inspect()` - Added SafeCast overflow assumption
- ✅ `test_toSD()` - Improved assumption precision
- ✅ `test_quoteOFT()` - Added SafeCast overflow assumption

**Assumption Pattern**:
```solidity
vm.assume(amountToSendLD / aOFT.asOFTMock().decimalConversionRate() <= type(uint64).max);
```

#### **Why This Matters**

1. **Security**: Prevents potential loss of funds from uint64 overflow scenarios
2. **Reliability**: Clear error messages instead of silent delivery of wrong funds
3. **Testing**: Maintains comprehensive test coverage while respecting new safety constraints

#### **Breaking Changes**
⚠️ **Potential Breaking Change**: Operations that previously succeeded with silent truncation will now revert. This is **intentional** and **improves security**.

The changes ensure that any amount conversion that would result in uint64 overflow fails explicitly rather than producing incorrect results.