### PR TITLE
docs(examples): add comment clarifying sellers fee basis points param

### DIFF
--- a/examples/lzapp-migration/tasks/solana/createOFT.ts
+++ b/examples/lzapp-migration/tasks/solana/createOFT.ts
@@ -75,7 +75,7 @@ interface CreateOFTTaskArgs {
     programId: string
 
     /**
-     * The seller fee basis points.
+     * The seller fee basis points for Metaplex's Token Metadata standard (not enforced on-chain). This is not related to OFT fees.
      */
     sellerFeeBasisPoints: number
 
@@ -133,7 +133,7 @@ task('lz:oft:solana:create', 'Mints new SPL Token and creates new OFT Store acco
     .addParam('name', 'Token Name', 'MockOFT', devtoolsTypes.string)
     .addOptionalParam('mint', 'The Token mint public key (used for MABA only)', undefined, devtoolsTypes.string)
     .addParam('programId', 'The OFT Program id')
-    .addParam('sellerFeeBasisPoints', 'Seller fee basis points', 0, devtoolsTypes.int)
+    .addParam('sellerFeeBasisPoints', 'Seller fee basis points', 0, devtoolsTypes.int) // Note: This is for Metaplex's Token Metadata standard (not enforced on-chain). This is not related to OFT fees.
     .addParam('symbol', 'Token Symbol', 'MOFT', devtoolsTypes.string)
     .addParam('tokenMetadataIsMutable', 'Token metadata is mutable', true, devtoolsTypes.boolean)
     .addParam('additionalMinters', 'Comma-separated list of additional minters', undefined, devtoolsTypes.csv, true)

--- a/examples/oft-solana/tasks/solana/createOFT.ts
+++ b/examples/oft-solana/tasks/solana/createOFT.ts
@@ -75,7 +75,7 @@ interface CreateOFTTaskArgs {
     programId: string
 
     /**
-     * The seller fee basis points.
+     * The seller fee basis points for Metaplex's Token Metadata standard (not enforced on-chain). This is not related to OFT fees.
      */
     sellerFeeBasisPoints: number
 
@@ -133,7 +133,7 @@ task('lz:oft:solana:create', 'Mints new SPL Token and creates new OFT Store acco
     .addParam('name', 'Token Name', 'MockOFT', devtoolsTypes.string)
     .addOptionalParam('mint', 'The Token mint public key (used for MABA only)', undefined, devtoolsTypes.string)
     .addParam('programId', 'The OFT Program id')
-    .addParam('sellerFeeBasisPoints', 'Seller fee basis points', 0, devtoolsTypes.int)
+    .addParam('sellerFeeBasisPoints', 'Seller fee basis points', 0, devtoolsTypes.int) // Note: This is for Metaplex's Token Metadata standard (not enforced on-chain). This is not related to OFT fees.
     .addParam('symbol', 'Token Symbol', 'MOFT', devtoolsTypes.string)
     .addParam('tokenMetadataIsMutable', 'Token metadata is mutable', true, devtoolsTypes.boolean)
     .addParam('additionalMinters', 'Comma-separated list of additional minters', undefined, devtoolsTypes.csv, true)


### PR DESCRIPTION
diff is purely comments.

The param is passed into the `createV1` call of the Metaplex library and is saved into the Token Metadata account. It is not enforced on-chain and is typically used by NFT collections.

source: https://developers.metaplex.com/token-metadata#:~:text=Whilst%20there%20is%20Seller%20Fee%20Basis%20Points%20attribute%20on%20the%20Metadata%20account%2C%20it%20is%20purely%20indicative%20and%20anyone%20could%20create%20a%20marketplace%20that%20does%20not%20honor%20royalties%20%E2%80%94%20which%20is%20exactly%20what%20happened.