### PR TITLE
Feat/add onft721msgcodec new decode functions

### DIFF
--- a/.changeset/swift-cooks-serve.md
+++ b/.changeset/swift-cooks-serve.md
@@ -2,4 +2,4 @@
 "@layerzerolabs/onft-evm": patch
 ---
 
-Fixed a bug in ONFT721MsgCodec. It was ignoring the SENDER offset when decoding composed messages. Added a SENDER_OFFSET variable and replaced the old TOKEN_ID_OFFSET with it for composed messages decoding.
+The ONFT721MsgCodec library composeMsg function was ignoring the sender offset when decoding composed messages. Added a new SENDER_OFFSET constant variable and 2 new helper functions composeMsgFrom and composeMsgPayload to decode every member of the composed message separately and keep backwards compatibility.

--- a/packages/onft-evm/contracts/onft721/libs/ONFT721MsgCodec.sol
+++ b/packages/onft-evm/contracts/onft721/libs/ONFT721MsgCodec.sol
@@ -72,13 +72,13 @@ library ONFT721MsgCodec {
      * @return The sender address of the composed message in bytes32 format.
      */
     function composeMsgFrom(bytes calldata _msg) internal pure returns (bytes32) {
-        return _msg[TOKEN_ID_OFFSET:SENDER_OFFSET];
+        return bytes32(_msg[TOKEN_ID_OFFSET:SENDER_OFFSET]);
     }
 
     /**
      * @dev Decodes the payload from the composed message.
      * @param _msg The message.
-     * @return The composed message.
+     * @return The composed message payload.
      */
     function composeMsgPayload(bytes calldata _msg) internal pure returns (bytes memory) {
         return _msg[SENDER_OFFSET:];


### PR DESCRIPTION
The ONFT721MsgCodec library composeMsg function was ignoring the sender offset when decoding composed messages. Added a new SENDER_OFFSET constant variable and 2 new helper functions composeMsgFrom and composeMsgPayload to decode every member of the composed message separately and keep backwards compatibility.

it will help implementations like that
<img width="1062" height="376" alt="Screenshot from 2025-12-14 16-56-31" src="https://github.com/user-attachments/assets/f19b307c-789b-402a-9607-6a0d3e3b9b6a" />


Related with #1879 