### PR TITLE
Hlp/asset activation composer

### DIFF
--- a/examples/oft-hyperliquid/contracts/extensions/MyHyperLiquidComposer_FeeAbstraction.sol
+++ b/examples/oft-hyperliquid/contracts/extensions/MyHyperLiquidComposer_FeeAbstraction.sol
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.22;
+
+import { HyperLiquidComposer } from "@layerzerolabs/hyperliquid-composer/contracts/HyperLiquidComposer.sol";
+import { RecoverableComposer } from "@layerzerolabs/hyperliquid-composer/contracts/extensions/RecoverableComposer.sol";
+import { FeeToken } from "@layerzerolabs/hyperliquid-composer/contracts/extensions/FeeToken.sol";
+import { PreFundedFeeAbstraction } from "@layerzerolabs/hyperliquid-composer/contracts/extensions/PreFundedFeeAbstraction.sol";
+
+/// @dev Composer with PreFundedFeeAbstraction extension for NonFee tokens.
+///      Activation fees are charged from deposited assets using real-time spot prices.
+///      Fees are collected in the base asset and can be retrieved by the recovery address.
+///      Composer maintains a balance of the quote asset (FeeToken) which is used to pay for activation fees.
+///
+/// @dev Does NOT refund dust due to sharedDecimals truncation.
+/// @dev Disclaimer: If EVM supply exceeds bridge balance, tokens return to sender on HyperEVM.
+contract MyHyperLiquidComposer_FeeAbstraction is FeeToken, RecoverableComposer, PreFundedFeeAbstraction {
+    error InvalidRecoveryAddress();
+
+    /// @param _oft The OFT address
+    /// @param _hlIndexId The HyperLiquid core spot index
+    /// @param _assetDecimalDiff EVM - HyperLiquid decimal difference
+    /// @param _spotId The spot pair ID (e.g., 107 for HYPE/USDC)
+    /// @param _activationOverheadFee Overhead fee in cents on top of $1 base
+    /// @param _recoveryAddress Address for fee recovery
+    constructor(
+        address _oft,
+        uint64 _hlIndexId,
+        int8 _assetDecimalDiff,
+        uint64 _spotId,
+        uint16 _activationOverheadFee,
+        address _recoveryAddress
+    )
+        HyperLiquidComposer(_oft, _hlIndexId, _assetDecimalDiff)
+        RecoverableComposer(_recoveryAddress)
+        FeeToken()
+        PreFundedFeeAbstraction(_spotId, _activationOverheadFee)
+    {
+        if (_recoveryAddress == address(0)) revert InvalidRecoveryAddress();
+    }
+
+    /**
+     * @notice Override to use PreFundedFeeAbstraction implementation for activation fee calculation
+     */
+    function activationFee() public view virtual override(FeeToken, PreFundedFeeAbstraction) returns (uint64) {
+        return PreFundedFeeAbstraction.activationFee();
+    }
+
+    /**
+     * @notice Override to use PreFundedFeeAbstraction implementation for fee calculation with user activation
+     */
+    function _getFinalCoreAmount(
+        address _to,
+        uint64 _coreAmount
+    ) internal view virtual override(FeeToken, HyperLiquidComposer, PreFundedFeeAbstraction) returns (uint64) {
+        return PreFundedFeeAbstraction._getFinalCoreAmount(_to, _coreAmount);
+    }
+
+    /**
+     * @notice Override to use PreFundedFeeAbstraction implementation for fee tracking during transfers
+     */
+    function _transferERC20ToHyperCore(
+        address _to,
+        uint256 _amountLD
+    ) internal virtual override(HyperLiquidComposer, PreFundedFeeAbstraction) {
+        PreFundedFeeAbstraction._transferERC20ToHyperCore(_to, _amountLD);
+    }
+
+    /**
+     * @notice Override to use PreFundedFeeAbstraction implementation for retrieving USDC
+     */
+    function retrieveCoreUSDC(
+        uint64 _coreAmount,
+        address _to
+    ) public virtual override(RecoverableComposer, PreFundedFeeAbstraction) onlyRecoveryAddress {
+        PreFundedFeeAbstraction.retrieveCoreUSDC(_coreAmount, _to);
+    }
+}

