### PR TITLE
DEVREL-885: solve running hardhat script issue

### DIFF
--- a/examples/oapp-solana/hardhat.config.ts
+++ b/examples/oapp-solana/hardhat.config.ts
@@ -1,10 +1,3 @@
-// Force ts-node to use CommonJS mode
-// This must be set before any imports
-process.env.TS_NODE_COMPILER_OPTIONS = JSON.stringify({
-    module: 'commonjs',
-    esModuleInterop: true,
-})
-
 // Get the environment configuration from .env file
 //
 // To make use of automatic environment setup:

--- a/examples/oft-solana/hardhat.config.ts
+++ b/examples/oft-solana/hardhat.config.ts
@@ -1,10 +1,3 @@
-// Force ts-node to use CommonJS mode
-// This must be set before any imports
-process.env.TS_NODE_COMPILER_OPTIONS = JSON.stringify({
-    module: 'commonjs',
-    esModuleInterop: true,
-})
-
 // Get the environment configuration from .env file
 //
 // To make use of automatic environment setup:


### PR DESCRIPTION
Certain partners run into:

```
Error HH19: Your project is an ESM project (you have "type": "module" set in your package.json) but your Hardhat config file uses the .js extension.
```