### PR TITLE
build: fix foundryup line

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -422,7 +422,7 @@ ENV CARGO_BUILD_JOBS=$CARGO_BUILD_JOBS
 ENV PATH="/root/.foundry/bin:$PATH"
 RUN curl -L https://foundry.paradigm.xyz | bash && \
     foundryup -i ${FOUNDRY_VERSION} && \
-    foundryup -u ${FOUNDRY_VERSION}
+    foundryup -u v${FOUNDRY_VERSION}
 
 # Install SVM and Solidity compiler in single layer
 RUN cargo +${RUST_TOOLCHAIN_VERSION_ANCHOR} install svm-rs@${SVM_RS_VERSION} && \


### PR DESCRIPTION
## Diagnosis

````
foundryup -u 1.4.4.
````

results in `version 1.4.4 not installed`

refer to the failing run of build base image on main: https://github.com/LayerZero-Labs/devtools/actions/runs/19776463219/job/56669775441#step:3:4296

turns out, 

we need to do

```
foundryup -u v1.4.4.
```

that `v` is important.

basically, `foundryup -u` just looks for the folder under FOUNDRY_DIR named exactly what you pass it
and if we installed 1.4.4. the directory would be `FOUNDRY_DIR/versions/v1.4.4`
so doing only `foundryup -u 1.4.4.` would mean it looks for `FOUNDRY_DIR/versions/1.4.4` which does not exist

## Proof of Successful Build Image Run

https://github.com/LayerZero-Labs/devtools/actions/runs/19777418103

## Proof of successful CI with new image

https://github.com/LayerZero-Labs/devtools/pull/1856

