### PR TITLE
Find commented chain mismatch in config

### DIFF
--- a/examples/oft/layerzero.config.ts
+++ b/examples/oft/layerzero.config.ts
@@ -35,10 +35,10 @@ const EVM_ENFORCED_OPTIONS: OAppEnforcedOption[] = [
 const pathways: TwoWayConfig[] = [
     [
         optimismContract, // Chain A contract
-        arbitrumContract, // Chain C contract
+        arbitrumContract, // Chain B contract
         [['LayerZero Labs'], []], // [ requiredDVN[], [ optionalDVN[], threshold ] ]
         [1, 1], // [A to B confirmations, B to A confirmations]
-        [EVM_ENFORCED_OPTIONS, EVM_ENFORCED_OPTIONS], // Chain C enforcedOptions, Chain A enforcedOptions
+        [EVM_ENFORCED_OPTIONS, EVM_ENFORCED_OPTIONS], // Chain B enforcedOptions, Chain A enforcedOptions
     ],
 ]
 


### PR DESCRIPTION
Corrected comments in `examples/oft/layerzero.config.ts` to accurately reflect the two-chain configuration.

The comments incorrectly referred to "Chain C" when only "Chain A" and "Chain B" were present, leading to confusion.

---
<a href="https://cursor.com/background-agent?bcId=bc-7e89bb34-2ed3-48c2-8486-a4bc22d15179">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7e89bb34-2ed3-48c2-8486-a4bc22d15179">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>