### PR TITLE
chore: remove redundant words

### DIFF
--- a/examples/oft-hyperliquid/HYPERLIQUID.README.md
+++ b/examples/oft-hyperliquid/HYPERLIQUID.README.md
@@ -167,7 +167,7 @@ The current architecture has certain error handling AND checks (because hyperliq
 
 #### Transfer exceeding u64.max
 
-HyperCore's spot send only allows for a maximum of `u64` tokens to be transferred across. This means (in the unlikely event) that the user sends across greater than `u64` the difference would be returned the the `receiver` address on `HyperEVM`.
+HyperCore's spot send only allows for a maximum of `u64` tokens to be transferred across. This means (in the unlikely event) that the user sends across greater than `u64` the difference would be returned the `receiver` address on `HyperEVM`.
 
 #### Transfer exceeding HyperCore Bridge Capactiy
 

--- a/packages/hyperliquid-composer/HYPERLIQUID.README.md
+++ b/packages/hyperliquid-composer/HYPERLIQUID.README.md
@@ -454,7 +454,7 @@ The current architecture has certain error handling AND checks (because Hyperliq
 
 #### Transfer exceeding u64.max
 
-HyperCore's spot send only allows for a maximum of `u64` tokens to be transferred across. This means (in the unlikely event) that the user sends across greater than `u64` the difference would be returned the the `receiver` address on `HyperEVM`.
+HyperCore's spot send only allows for a maximum of `u64` tokens to be transferred across. This means (in the unlikely event) that the user sends across greater than `u64` the difference would be returned the `receiver` address on `HyperEVM`.
 
 #### Transfer exceeding HyperCore Bridge Capactiy
 


### PR DESCRIPTION
remove redundant words