### PR TITLE
fix: ci build step after linting

### DIFF
--- a/examples/native-oft-adapter/.eslintrc.js
+++ b/examples/native-oft-adapter/.eslintrc.js
@@ -7,5 +7,6 @@ module.exports = {
         // @layerzerolabs/eslint-config-next defines rules for turborepo-based projects
         // that are not relevant for this particular project
         'turbo/no-undeclared-env-vars': 'off',
+        'import/no-unresolved': 'warn', // lint runs before workspace packages are built; missing dist/ folders cause false unresolved errors
     },
 };

--- a/turbo.json
+++ b/turbo.json
@@ -20,12 +20,10 @@
       "persistent": true
     },
     "lint": {
-      "cache": false,
-      "dependsOn": ["^build"]
+      "cache": false
     },
     "lint:fix": {
-      "cache": false,
-      "dependsOn": ["^build"]
+      "cache": false
     },
     "start": {
       "outputs": [],


### PR DESCRIPTION
### Description

- #1717 introduced a `build` dependency on turbo `lint` commands ([turbo.json](https://github.com/LayerZero-Labs/devtools/blob/762cfa24446ed69501d61e1fe56b9fb2472eeb97/turbo.json#L22-L29)).
- A file is being created in the `pnpm lint` step in the CI in the arm64 machine, with non-UFT-8 characters in its filename. This is `./packages/test-devtools-evm-hardhat/p@���@8` ([workflow run](https://github.com/LayerZero-Labs/devtools/actions/runs/18210429126/job/51849699705)).
- The `build` dependency before `lint` is only needed to circumvent eslint's `'import/no-unresolved'` error, which is already re-classified in other packages as a warning so that we don't need to build before linting.
- To avoid diving deeper into the created non-UTF-8 filename, we can just apply the ostrich algorithm.

   <img width="468" height="339" alt="image" src="https://github.com/user-attachments/assets/4af13271-fe3f-4695-a993-3e8bbd1d0f34" />
