### PR TITLE
DEVREL-658 Fix Solana OFT initialization to prevent configuration failures

### DIFF
--- a/.changeset/moody-ears-smile.md
+++ b/.changeset/moody-ears-smile.md
@@ -1,0 +1,7 @@
+---
+"@layerzerolabs/protocol-devtools-solana": patch
+"@layerzerolabs/ua-devtools-solana": patch
+"@layerzerolabs/oft-solana-example": patch
+---
+
+Fix the handling of initSendLibrary and initReceiveLibrary to properly initialize in the init step rather than during setPeer

--- a/examples/oft-solana/tasks/common/wire.ts
+++ b/examples/oft-solana/tasks/common/wire.ts
@@ -6,6 +6,7 @@ import { SUBTASK_LZ_SIGN_AND_SEND, types as devtoolsTypes } from '@layerzerolabs
 import { setTransactionSizeBuffer } from '@layerzerolabs/devtools-solana'
 import { type LogLevel, createLogger } from '@layerzerolabs/io-devtools'
 import { ChainType, endpointIdToChainType } from '@layerzerolabs/lz-definitions'
+import { BlockedMessageLibProgram } from '@layerzerolabs/lz-solana-sdk-v2'
 import { type IOApp, type OAppConfigurator, type OAppOmniGraph, configureOwnable } from '@layerzerolabs/ua-devtools'
 import {
     SUBTASK_LZ_OAPP_WIRE_CONFIGURE,
@@ -129,7 +130,10 @@ task(TASK_LZ_OAPP_WIRE)
                     for (const connection of graph.connections) {
                         // check if from Solana Endpoint
                         if (endpointIdToChainType(connection.vector.from.eid) === ChainType.SOLANA) {
-                            if (connection.config?.sendLibrary) {
+                            if (
+                                connection.config?.sendLibrary &&
+                                connection.config.sendLibrary !== BlockedMessageLibProgram.PROGRAM_ID.toString()
+                            ) {
                                 // if from Solana Endpoint, ensure the PeerConfig account was already initialized
                                 const solanaConnection = await connectionFactory(connection.vector.from.eid)
 

--- a/packages/protocol-devtools-solana/src/uln302/schema.ts
+++ b/packages/protocol-devtools-solana/src/uln302/schema.ts
@@ -8,11 +8,13 @@ export const Uln302UlnConfigInputSchema: z.ZodSchema<Uln302UlnConfig, z.ZodTypeD
         confirmations: z.union([UIntBigIntSchema, BNBigIntSchema]),
         optionalDvnThreshold: UIntNumberSchema,
         requiredDvns: z.array(PublicKeyBase58Schema),
+        requiredDvnCount: UIntNumberSchema,
         optionalDvns: z.array(PublicKeyBase58Schema),
     })
-    .transform(({ confirmations, optionalDvnThreshold, requiredDvns, optionalDvns }) => ({
+    .transform(({ confirmations, optionalDvnThreshold, requiredDvns, requiredDvnCount, optionalDvns }) => ({
         confirmations,
         optionalDVNThreshold: optionalDvnThreshold,
         requiredDVNs: requiredDvns,
+        requiredDVNCount: requiredDvnCount,
         optionalDVNs: optionalDvns,
     }))


### PR DESCRIPTION
Fixes DEVREL-658

## Problem
Deploying Solana OFTs were encountering errors during the configuration process:
```
Error: Unable to find defaultSendLibraryConfig/sendLibraryConfig account at xxx/xxxx
```

**Workaround**: Downgrading to `@layerzerolabs/lz-solana-sdk-v2@3.0.114` temporarily resolved the issue, but this was not a sustainable solution as it affected all deploying Solana OFTs.

## Root Cause
The issue was introduced in version 3.0.115 and was related to the transaction execution order in the devtools wiring process:

1. This caused the `getSendLibrary` call to fail when the required PDA accounts didn't exist
2. The `initSendLibrary` and `initReceiveLibrary` operations were only happening during `setPeer`, but library initialization shouldn't depend on peers being set

### Breaking Change in 3.0.115
The issue was exposed by a **breaking change** in `@layerzerolabs/lz-solana-sdk-v2@3.0.115`:

- **Before 3.0.115**: When `getSendLibrary()` was called on non-existent PDA accounts, it would return a **warning** and return `null`, allowing the process to continue
- **After 3.0.115**: The same scenario now **throws an exception** instead of returning `null`, causing the entire configuration process to fail


## Solution
Instead of downgrading the SDK version, this PR fixes the underlying initialization flow by:

1. **Proper Initialization Order**: Move `initSendLibrary` and `initReceiveLibrary` into the initial `initConfig` step instead of waiting for peer configuration

2. **Enhanced Validation**: Improve the `sendConfigIsInitialized` method to check for:
   - OFT store account existence
   - Send library initialization status  
   - Receive library initialization status

3. **Robust Configuration**: Update `initConfig` to handle multiple initialization steps:
   - Initialize OFT store account if it doesn't exist
   - Initialize send library if not already done
   - Initialize receive library if not already done

4. **Blocked Message Library Support**: Fix pre-wiring validation to properly handle blocked message library configurations

## Fix Instructions
To resolve this issue in your project:

1. **Update devtools**: Pull the latest devtools changes that include this fix
2. **Run initialization**: Execute `npx hardhat lz:oft:solana:init-config` before running the wire command
3. **Proceed with wiring**: Run `npx hardhat lz:oapp:wire --oapp-config layerzero.config.ts` as normal

The fix ensures that all required PDA accounts are properly initialized before any configuration attempts are made.