--- a/examples/oft-hyperliquid/deploy/MyHyperLiquidComposer_FeeAbstraction.ts
+++ b/examples/oft-hyperliquid/deploy/MyHyperLiquidComposer_FeeAbstraction.ts
@@ -1,0 +1,143 @@
+import assert from 'assert'
+
+import { Wallet } from 'ethers'
+import { type DeployFunction } from 'hardhat-deploy/types'
+import inquirer from 'inquirer'
+
+import { CHAIN_IDS, getCoreSpotDeployment, useBigBlock, useSmallBlock } from '@layerzerolabs/hyperliquid-composer'
+
+const contractName_oft = 'MyOFT'
+const contractName_composer = 'MyHyperLiquidComposer_FeeAbstraction'
+
+const deploy: DeployFunction = async (hre) => {
+    const { coreSpotIndex } = await inquirer.prompt([
+        {
+            type: 'input',
+            name: 'coreSpotIndex',
+            message: 'Enter the core spot index from deployments that you would like to use',
+        },
+    ])
+
+    const { spotId } = await inquirer.prompt([
+        {
+            type: 'input',
+            name: 'spotId',
+            message: 'Enter the spot pair ID for price queries (e.g., 107 for HYPE/USDC)',
+        },
+    ])
+
+    const { activationOverheadFee } = await inquirer.prompt([
+        {
+            type: 'input',
+            name: 'activationOverheadFee',
+            message: 'Enter activation overhead fee in cents (e.g., 100 = $1.00 overhead on top of $1.00 base)',
+            default: '100',
+        },
+    ])
+
+    const { getNamedAccounts, deployments } = hre
+
+    const { deploy } = deployments
+    const { deployer, recoveryAddress } = await getNamedAccounts()
+    assert(deployer, 'Missing named deployer account')
+    assert(recoveryAddress, 'Missing recovery address. Please set RECOVERY_ADDRESS in .env file')
+
+    const networkName = hre.network.name
+    const privateKey = hre.network.config.accounts
+    assert(
+        privateKey,
+        `Can not find a private key associated with hre.network.config.accounts for the network ${networkName} in hardhat.config.ts`
+    )
+
+    // Get logger from hardhat flag --log-level
+    const loglevel = hre.hardhatArguments.verbose ? 'debug' : 'error'
+
+    const wallet = new Wallet(privateKey.toString())
+    const chainId = (await hre.ethers.provider.getNetwork()).chainId
+    const isHyperliquid = chainId === CHAIN_IDS.MAINNET || chainId === CHAIN_IDS.TESTNET
+    const isTestnet = chainId === CHAIN_IDS.TESTNET
+
+    console.log(`Network: ${networkName}`)
+    console.log(`Deployer: ${deployer}`)
+    console.log(`Recovery Address: ${recoveryAddress}`)
+    console.log(`Spot ID: ${spotId}`)
+    console.log(`Activation Overhead Fee: ${activationOverheadFee} cents`)
+
+    assert(isHyperliquid, 'The hyperliquid composer is only supported on hyperliquid networks')
+
+    // Validates and returns the native spot
+    const hip1Token = getCoreSpotDeployment(coreSpotIndex, isTestnet)
+
+    const { address: address_oft } = await hre.deployments.get(contractName_oft).catch(async () => {
+        console.log(`Deployment file for ${contractName_oft}.json in deployments/${networkName} not found`)
+        const { proceedWithOFTAddress } = await inquirer.prompt([
+            {
+                type: 'input',
+                name: 'proceedWithOFTAddress',
+                message: 'Do you have an OFT address that you would like to use? (y/n)',
+            },
+        ])
+        if (proceedWithOFTAddress) {
+            const { oftAddress } = await inquirer.prompt([
+                {
+                    type: 'input',
+                    name: 'oftAddress',
+                    message: 'Please enter the OFT you would like the composer to be associated with:',
+                },
+            ])
+
+            return oftAddress
+        } else {
+            throw new Error(`Needs ${contractName_oft} to be deployed before deploying MyHyperLiquidComposer`)
+        }
+    })
+
+    if (!hre.ethers.utils.isAddress(address_oft)) {
+        throw new Error(`Input address ${address_oft} is not a valid address`)
+    }
+
+    // Switch to hyperliquid big block if the contract is not deployed
+    const isDeployed_composer = await hre.deployments.getOrNull(contractName_composer)
+
+    if (!isDeployed_composer) {
+        console.log(`Switching to hyperliquid big block for the address ${deployer} to deploy ${contractName_composer}`)
+        const res = await useBigBlock(wallet, isTestnet, loglevel)
+        console.log(res)
+        console.log(`Deplying a contract uses big block which is mined at a transaction per minute.`)
+    }
+
+    // Deploy the OFT composer with FeeAbstraction extension
+    const { address: address_composer } = await deploy(contractName_composer, {
+        from: deployer,
+        args: [
+            address_oft, // OFT address
+            hip1Token.coreSpot.index, // Core index id
+            hip1Token.txData.weiDiff, // Asset decimal difference
+            parseInt(spotId), // Spot pair ID for price queries
+            parseInt(activationOverheadFee), // Activation overhead fee in cents
+            recoveryAddress, // Recovery address for fee management
+        ],
+        log: true,
+        skipIfAlreadyDeployed: false,
+    })
+
+    console.log(
+        `Deployed HyperliquidComposer with FeeAbstraction: ${contractName_composer}, network: ${hre.network.name}, address: ${address_composer}`
+    )
+    console.log(`  - Spot ID: ${spotId}`)
+    console.log(
+        `  - Overhead Fee: ${activationOverheadFee} cents (Total fee: $${(100 + parseInt(activationOverheadFee)) / 100})`
+    )
+    console.log(`  - Recovery Address: ${recoveryAddress}`)
+
+    // Set small block eitherway as we do not have a method to check which hyperliquidblock we are on
+    {
+        console.log(`Using small block with address ${deployer} for faster transactions`)
+        const res = await useSmallBlock(wallet, isTestnet, loglevel)
+        console.log(JSON.stringify(res, null, 2))
+    }
+}
+
+deploy.tags = [contractName_composer]
+
+export default deploy

