### PR TITLE
fix: composeMsg in debug send script

### DIFF
--- a/.changeset/pink-coins-fix.md
+++ b/.changeset/pink-coins-fix.md
@@ -1,0 +1,5 @@
+---
+"@layerzerolabs/ovault-evm-example": patch
+---
+
+fix DebugSendScript to include composeValue in composeMsg

--- a/examples/ovault-evm/script/DebugSendScript.sol
+++ b/examples/ovault-evm/script/DebugSendScript.sol
@@ -105,7 +105,7 @@ contract DebugSendScript is Script {
                 composeMsg: composeMsg,
                 oftCmd: hex""
             });
-            composeMsg = abi.encode(hopSendParam);
+            composeMsg = abi.encode(hopSendParam, _lzComposeValue);
             to = _composer.toBytes32();
             dstEid = HUB_EID;
         }


### PR DESCRIPTION
composeMsg is `abi.encode(SendParam, uint256 minMsgValue)` where `minMsgValue` is the `composeValue`