### PR TITLE
DEVREL-807 check nonce account existence in setPeer call

### DIFF
--- a/.changeset/clean-ants-worry.md
+++ b/.changeset/clean-ants-worry.md
@@ -1,0 +1,5 @@
+---
+"@layerzerolabs/ua-devtools-solana": patch
+---
+
+check nonce account existence in setPeer call

--- a/packages/ua-devtools-solana/src/oft/sdk.ts
+++ b/packages/ua-devtools-solana/src/oft/sdk.ts
@@ -32,7 +32,7 @@ import {
 } from '@metaplex-foundation/umi'
 import { mplToolbox } from '@metaplex-foundation/mpl-toolbox'
 import { createUmi } from '@metaplex-foundation/umi-bundle-defaults'
-import { fromWeb3JsPublicKey } from '@metaplex-foundation/umi-web3js-adapters'
+import { fromWeb3JsPublicKey, toWeb3JsPublicKey } from '@metaplex-foundation/umi-web3js-adapters'
 import { EndpointProgram, MessageLibPDADeriver, UlnProgram } from '@layerzerolabs/lz-solana-sdk-v2'
 
 // TODO: Use exported interfaces when they are available
@@ -170,6 +170,7 @@ export class OFT extends OmniSDK implements IOApp {
 
     async setPeer(eid: EndpointId, address: OmniAddress | null | undefined): Promise<OmniTransaction> {
         const eidLabel = formatEid(eid)
+        const endpointDeriver = (await this.getEndpointSDK()).deriver
         // We use the `mapError` and pretend `normalizePeer` is async to avoid having a let and a try/catch block
         const normalizedPeer = await mapError(
             async () => normalizePeer(address, eid),
@@ -177,6 +178,10 @@ export class OFT extends OmniSDK implements IOApp {
                 new Error(`Failed to convert peer ${address} for ${eidLabel} for ${this.label} to bytes: ${error}`)
         )
         const peerAsBytes32 = makeBytes32(normalizedPeer)
+        const [nonceAccount] = endpointDeriver.nonce(toWeb3JsPublicKey(this.umiPublicKey), eid, normalizedPeer)
+        const nonceAccountInfo = await this.connection.getAccountInfo(nonceAccount)
+        const nonceAccountExists = nonceAccountInfo != null
+
         const delegate = await this.safeGetDelegate()
 
         const oftStore = this.umiPublicKey
@@ -204,8 +209,15 @@ export class OFT extends OmniSDK implements IOApp {
         // since the order is important, we push the instructions in the order we want them to be executed
         instructions.push(
             await this._setPeerEnforcedOptionsIx(new Uint8Array([0, 3]), new Uint8Array([0, 3]), eid), // admin
-            await this._setPeerFeeBpsIx(eid), // admin
-            oft.initOAppNonce({ admin: delegate, oftStore }, eid, normalizedPeer), // delegate
+            await this._setPeerFeeBpsIx(eid) // admin
+        )
+
+        if (!nonceAccountExists) {
+            // Only initialize the nonce account if it doesn't yet exist
+            instructions.push(oft.initOAppNonce({ admin: delegate, oftStore }, eid, normalizedPeer)) // delegate
+        }
+
+        instructions.push(
             await this._createSetPeerAddressIx(normalizedPeer, eid) // admin but is this needed?  set twice...
         )
 


### PR DESCRIPTION
## Changes

- only call .initNonce on Endpoint if the Nonce Account does not yet exist

## Reproducing the error

Using Arbitrum Sepolia (40231) <> Solana Devnet (40168)

To reproduce, I call .initNonce on the Endpoint before calling the wire task.

Txn that calls initNonce for the OApp + Peer combination before wiring task: https://solscan.io/tx/4MwquJFevRtVyvs9kS52SvTTwDnNu6d8t7rCAGpc4HkfSbgCd6Ko1dZ9EaCartVgub3diiNdnZkFb1mjYW2Mjh25?cluster=devnet

Running the wire task before patching devtools, I can reproduce the error:

 
```
Error: Simulation failed.
Message: Transaction simulation failed: Error processing Instruction 3: custom program error: 0x0.
Logs:
[
  "Program log: Instruction: SetPeerConfig",
  "Program H9j9Wp46t7GyDSU3NVV8AmYMdXZHoiZmAzVuDSVDY2jy consumed 9516 of 979896 compute units",
  "Program H9j9Wp46t7GyDSU3NVV8AmYMdXZHoiZmAzVuDSVDY2jy success",
  "Program 76y77prsiCMvXMjuoZ5VRrhG5qYBrUMYTE5WgHqgjEn6 invoke [1]",
  "Program log: Instruction: InitNonce",
  "Program 11111111111111111111111111111111 invoke [2]",
  "Allocate: account Address { address: AHUQZdSAvVhRWwfTrKt9BHCVMb9s9fxVzkMJjY3dFCvQ, base: None } already in use",
  "Program 11111111111111111111111111111111 failed: custom program error: 0x0",
  "Program 76y77prsiCMvXMjuoZ5VRrhG5qYBrUMYTE5WgHqgjEn6 consumed 9381 of 970380 compute units",
  "Program 76y77prsiCMvXMjuoZ5VRrhG5qYBrUMYTE5WgHqgjEn6 failed: custom program error: 0x0"
]

```

## Proof of Test

Continuing with my example used for the repro, after patching `setPeer()`, I called the wire task successfully despite the Nonce Account having already been initialized.

Successful txn from `setPeer` that excludes `initNonce`: https://solscan.io/tx/9LyTL2LJgAaiC32AZrUg9k6rPZrSLRRFyPJPwCftbHwrGzbkn1DzkWXiidDj7iTbLohaDwoHvKeXRSiwqhLSo34?cluster=devnet

## Testing

Ensure you first link the updated package so that the patched version (from this PR) is used:

Inside `packages/ua-devtools-solana`, run:

```
pnpm link --global
```

At the repo root, run the build step:
```
pnpm -F ua-devtools-solana build
```

Inside examples/oft-solana, run:
```
pnpm link --global @layerzerolabs/ua-devtools-solana
```

To repro, you can temporarily create a examples/oft-solana/tasks/solana/initOAppNonce.ts:

```
import { publicKey, transactionBuilder } from '@metaplex-foundation/umi'
import bs58 from 'bs58'
import { task } from 'hardhat/config'

import { types } from '@layerzerolabs/devtools-evm-hardhat'
import { createLogger } from '@layerzerolabs/io-devtools'
import { EndpointId, endpointIdToNetwork } from '@layerzerolabs/lz-definitions'
import { addressToBytes32 } from '@layerzerolabs/lz-v2-utilities'
import { oft } from '@layerzerolabs/oft-v2-solana-sdk'

import { deriveConnection, getExplorerTxLink, getSolanaDeployment } from './index'

const logger = createLogger()

interface Args {
    eid: EndpointId
    peer: string // remote OApp address (hex bytes32 for EVM; base58 for Solana)
}

// Run: npx hardhat lz:oft:solana:init-oapp-nonce --eid <SOLANA_EID> --peer <REMOTE_OAPP_ADDRESS>
task('lz:oft:solana:init-oapp-nonce', 'Initialize the OApp nonce PDA for a specific remote peer on Solana')
    .addParam('eid', 'The Solana EndpointId', undefined, types.eid)
    .addParam('dstEid', 'The destination EndpointId', undefined, types.eid)
    .addParam('peer', 'The remote OApp address (hex bytes32 or base58)', undefined, types.string)
    .setAction(async ({ eid, dstEid, peer }: Args) => {
        // Derive signer and connection for the given Solana eid
        const { connection, umi, umiWalletSigner } = await deriveConnection(eid)

        // Resolve deployed OFT program + store
        const { programId, oftStore } = (() => {
            const deployment = getSolanaDeployment(eid)
            return { programId: deployment.programId, oftStore: deployment.oftStore }
        })()

        // Normalize peer to 32-byte array
        let peerBytes: Uint8Array
        if (/^0x[0-9a-fA-F]+$/.test(peer)) {
            peerBytes = addressToBytes32(peer)
        } else {
            // assume base58 32-byte public key
            const decoded = bs58.decode(peer)
            if (decoded.length !== 32) {
                throw new Error(
                    `Invalid peer address. Expected bytes32 hex or base58(32), got length ${decoded.length}`
                )
            }
            peerBytes = decoded
        }

        // Build initOAppNonce instruction
        const ix = oft.initOAppNonce(
            {
                admin: umiWalletSigner,
                oftStore: publicKey(oftStore),
            },
            dstEid,
            peerBytes
        )

        // Send the transaction
        const txB = transactionBuilder().add(ix)
        const { signature } = await txB.sendAndConfirm(umi)
        const sig = bs58.encode(signature)

        const isTestnet = eid === EndpointId.SOLANA_V2_TESTNET
        logger.info(`Initialized OApp nonce for peer on ${endpointIdToNetwork(eid)} (eid ${eid})`)
        logger.info(`Tx: ${sig}`)
        logger.info(`Explorer: ${getExplorerTxLink(sig, isTestnet)}`)
    })
```

Ensure you add the following into the example's `tasks/index.ts`:

```
import './solana/initOAppNonce'
```

After having deployed the OFTs, but before the wiring step, run:

```
pnpm hardhat lz:oft:solana:init-oapp-nonce --eid 40168 --peer <PEER_ADDRESS> --dst-eid 40231
```

