### PR TITLE
Ovault - audit paladin

### DIFF
--- a/packages/ovault-evm/contracts/VaultComposerSync.sol
+++ b/packages/ovault-evm/contracts/VaultComposerSync.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.22;
 
 import { SafeERC20, IERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
-import { IERC4626 } from "@openzeppelin/contracts/interfaces/IERC4626.sol";
+import { ERC4626, IERC4626 } from "@openzeppelin/contracts/token/ERC20/extensions/ERC4626.sol";
 
 import { ReentrancyGuard } from "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
 
@@ -273,6 +273,7 @@ contract VaultComposerSync is IVaultComposerSync, ReentrancyGuard {
     /**
      * @notice Quotes the send operation for the given OFT and SendParam
      * @dev Revert on slippage will be thrown by the OFT and not _assertSlippage
+     * @param _from The "sender address" used for the quote
      * @param _targetOFT The OFT contract address to quote
      * @param _vaultInAmount The amount of tokens to send to the vault
      * @param _sendParam The parameters for the send operation
@@ -280,6 +281,7 @@ contract VaultComposerSync is IVaultComposerSync, ReentrancyGuard {
      * @dev This function can be overridden to implement custom quoting logic
      */
     function quoteSend(
+        address _from,
         address _targetOFT,
         uint256 _vaultInAmount,
         SendParam memory _sendParam
@@ -287,8 +289,18 @@ contract VaultComposerSync is IVaultComposerSync, ReentrancyGuard {
         /// @dev When quoting the asset OFT, the function input is shares and the SendParam.amountLD into quoteSend() should be assets (and vice versa)
 
         if (_targetOFT == ASSET_OFT) {
+            uint256 maxDeposit = VAULT.maxDeposit(_from);
+            if (_vaultInAmount > maxDeposit) {
+                revert ERC4626.ERC4626ExceededMaxDeposit(_from, _vaultInAmount, maxDeposit);
+            }
+
             _sendParam.amountLD = VAULT.previewRedeem(_vaultInAmount);
         } else {
+            uint256 maxRedeem = VAULT.maxRedeem(_from);
+            if (_vaultInAmount > maxRedeem) {
+                revert ERC4626.ERC4626ExceededMaxRedeem(_from, _vaultInAmount, maxRedeem);
+            }
+
             _sendParam.amountLD = VAULT.previewDeposit(_vaultInAmount);
         }
         return IOFT(_targetOFT).quoteSend(_sendParam, false);

--- a/packages/ovault-evm/contracts/VaultComposerSync.sol
+++ b/packages/ovault-evm/contracts/VaultComposerSync.sol
@@ -289,16 +289,16 @@ contract VaultComposerSync is IVaultComposerSync, ReentrancyGuard {
         /// @dev When quoting the asset OFT, the function input is shares and the SendParam.amountLD into quoteSend() should be assets (and vice versa)
 
         if (_targetOFT == ASSET_OFT) {
-            uint256 maxDeposit = VAULT.maxDeposit(_from);
-            if (_vaultInAmount > maxDeposit) {
-                revert ERC4626.ERC4626ExceededMaxDeposit(_from, _vaultInAmount, maxDeposit);
+            uint256 maxRedeem = VAULT.maxRedeem(_from);
+            if (_vaultInAmount > maxRedeem) {
+                revert ERC4626.ERC4626ExceededMaxRedeem(_from, _vaultInAmount, maxRedeem);
             }
 
             _sendParam.amountLD = VAULT.previewRedeem(_vaultInAmount);
         } else {
-            uint256 maxRedeem = VAULT.maxRedeem(_from);
-            if (_vaultInAmount > maxRedeem) {
-                revert ERC4626.ERC4626ExceededMaxRedeem(_from, _vaultInAmount, maxRedeem);
+            uint256 maxDeposit = VAULT.maxDeposit(_from);
+            if (_vaultInAmount > maxDeposit) {
+                revert ERC4626.ERC4626ExceededMaxDeposit(_from, _vaultInAmount, maxDeposit);
             }
 
             _sendParam.amountLD = VAULT.previewDeposit(_vaultInAmount);

--- a/packages/ovault-evm/contracts/interfaces/IVaultComposerSync.sol
+++ b/packages/ovault-evm/contracts/interfaces/IVaultComposerSync.sol
@@ -56,6 +56,7 @@ interface IVaultComposerSync is IOAppComposer {
 
     /**
      * @notice Quotes the send operation for the given OFT and SendParam
+     * @param from The "sender address" used for the quote
      * @param targetOft The OFT contract address to quote
      * @param vaultInAmount The amount of tokens to send to the vault
      * @param sendParam The parameters for the send operation
@@ -63,6 +64,7 @@ interface IVaultComposerSync is IOAppComposer {
      * @dev This function can be overridden to implement custom quoting logic
      */
     function quoteSend(
+        address from,
         address targetOft,
         uint256 vaultInAmount,
         SendParam memory sendParam

--- a/packages/ovault-evm/test/vault-sync/VaultComposerSync_ProxySend.t.sol
+++ b/packages/ovault-evm/test/vault-sync/VaultComposerSync_ProxySend.t.sol
@@ -104,7 +104,7 @@ contract VaultComposerSyncProxySendTest is VaultComposerSyncBaseTest {
 
         MessagingFee memory fee = VaultComposerSyncArb.quoteSend(
             userA,
-            address(assetOFT_arb),
+            address(shareOFT_arb),
             TOKENS_TO_SEND,
             sendParam
         );
@@ -130,7 +130,7 @@ contract VaultComposerSyncProxySendTest is VaultComposerSyncBaseTest {
 
         MessagingFee memory fee = VaultComposerSyncArb.quoteSend(
             userA,
-            address(shareOFT_arb),
+            address(assetOFT_arb),
             TOKENS_TO_SEND,
             sendParam
         );

--- a/packages/ovault-evm/test/vault-sync/VaultComposerSync_ProxySend.t.sol
+++ b/packages/ovault-evm/test/vault-sync/VaultComposerSync_ProxySend.t.sol
@@ -102,7 +102,12 @@ contract VaultComposerSyncProxySendTest is VaultComposerSyncBaseTest {
         SendParam memory sendParam = SendParam(POL_EID, addressToBytes32(userA), TOKENS_TO_SEND, 0, "", "", "");
         assetOFT_arb.mint(address(userA), TOKENS_TO_SEND);
 
-        MessagingFee memory fee = VaultComposerSyncArb.quoteSend(address(assetOFT_arb), TOKENS_TO_SEND, sendParam);
+        MessagingFee memory fee = VaultComposerSyncArb.quoteSend(
+            userA,
+            address(assetOFT_arb),
+            TOKENS_TO_SEND,
+            sendParam
+        );
 
         vm.startPrank(userA);
         assetOFT_arb.approve(address(VaultComposerSyncArb), TOKENS_TO_SEND);
@@ -123,7 +128,12 @@ contract VaultComposerSyncProxySendTest is VaultComposerSyncBaseTest {
         assetOFT_arb.mint(address(vault_arb), TOKENS_TO_SEND);
         vault_arb.mint(address(userA), TOKENS_TO_SEND);
 
-        MessagingFee memory fee = VaultComposerSyncArb.quoteSend(address(shareOFT_arb), TOKENS_TO_SEND, sendParam);
+        MessagingFee memory fee = VaultComposerSyncArb.quoteSend(
+            userA,
+            address(shareOFT_arb),
+            TOKENS_TO_SEND,
+            sendParam
+        );
 
         vm.startPrank(userA);
         vault_arb.approve(address(VaultComposerSyncArb), TOKENS_TO_SEND);


### PR DESCRIPTION
Adding in `_from` as the "sender" in `quoteSend(_from, ...oldArgs)`

Updated interface and tests. 

`quoteSend()` also checks if the `vaultInAmout` can be deposited or redeemed by checking it against `maxDeposit()` OR `maxRedeem()`