### PR TITLE
feat: solana ci upgrade

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -21,12 +21,21 @@ docker-*.yaml
 # Dependencies & deployments
 **/node_modules
 
-# Build files & cache
+# Build files & cache  
 **/deployments
 **/dist
 **/artifacts
 **/cache
 **/out
+**/.turbo
+**/coverage
+**/tmp
+**/temp
+
+# Keep tests/ for specific builds but exclude heavy files
+tests/**/node_modules/
+tests/**/.turbo/
+tests/**/coverage/
 
 # Metadata
 *.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -268,17 +268,17 @@ ARG CARGO_BUILD_JOBS=default
 ENV CARGO_BUILD_JOBS=$CARGO_BUILD_JOBS
 
 RUN BUILD_FROM_SOURCE=true; \
-# Install Solana using a binary with a fallback to installing from source. 
-# List of machines that have prebuilt binaries:
+    # Install Solana using a binary with a fallback to installing from source. 
+    # List of machines that have prebuilt binaries:
     # - amd64/linux - last checked on Feb 11, 2025
     if [ "$(dpkg --print-architecture)" = "amd64" ]; then \
-    curl --proto '=https' --tlsv1.2 -sSf https://release.anza.xyz/v${SOLANA_VERSION}/install | sh -s && \
-    BUILD_FROM_SOURCE=false; \
+        curl --proto '=https' --tlsv1.2 -sSf https://release.anza.xyz/v${SOLANA_VERSION}/install | sh -s && \
+        BUILD_FROM_SOURCE=false; \
     fi && \
     # If we need to build from source, we'll do it here
     # List of machines that need to be built from source:
-        # - arm64/linux - last checked on Feb 11, 2025
-        if [ "$BUILD_FROM_SOURCE" = "true" ]; then \
+    # - arm64/linux - last checked on Feb 11, 2025
+    if [ "$BUILD_FROM_SOURCE" = "true" ]; then \
         git clone https://github.com/anza-xyz/agave.git --depth 1 --branch v${SOLANA_VERSION} ~/solana-v${SOLANA_VERSION} && \
         # Produces the same directory structure as the prebuilt binaries
         # Make the active release point to the new release
@@ -286,7 +286,7 @@ RUN BUILD_FROM_SOURCE=true; \
         ln --symbolic ~/.local/share/solana/install/releases/${SOLANA_VERSION} ~/.local/share/solana/install/active_release && \
         # Clean up the source code
         rm -rf ~/solana-v${SOLANA_VERSION}; \
-        fi
+    fi
         
 # Move this down to use docker caching on Solana build
 # https://github.dev/anza-xyz/agave/blob/v2.2.20/sbf/scripts/install.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -96,6 +96,8 @@ RUN apt-get install --yes \
     libatomic1 libssl-dev \
     # Required to build the base image
     build-essential \
+    # Required for node-gyp to build native Node.js modules (like utf-8-validate)
+    python3 \
     # speed up llvm builds
     ninja-build
 


### PR DESCRIPTION
upgrading

rustc to 1.84.1
solana to 2.2.20
anchor to 0.31.1
platform-tools to 1.48

evm node no longer cares about solana
enabling parallel compilation on rust 
reducing layers by combining some
