### PR TITLE
feat: codeql workflow for ts and rust

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -2,7 +2,7 @@
 #  / / \ \ / / \ \ / / \ \ / / \ \ / / \ \ / / \ \ / / \ \ / / \ / / \ \ / / \ \ / / \
 # `-'   `-`-'   `-`-'   `-`-'   `-`-'   `-`-'   `-`-'   `-'   `-`-'   `-`-'   `-`-'
 #
-#                       CodeQL Security Analysis
+#                       CodeQL
 #
 #  This workflow replaces the GitHub CodeQL extension to support fork PRs.
 #  The extension doesn't trigger on fork PRs due to security restrictions.
@@ -11,7 +11,7 @@
 #   .-.-.   .-.-.   .-.-.   .-.-.   .-.-.   .-.-.   .-.-.   .-.-  .-.-.   .-.-.   .-.-
 #  / / \ \ / / \ \ / / \ \ / / \ \ / / \ \ / / \ \ / / \ \ / / \ / / \ \ / / \ \ / / \
 # `-'   `-`-'   `-`-'   `-`-'   `-`-'   `-`-'   `-`-'   `-`-'   `-'   `-`-'   `-`-'
-name: CodeQL Security Analysis
+name: CodeQL
 
 on:
   push:


### PR DESCRIPTION
CodeQL extension does not run on fork prs into devtools. This workflow yaml should effectively replace the extension.

Also took the liberty to add in:
1. `Dockerfile` scanning
2. `Shell script` scanning 

ontop of `codeql`'s `js`-`ts` and `rust`

It also runs weekly scans on `main` 