--- a/packages/hyperliquid-composer/contracts/extensions/PreFundedFeeAbstraction.sol
+++ b/packages/hyperliquid-composer/contracts/extensions/PreFundedFeeAbstraction.sol
@@ -1,0 +1,222 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import { IERC20Metadata } from "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+
+import { HyperLiquidComposer } from "../HyperLiquidComposer.sol";
+import { HyperLiquidComposerCodec } from "../library/HyperLiquidComposerCodec.sol";
+import { FeeToken } from "../extensions/FeeToken.sol";
+import { RecoverableComposer } from "../extensions/RecoverableComposer.sol";
+import { IHyperAssetAmount } from "../interfaces/IHyperLiquidComposer.sol";
+
+import { IPreFundedFeeAbstraction, SpotInfo, TokenInfo } from "../interfaces/IPreFundedFeeAbstraction.sol";
+
+/**
+ * @title PreFunded Fee Abstraction
+ * @author LayerZero Labs (@shankars99)
+ * @notice Extension that eliminates the need for pre-funding composers with USDC by using deposited assets for activation fees
+ * @dev Instead of maintaining separate balances for activation, this extension deducts fees from user deposits in their native asset
+ * @dev The composer calculates USD-equivalent fee amounts using real-time HyperCore spot prices and asset conversion
+ * @dev Accumulated fees are tracked and can be retrieved by the recovery address for external liquidation
+ */
+abstract contract PreFundedFeeAbstraction is FeeToken, RecoverableComposer, IPreFundedFeeAbstraction {
+    using SafeERC20 for IERC20;
+
+    address internal constant SPOT_PX_PRECOMPILE_ADDRESS = 0x0000000000000000000000000000000000000808;
+    address internal constant SPOT_INFO_PRECOMPILE_ADDRESS = 0x000000000000000000000000000000000000080b;
+    address internal constant TOKEN_INFO_PRECOMPILE_ADDRESS = 0x000000000000000000000000000000000000080C;
+
+    /// @dev Hyperliquid protocol constant: spot prices use MAX_DECIMALS of 8
+    uint8 constant MAX_SPOT_PRICE_DECIMALS = 8;
+
+    /// @dev Hyperliquid protocol requires 1 quote token for activation
+    uint64 constant BASE_ACTIVATION_FEE_CENTS = 100;
+
+    uint8 constant DEFAULT_MIN_USDC_PRE_FUND_AMOUNT = 20;
+
+    /// @dev Total activation cost in quote token wei (base + overhead)
+    uint64 public immutable ACTIVATION_COST;
+
+    uint64 public immutable SPOT_ID;
+    uint64 public immutable QUOTE_ASSET_INDEX;
+
+    /// @dev Pre-calculated spot price decimals for gas efficiency: (8 - szDecimals)
+    uint8 public immutable SPOT_PRICE_DECIMALS;
+
+    /// @dev Activation fee are collected in the base asset and can be retrieved by recovery address
+    /// @dev Amount is denoted in HyperCore decimals
+    uint64 public accruedActivationFee;
+
+    /**
+     * @notice Constructor for the PreFundedFeeAbstraction extension
+     * @param _spotId The spot pair ID for the asset/quote pair (e.g., 107 for HYPE/USDC)
+     * @param _activationOverheadFee The activation overhead fee in cents on top of $1 base (e.g., 50 = 50 cents = $0.50 overhead)
+     */
+    constructor(uint64 _spotId, uint16 _activationOverheadFee) {
+        uint64[2] memory tokens = _spotInfo(_spotId).tokens;
+        uint64 assetIndex = tokens[0];
+        QUOTE_ASSET_INDEX = tokens[1];
+
+        /// @dev The spot ID is NOT the same as the core asset index
+        /// @dev Example: HYPE has core index 150 but HYPE/USDC has spot ID 107
+        if (assetIndex != ERC20_CORE_INDEX_ID) revert InvalidSpot();
+        SPOT_ID = _spotId;
+
+        TokenInfo memory baseAssetInfo = _tokenInfo(assetIndex);
+        TokenInfo memory quoteAssetInfo = _tokenInfo(QUOTE_ASSET_INDEX);
+
+        /// @dev Hyperliquid protocol uses (8 - szDecimals) for spot price decimal encoding
+        SPOT_PRICE_DECIMALS = MAX_SPOT_PRICE_DECIMALS - baseAssetInfo.szDecimals;
+
+        uint64 totalCentsAmount = BASE_ACTIVATION_FEE_CENTS + _activationOverheadFee;
+        ACTIVATION_COST = uint64((totalCentsAmount * (10 ** quoteAssetInfo.weiDecimals)) / 100);
+    }
+
+    /**
+     * @notice Deducts activation fee if user not activated, otherwise returns full amount
+     * @param _to Destination address on HyperCore
+     * @param _coreAmount Original core amount before fee deduction
+     * @return Final core amount after potential fee deduction
+     */
+    function _getFinalCoreAmount(
+        address _to,
+        uint64 _coreAmount
+    ) internal view virtual override(FeeToken, HyperLiquidComposer) returns (uint64) {
+        if (coreUserExists(_to).exists) return _coreAmount;
+
+        uint64 fee = activationFee();
+        if (_coreAmount <= fee) revert InsufficientCoreAmountForActivation();
+        return _coreAmount - fee;
+    }
+
+    /**
+     * @notice Override to track activation fees during transfers
+     * @param _to Destination address on HyperCore
+     * @param _amountLD Amount to transfer in LayerZero decimals
+     */
+    function _transferERC20ToHyperCore(address _to, uint256 _amountLD) internal virtual override {
+        IHyperAssetAmount memory amounts = quoteHyperCoreAmount(
+            ERC20_CORE_INDEX_ID,
+            ERC20_DECIMAL_DIFF,
+            ERC20_ASSET_BRIDGE,
+            _amountLD
+        );
+
+        if (amounts.evm != 0) {
+            uint64 originalAmount = amounts.core;
+            uint64 coreAmount = _getFinalCoreAmount(_to, originalAmount);
+
+            if (!coreUserExists(_to).exists) {
+                uint64 feeCollected = originalAmount - coreAmount;
+                accruedActivationFee += feeCollected;
+                emit FeeCollected(feeCollected);
+            }
+
+            IERC20(ERC20).safeTransfer(ERC20_ASSET_BRIDGE, amounts.evm);
+            _submitCoreWriterTransfer(_to, ERC20_CORE_INDEX_ID, coreAmount);
+        }
+    }
+
+    /**
+     * @notice Calculates activation fee in asset tokens using current spot price
+     * @return Activation fee amount in core asset decimals
+     */
+    function activationFee() public view virtual override returns (uint64) {
+        uint64 rawPrice = _spotPx();
+
+        return uint64((ACTIVATION_COST * (10 ** SPOT_PRICE_DECIMALS)) / rawPrice);
+    }
+
+    /**
+     * @notice Estimates USD value of accumulated fees using current spot price
+     * @return USD value in quote token terms
+     */
+    function getAccruedFeeUsdValue() public view returns (uint64) {
+        if (accruedActivationFee == 0) return 0;
+
+        uint64 rawPrice = _spotPx();
+        return uint64((rawPrice * accruedActivationFee) / (10 ** SPOT_PRICE_DECIMALS));
+    }
+
+    /**
+     * @notice Transfers accumulated fees to specified address for external liquidation
+     * @dev Permissioned call by the recovery address
+     * @param _coreAmount Amount to transfer in core decimals, or FULL_TRANSFER for all
+     * @param _to Destination address on HyperCore
+     */
+    function retrieveAccruedFees(uint64 _coreAmount, address _to) external onlyRecoveryAddress {
+        if (accruedActivationFee == 0) revert NoFeesToConvert();
+
+        uint64 transferAmount = _coreAmount == FULL_TRANSFER ? accruedActivationFee : _coreAmount;
+
+        if (transferAmount > accruedActivationFee) {
+            revert MaxRetrieveAmountExceeded(accruedActivationFee, transferAmount);
+        }
+
+        accruedActivationFee -= transferAmount;
+        _submitCoreWriterTransfer(_to, ERC20_CORE_INDEX_ID, transferAmount);
+
+        emit Retrieved(ERC20_CORE_INDEX_ID, transferAmount, _to);
+    }
+
+    function retrieveCoreUSDC(uint64 _coreAmount, address _to) public virtual override onlyRecoveryAddress {
+        uint64 maxTransferAmt = _getMaxTransferAmount(USDC_CORE_INDEX, _coreAmount);
+        uint64 minComposerBalance = MIN_USDC_PRE_FUND_AMOUNT();
+
+        if (maxTransferAmt > minComposerBalance) {
+            revert MaxRetrieveAmountExceeded(minComposerBalance, maxTransferAmt);
+        }
+
+        _submitCoreWriterTransfer(_to, USDC_CORE_INDEX, maxTransferAmt);
+        emit Retrieved(USDC_CORE_INDEX, maxTransferAmt, _to);
+    }
+
+    /**
+     * @notice Gets current spot price from HyperCore precompile
+     * @return Raw spot price with protocol-specific decimal encoding
+     */
+    function _spotPx() internal view returns (uint64) {
+        bool success;
+        bytes memory result;
+        (success, result) = SPOT_PX_PRECOMPILE_ADDRESS.staticcall(abi.encode(SPOT_ID));
+        require(success, "SpotPx precompile call failed");
+        return abi.decode(result, (uint64));
+    }
+
+    /**
+     * @notice Gets spot pair info from HyperCore precompile
+     * @param _spot Spot pair ID to query
+     * @return SpotInfo containing pair name and token indices
+     */
+    function _spotInfo(uint64 _spot) internal view returns (SpotInfo memory) {
+        bool success;
+        bytes memory result;
+        (success, result) = SPOT_INFO_PRECOMPILE_ADDRESS.staticcall(abi.encode(_spot));
+        require(success, "SpotInfo precompile call failed");
+        return abi.decode(result, (SpotInfo));
+    }
+
+    /**
+     * @notice Gets token metadata from HyperCore precompile
+     * @param _coreSpotIndex Core token index to query
+     * @return TokenInfo with token metadata and decimal configurations
+     */
+    function _tokenInfo(uint64 _coreSpotIndex) internal view returns (TokenInfo memory) {
+        bool success;
+        bytes memory result;
+        (success, result) = TOKEN_INFO_PRECOMPILE_ADDRESS.staticcall(abi.encode(_coreSpotIndex));
+        require(success, "TokenInfo precompile call failed");
+        return abi.decode(result, (TokenInfo));
+    }
+
+    /**
+     * @notice Returns the minimum activation cost threshold in USD terms
+     * @dev Can be overridden by implementing contracts to adjust minimum fee requirements
+     * @return The minimum USD amount required for activation fees
+     */
+    function MIN_USDC_PRE_FUND_AMOUNT() public pure virtual returns (uint8) {
+        return DEFAULT_MIN_USDC_PRE_FUND_AMOUNT;
+    }
+}

