### PR TITLE
fix: exports supports esm

### DIFF
--- a/packages/oapp-alt-evm/package.json
+++ b/packages/oapp-alt-evm/package.json
@@ -22,7 +22,8 @@
     "./artifacts/*.json": {
       "require": "./artifacts/*.json",
       "imports": "./artifacts/*.json"
-    }
+    },
+    "./contracts/*.sol": "./contracts/*.sol"
   },
   "files": [
     "artifacts/**/*",

--- a/packages/oapp-evm-upgradeable/package.json
+++ b/packages/oapp-evm-upgradeable/package.json
@@ -21,7 +21,8 @@
     "./artifacts/*.json": {
       "require": "./artifacts/*.json",
       "imports": "./artifacts/*.json"
-    }
+    },
+    "./contracts/*.sol": "./contracts/*.sol"
   },
   "files": [
     "artifacts/**/*",

--- a/packages/oapp-evm/package.json
+++ b/packages/oapp-evm/package.json
@@ -20,7 +20,8 @@
     "./artifacts/*.json": {
       "require": "./artifacts/*.json",
       "imports": "./artifacts/*.json"
-    }
+    },
+    "./contracts/*.sol": "./contracts/*.sol"
   },
   "files": [
     "artifacts/**/*",

--- a/packages/oft-alt-evm/package.json
+++ b/packages/oft-alt-evm/package.json
@@ -22,7 +22,8 @@
     "./artifacts/*.json": {
       "require": "./artifacts/*.json",
       "imports": "./artifacts/*.json"
-    }
+    },
+    "./contracts/*.sol": "./contracts/*.sol"
   },
   "files": [
     "artifacts/**/*",

--- a/packages/oft-evm-upgradeable/package.json
+++ b/packages/oft-evm-upgradeable/package.json
@@ -22,7 +22,8 @@
     "./artifacts/*.json": {
       "require": "./artifacts/*.json",
       "imports": "./artifacts/*.json"
-    }
+    },
+    "./contracts/*.sol": "./contracts/*.sol"
   },
   "files": [
     "artifacts/Fee.sol/Fee.json",

--- a/packages/oft-evm/package.json
+++ b/packages/oft-evm/package.json
@@ -22,7 +22,8 @@
     "./artifacts/*.json": {
       "require": "./artifacts/*.json",
       "imports": "./artifacts/*.json"
-    }
+    },
+    "./contracts/*.sol": "./contracts/*.sol"
   },
   "files": [
     "artifacts/Fee.sol/Fee.json",

--- a/packages/onft-evm/package.json
+++ b/packages/onft-evm/package.json
@@ -21,7 +21,8 @@
     "./artifacts/*.json": {
       "require": "./artifacts/*.json",
       "imports": "./artifacts/*.json"
-    }
+    },
+    "./contracts/*.sol": "./contracts/*.sol"
   },
   "files": [
     "artifacts/IONFT721.sol/IONFT721.json",


### PR DESCRIPTION
add support for evm packages.
Fix hardhat v3 The file "contracts/oapp/interfaces/IOAppCore.sol" is not exported by the package.