### PR TITLE
fix(ovault-evm): override _sendLocal in VaultComposerSyncNative to deliver native ETH

### DIFF
--- a/packages/ovault-evm/contracts/VaultComposerSyncNative.sol
+++ b/packages/ovault-evm/contracts/VaultComposerSyncNative.sol
@@ -86,6 +86,31 @@ contract VaultComposerSyncNative is VaultComposerSync, IVaultComposerSyncNative 
     }
 
     /**
+     * @dev Unwrap WETH and transfer native ETH directly to recipient on the same chain
+     * @dev Overrides base _sendLocal which would incorrectly transfer WETH (ERC20) instead of native ETH
+     * @dev The base VaultComposerSync._sendLocal does `IERC20(ASSET_ERC20).safeTransfer(recipient, amount)`
+     *      which transfers WETH. For the native variant, the vault redeems WETH but the recipient
+     *      expects native ETH, so we must call WETH.withdraw() first.
+     * @param _oft The OFT contract address to determine asset vs share path
+     * @param _sendParam The parameters for the send operation
+     */
+    function _sendLocal(
+        address _oft,
+        SendParam memory _sendParam,
+        address _refundAddress,
+        uint256 _msgValue
+    ) internal override virtual {
+        if (_oft == ASSET_OFT) {
+            /// @dev Vault redeems WETH; unwrap to native ETH before delivering to recipient
+            IWETH(ASSET_ERC20).withdraw(_sendParam.amountLD);
+            (bool success, ) = payable(address(uint160(uint256(_sendParam.to)))).call{ value: _sendParam.amountLD }("");
+            if (!success) revert NativeTransferFailed();
+        } else {
+            super._sendLocal(_oft, _sendParam, _refundAddress, _msgValue);
+        }
+    }
+
+    /**
      * @dev Unwrap WETH when sending to Stargate PoolNative and send via OFT
      * @dev Overriden to unwrap WETH when sending to Stargate PoolNative
      * @param _oft The OFT contract address to use for sending

--- a/packages/ovault-evm/contracts/interfaces/IVaultComposerSyncNative.sol
+++ b/packages/ovault-evm/contracts/interfaces/IVaultComposerSyncNative.sol
@@ -7,6 +7,7 @@ interface IVaultComposerSyncNative {
     error AssetOFTTokenNotNative(); // 0xd61c4b4a
     error AmountExceedsMsgValue(); // 0x0f971d59
     error ETHTransferNotFromAsset(); // 0x02cadbeb
+    error NativeTransferFailed(); // 0x26b2aba5
 
     /**
      * @notice Deposits Native token (ETH) from the caller into the vault and sends them to the recipient


### PR DESCRIPTION
## Problem

`VaultComposerSyncNative` correctly overrides `_sendRemote` to unwrap WETH → ETH before a cross-chain send via Stargate PoolNative. However, it was missing the same override for `_sendLocal` (same-chain delivery, `dstEid == VAULT_EID`).

The base `VaultComposerSync._sendLocal` does:
```solidity
address erc20 = _oft == ASSET_OFT ? ASSET_ERC20 : SHARE_ERC20;
IERC20(erc20).safeTransfer(recipient, amount); // transfers WETH, not ETH
```

This caused the `lzCompose` redeem path (e.g. Katana vbWETH → Ethereum native ETH) to deliver **WETH** instead of **native ETH** to the recipient when `dstEid == VAULT_EID`.

Confirmed via Tenderly trace on mainnet tx `0x634177bc2e23536080ca93ae73f4e626a3bd84ce912b314b62aa524b8b08b645`:
```
_sendLocal(_oft=ASSET_OFT, dstEid=30101)
  → safeTransfer(WETH, recipient, 1693000000000000)  ← wrong, should be native ETH
```

## Fix

Override `_sendLocal` in `VaultComposerSyncNative` to call `WETH.withdraw()` then transfer native ETH for the `ASSET_OFT` path. Share-path local sends (`_oft == SHARE_OFT`) fall through to `super._sendLocal` unchanged.

The `receive()` function already permits ETH from `ASSET_ERC20` (WETH), so the `withdraw()` call is handled correctly.

## Test plan

- [ ] Unit test: redeem vbWETH shares with `dstEid == VAULT_EID` via `lzCompose`, verify recipient receives native ETH not WETH
- [ ] Confirm `_sendLocal` share path (`_oft == SHARE_OFT`) still calls `super._sendLocal` unchanged
- [ ] Confirm `_sendRemote` path is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)