### PR TITLE
remove call to getInitiaDeployerAddress

### DIFF
--- a/packages/devtools-move/tasks/move/utils/config.ts
+++ b/packages/devtools-move/tasks/move/utils/config.ts
@@ -163,8 +163,7 @@ export async function getNamedAddresses(
     if (chain === 'movement' || chain === 'aptos') {
         named_addresses = `${moveTomlAdminName.replace('_admin', '')}=${oAppOwner},${moveTomlAdminName}=${oAppOwner}`
     } else if (chain === 'initia') {
-        const oAppDeployer = await getInitiaDeployerAddress(oAppOwner)
-        named_addresses = `${moveTomlAdminName.replace('_admin', '')}=${oAppDeployer},${moveTomlAdminName}=${oAppOwner}`
+        named_addresses = `${moveTomlAdminName.replace('_admin', '')}=${oAppOwner},${moveTomlAdminName}=${oAppOwner}`
     }
     const deploymentAddresses = await getDeploymentAddresses(chain, networkType)
     const allAddresses = named_addresses + ',' + deploymentAddresses


### PR DESCRIPTION
## Problem

The `initia-version-bump-standalone` branch added TS-side address derivation (`getInitiaDeployerAddress`) to compute the object address before `initiad` deploys. This was believed to be required because `initiad` needs named addresses at compile time.

However, **`initiad` already handles address derivation internally** during `publish-object`. The TS derivation is unnecessary and adds complexity (sequence number lookups, deploy counter queries, SHA3-256 hashing).

## Changes

- Remove `getInitiaDeployerAddress()` call from `getNamedAddresses()` for the Initia branch
  - Initia now uses the same `oAppOwner` for both the module address and admin, matching Movement/Aptos behavior
  - `initiad publish-object` derives the object address internally and substitutes it at deploy time

### What's NOT removed

The helper functions themselves (`getInitiaDeployerAddress`, `getInitiaBech32`, `getInitiaSequenceNumber`, `getInitiaDeployCount`) and their tests are intentionally kept. They are not harmful — just no longer called during deploy — and may be useful later (e.g. for pre-deploy address prediction or tooling that needs to know the object address before publishing).

## How to validate

### Prerequisites
- `initiad` CLI >= 1.3.1
- Initia testnet account with INIT tokens
- `.env` configured with `INITIA_KEY_NAME`, `INITIA_RPC_URL`, `INITIA_CHAIN_ID`, `INITIA_ACCOUNT_ADDRESS`

### Steps

1. **Clean deployment state**
   ```bash
   cd examples/oft-initia
   rm -rf deployments/initia-testnet
   ```

2. **Build the package**
   ```bash
   pnpm build --filter=@layerzerolabs/devtools-move
   ```

3. **Verify the built output does NOT contain `getInitiaDeployerAddress` in the Initia branch of `getNamedAddresses`**
   ```bash
   grep -A8 "getNamedAddresses" packages/devtools-move/dist/index.js | head -12
   ```
   The Initia branch should look identical to the Movement/Aptos branch:
   ```js
   } else if (chain2 === "initia") {
     named_addresses = `${moveTomlAdminName.replace("_admin", "")}=${oAppOwner},${moveTomlAdminName}=${oAppOwner}`;
   }
   ```

4. **Deploy**
   ```bash
   pnpm run lz:sdk:move:deploy \
     --oapp-config move.layerzero.config.ts \
     --move-deploy-script deploy-move/OFTInitParams.ts \
     --address-name oft \
     --oapp-type oft
   ```

5. **Confirm deployment succeeds** - `initiad` will compile, derive the object address, and publish. The output should show:
   ```
   Publishing package at object address 0x<DERIVED_ADDRESS>
   ...
   ✅ Deployment successful ✅
   ```

### What was tested

On `initia-no-ts-derivation` branch (child of `initia-version-bump-standalone`), with the TS derivation removed:

- Deployed successfully to Initia testnet at [0xDEE11D452BE32192D82CF25380D7753CF62B5C582ACAD71F5404B9A5E522C152](https://scan.testnet.initia.xyz/initiation-2/accounts/0xDEE11D452BE32192D82CF25380D7753CF62B5C582ACAD71F5404B9A5E522C152)
- Deploy TX: [08EBA63B018E594D8BC2E062239E5ABF90FB552A5A71555E949A5CB6D71026B8](https://scan.testnet.initia.xyz/initiation-2/txs/08EBA63B018E594D8BC2E062239E5ABF90FB552A5A71555E949A5CB6D71026B8)

