### PR TITLE
fix getSendLibrary throwing in happy path

### DIFF
--- a/.changeset/witty-ties-breathe.md
+++ b/.changeset/witty-ties-breathe.md
@@ -1,0 +1,5 @@
+---
+"@layerzerolabs/protocol-devtools-solana": patch
+---
+
+fix wiring error


### PR DESCRIPTION
Previously, sendLibrary would not throw, but just return null, when the defaultSendLibrary was not found. Wiring was allowed to continue. This PR catches the specific new error and allows wiring to continue.

## How I tested


## Proof of Test

https://testnet.layerzeroscan.com/tx/2cmxP2GGyumksbVAism2QFouvLmoNhz9vpKh65fcij9uJ2LLCJ7AVy5muCyRCfVSxNk5ourYmSqw394tvK5xAAsS
https://testnet.layerzeroscan.com/tx/0xc07afa6cfad3b5b53def8dadfec4a7fd75b8c87cc44491bc8fbe5d4afdcf665c