--- a/packages/hyperliquid-composer/contracts/extensions/RecoverableComposer.sol
+++ b/packages/hyperliquid-composer/contracts/extensions/RecoverableComposer.sol
@@ -81,7 +81,7 @@ abstract contract RecoverableComposer is HyperLiquidComposer, IRecoverableCompos
      * @param _coreAmount Amount of USDC tokens to retrieve in HyperCore decimals, or FULL_TRANSFER for all
      * @param _to Destination address to receive the retrieved USDC tokens
      */
-    function retrieveCoreUSDC(uint64 _coreAmount, address _to) public onlyRecoveryAddress {
+    function retrieveCoreUSDC(uint64 _coreAmount, address _to) public virtual onlyRecoveryAddress {
         uint64 maxTransferAmt = _getMaxTransferAmount(USDC_CORE_INDEX, _coreAmount);
 
         _submitCoreWriterTransfer(_to, USDC_CORE_INDEX, maxTransferAmt);

--- a/packages/hyperliquid-composer/contracts/interfaces/IPreFundedFeeAbstraction.sol
+++ b/packages/hyperliquid-composer/contracts/interfaces/IPreFundedFeeAbstraction.sol
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+struct SpotInfo {
+    string name;
+    uint64[2] tokens;
+}
+
+struct TokenInfo {
+    string name;
+    uint64[] spots;
+    uint64 deployerTradingFeeShare;
+    address deployer;
+    address evmContract;
+    uint8 szDecimals;
+    uint8 weiDecimals;
+    int8 evmExtraWeiDecimals;
+}
+
+interface IPreFundedFeeAbstraction {
+    error InvalidSpot();
+    error ActivationCostTooLow();
+    error ActivationFeeTooHigh();
+    error NoFeesToConvert();
+
+    event FeeCollected(uint256 amount);
+
+    /// Immutable variables
+    function SPOT_ID() external view returns (uint64);
+
+    function getAccruedFeeUsdValue() external view returns (uint64);
+    function retrieveAccruedFees(uint64 _coreAmount, address _to) external;
+}

--- a/packages/hyperliquid-composer/contracts/interfaces/IPreFundedFeeAbstraction.sol
+++ b/packages/hyperliquid-composer/contracts/interfaces/IPreFundedFeeAbstraction.sol
@@ -30,4 +30,5 @@ interface IPreFundedFeeAbstraction {
 
     function getAccruedFeeUsdValue() external view returns (uint64);
     function retrieveAccruedFees(uint64 _coreAmount, address _to) external;
+    function drainFeeToken(address _to) external;
 }


### PR DESCRIPTION
Composer that activates addresses on hypercore by collecting a Fee in the asset token that is sent across (ex: USDe, ENA, PENGU) for tokens that are NOT FeeTokens (USDT0).

The composer has a pre-funding of X USDT/USDC which it spends to activate accounts. There is a minimum balance, and if we ever go under it then we simply revert and give the user tokens on HyperEVM.

The AssetTokens that have been collected as the Fee can be withdrawn by the RecoveryAddress. 

Deployments (not latest but functionally equivalent except for reverting) 

Composer deployed:
https://hyperevmscan.io/address/0x745D6DE83F4E09A8677723645f9C959d3cf9A107#code 
With overhead fee of 1.5 USD-stable ($2.5 per activation - $1 to hyperliquid + $1.5 fee)

https://layerzeroscan.com/tx/0xb477c34b42b0b9ae737bb09233b2943706d7cd3e8fb4b494af452007b75a06a3

Composer (evm -> core)
https://app.hyperliquid.xyz/explorer/tx/0xf45b426eba070c6af5d4042d09970b0101005a54550a2b3d9823edc1790ae655

Composer -> User (core -> core)
https://app.hyperliquid.xyz/explorer/tx/0xa72eb909d3984ee6a8a8042d09970b010200d0ef6e9b6db84af7645c929c28d1

Pre lzCompose composer balances:
```
npx @layerzerolabs/hyperliquid-composer get-core-balances -u 0x745D6DE83F4E09A8677723645f9C959d3cf9A107 -n mainnet
info:    [sdk-hyperliquid-composer] 
Balances:
┌──────┬───────┬─────────────┬──────┬───────────┐
│ Coin │ Token │       Total │ Hold │ Entry Ntl │
├──────┼───────┼─────────────┼──────┼───────────┤
│ USDC │     0 │ 10.00000000 │  0.0 │       0.0 │
└──────┴───────┴─────────────┴──────┴───────────┘

Showing 2 balances (2 non-zero out of 2 total)
```

Post lzCompose composer balances
```
$ npx @layerzerolabs/hyperliquid-composer get-core-balances -u 0x745D6DE83F4E09A8677723645f9C959d3cf9A107 -n mainnet   
info:    [sdk-hyperliquid-composer] 
Balances:
┌──────┬───────┬────────────┬──────┬───────────┐
│ Coin │ Token │      Total │ Hold │ Entry Ntl │
├──────┼───────┼────────────┼──────┼───────────┤
│ USDC │     0 │ 9.00000001 │  0.0 │       0.0 │
├──────┼───────┼────────────┼──────┼───────────┤
│ USDE │   235 │   2.500025 │  0.0 │       2.5 │
└──────┴───────┴────────────┴──────┴───────────┘

Showing 2 balances (2 non-zero out of 2 total)
```

Pre lzCompose account activation:
```
npx @layerzerolabs/hyperliquid-composer is-account-activated -u 0x3fBEE4E0546d8AaaF7c8B34D069064CdccDc8DBc -n mainnet
info:    [sdk-hyperliquid-composer] Account activated: false
```

Post lzCompose account activation:
```
$ npx @layerzerolabs/hyperliquid-composer is-account-activated -u 0x3fBEE4E0546d8AaaF7c8B34D069064CdccDc8DBc -n mainnet
info:    [sdk-hyperliquid-composer] Account activated: true
```

Post lzCompose balances of user:
```
npx @layerzerolabs/hyperliquid-composer get-core-balances -u 0x3fBEE4E0546d8AaaF7c8B34D069064CdccDc8DBc -n mainnet
info:    [sdk-hyperliquid-composer] 
Balances:
┌──────┬───────┬──────────┬──────┬───────────┐
│ Coin │ Token │    Total │ Hold │ Entry Ntl │
├──────┼───────┼──────────┼──────┼───────────┤
│ USDE │   235 │ 0.499975 │  0.0 │   0.49997 │
└──────┴───────┴──────────┴──────┴───────────┘
```