### PR TITLE
Update README.md

### DIFF
--- a/examples/oapp/README.md
+++ b/examples/oapp/README.md
@@ -124,13 +124,13 @@ With your OApps wired, you can now send messages cross-chain.
 Send a message from **Optimism Sepolia** to **Arbitrum Sepolia**:
 
 ```bash
-pnpm hardhat lz:oapp:send --dst-eid 40231 --string 'Hello from Ethereum!' --network optimism-testnet
+pnpm hardhat lz:oapp:send --dst-eid 40231 --string 'Hello from Optimism!' --network optimism-testnet
 ```
 
 Send a message from **Arbitrum Sepolia** to **Optimism Sepolia**:
 
 ```bash
-pnpm hardhat lz:oapp:send --dst-eid 40161 --string 'Hello from Arbitrum!' --network arbitrum-testnet
+pnpm hardhat lz:oapp:send --dst-eid 40232 --string 'Hello from Arbitrum!' --network arbitrum-testnet
 ```
 
 > :information_source: `40161` and `40231` are the Endpoint IDs of Optimism Sepolia and Arbitrum Sepolia respectively. The source network is determined by the `--network` flag, not a separate `--src-eid` parameter. View the list of chains and their Endpoint IDs on the [Deployed Endpoints](https://docs.layerzero.network/v2/deployments/deployed-contracts) page.


### PR DESCRIPTION
1. Line 127: The string message is incorrect

    - Current: 'Hello from Ethereum!'
    - Should be: 'Hello from Optimism!'
    - Reason: The command is sending from

   Optimism Sepolia, so the message should reflect that

2. Line 133: The destination EID is incorrect
    - Current: --dst-eid 40161 (Ethereum Sepolia)
    - Should be: --dst-eid 40232 (Optimism Sepolia)
    - Reason: The description says

 "Arbitrum Sepolia to Optimism Sepolia" but uses Ethereum Sepolia's EID