### PR TITLE
fix(hyperliquid-composer): validate evmExtraWeiDecimals before requestEvmContract

### DIFF
--- a/packages/hyperliquid-composer/src/commands/link-evm-core.ts
+++ b/packages/hyperliquid-composer/src/commands/link-evm-core.ts
@@ -54,34 +54,39 @@ export async function requestEvmContract(args: RequestEvmContractArgs): Promise<
     logger.verbose(`txData: \n ${JSON.stringify(txData, null, 2)}`)
 
     const rpcUrl = isTestnet ? RPC_URLS.TESTNET : RPC_URLS.MAINNET
-    const provider = new ethers.providers.JsonRpcProvider({ url: rpcUrl, skipFetchSetup: true })
-    const tokenAbi = await getERC20abi()
-    const tokenContract = new ethers.Contract(tokenAddress, tokenAbi, provider)
-    const onChainDecimals: number = await tokenContract.decimals()
-    const weiDecimals = coreSpotDeployment.coreSpot.weiDecimals
-    const expectedWeiDiff = onChainDecimals - weiDecimals
+    try {
+        const provider = new ethers.providers.JsonRpcProvider({ url: rpcUrl, skipFetchSetup: true })
+        const tokenAbi = await getERC20abi()
+        const tokenContract = new ethers.Contract(tokenAddress, tokenAbi, provider)
+        const onChainDecimals = Number(await tokenContract.decimals())
+        const weiDecimals = coreSpotDeployment.coreSpot.weiDecimals
+        const expectedWeiDiff = onChainDecimals - weiDecimals
 
-    if (txData.weiDiff !== expectedWeiDiff) {
-        logger.warn(`WARNING: txData.weiDiff (${txData.weiDiff}) does not match on-chain calculation`)
-        logger.warn(`  ERC20 decimals (on-chain): ${onChainDecimals}`)
-        logger.warn(`  HyperCore weiDecimals: ${weiDecimals}`)
-        logger.warn(`  Expected evmExtraWeiDecimals: ${expectedWeiDiff}`)
-        logger.warn(`  Stored evmExtraWeiDecimals:   ${txData.weiDiff}`)
+        if (txData.weiDiff !== expectedWeiDiff) {
+            logger.warn(`WARNING: txData.weiDiff (${txData.weiDiff}) does not match on-chain calculation`)
+            logger.warn(`  ERC20 decimals (on-chain): ${onChainDecimals}`)
+            logger.warn(`  HyperCore weiDecimals: ${weiDecimals}`)
+            logger.warn(`  Expected evmExtraWeiDecimals: ${expectedWeiDiff}`)
+            logger.warn(`  Stored evmExtraWeiDecimals:   ${txData.weiDiff}`)
 
-        const { useCorrectValue } = await inquirer.prompt([
-            {
-                type: 'confirm',
-                name: 'useCorrectValue',
-                message: `Use on-chain derived value (${expectedWeiDiff}) instead of stored value (${txData.weiDiff})?`,
-                default: true,
-            },
-        ])
+            const { useCorrectValue } = await inquirer.prompt([
+                {
+                    type: 'confirm',
+                    name: 'useCorrectValue',
+                    message: `Use on-chain derived value (${expectedWeiDiff}) instead of stored value (${txData.weiDiff})?`,
+                    default: true,
+                },
+            ])
 
-        if (useCorrectValue) {
-            txData.weiDiff = expectedWeiDiff
-            writeNativeSpotConnected(hyperAssetIndex, isTestnet, txData.connected, txData.weiDiff, logger)
-            logger.info(`Updated weiDiff to ${expectedWeiDiff} in deployment file`)
+            if (useCorrectValue) {
+                txData.weiDiff = expectedWeiDiff
+                writeNativeSpotConnected(hyperAssetIndex, isTestnet, txData.connected, txData.weiDiff, logger)
+                logger.info(`Updated weiDiff to ${expectedWeiDiff} in deployment file`)
+            }
         }
+    } catch (error) {
+        logger.warn(`Failed to fetch on-chain decimals: ${error instanceof Error ? error.message : error}`)
+        logger.warn(`Proceeding with stored txData.weiDiff (${txData.weiDiff}) without on-chain validation`)
     }
 
     const hyperAssetIndexInt = parseInt(hyperAssetIndex)

--- a/packages/hyperliquid-composer/src/commands/link-evm-core.ts
+++ b/packages/hyperliquid-composer/src/commands/link-evm-core.ts
@@ -1,7 +1,12 @@
 import { createModuleLogger, setDefaultLogLevel } from '@layerzerolabs/io-devtools'
 import inquirer from 'inquirer'
 
-import { getCoreSpotDeployment, writeUpdatedCoreSpotDeployment } from '@/io/parser'
+import {
+    getCoreSpotDeployment,
+    getERC20abi,
+    writeNativeSpotConnected,
+    writeUpdatedCoreSpotDeployment,
+} from '@/io/parser'
 import { getHyperliquidSigner } from '@/signer'
 import { setRequestEvmContract, setFinalizeEvmContract } from '@/operations'
 import { LOGGER_MODULES } from '@/types/cli-constants'
@@ -48,13 +53,44 @@ export async function requestEvmContract(args: RequestEvmContractArgs): Promise<
 
     logger.verbose(`txData: \n ${JSON.stringify(txData, null, 2)}`)
 
+    const rpcUrl = isTestnet ? RPC_URLS.TESTNET : RPC_URLS.MAINNET
+    const provider = new ethers.providers.JsonRpcProvider({ url: rpcUrl, skipFetchSetup: true })
+    const tokenAbi = await getERC20abi()
+    const tokenContract = new ethers.Contract(tokenAddress, tokenAbi, provider)
+    const onChainDecimals: number = await tokenContract.decimals()
+    const weiDecimals = coreSpotDeployment.coreSpot.weiDecimals
+    const expectedWeiDiff = onChainDecimals - weiDecimals
+
+    if (txData.weiDiff !== expectedWeiDiff) {
+        logger.warn(`WARNING: txData.weiDiff (${txData.weiDiff}) does not match on-chain calculation`)
+        logger.warn(`  ERC20 decimals (on-chain): ${onChainDecimals}`)
+        logger.warn(`  HyperCore weiDecimals: ${weiDecimals}`)
+        logger.warn(`  Expected evmExtraWeiDecimals: ${expectedWeiDiff}`)
+        logger.warn(`  Stored evmExtraWeiDecimals:   ${txData.weiDiff}`)
+
+        const { useCorrectValue } = await inquirer.prompt([
+            {
+                type: 'confirm',
+                name: 'useCorrectValue',
+                message: `Use on-chain derived value (${expectedWeiDiff}) instead of stored value (${txData.weiDiff})?`,
+                default: true,
+            },
+        ])
+
+        if (useCorrectValue) {
+            txData.weiDiff = expectedWeiDiff
+            writeNativeSpotConnected(hyperAssetIndex, isTestnet, txData.connected, txData.weiDiff, logger)
+            logger.info(`Updated weiDiff to ${expectedWeiDiff} in deployment file`)
+        }
+    }
+
     const hyperAssetIndexInt = parseInt(hyperAssetIndex)
 
     const { executeTx } = await inquirer.prompt([
         {
             type: 'confirm',
             name: 'executeTx',
-            message: `Trying to populate a request to connect HyperCore-EVM ${hyperAssetIndex} to ${tokenAddress}. This should be sent by the Spot Deployer and before finalizeEvmContract is executed. Do you want to execute the transaction?`,
+            message: `Connect HyperCore-EVM ${hyperAssetIndex} to ${tokenAddress} with evmExtraWeiDecimals=${txData.weiDiff}. This value is IRREVERSIBLE after finalization. Continue?`,
             default: false,
         },
     ])

--- a/packages/hyperliquid-composer/src/io/parser.ts
+++ b/packages/hyperliquid-composer/src/io/parser.ts
@@ -78,9 +78,16 @@ export function writeUpdatedCoreSpotDeployment(
     const fullPath = getFullPath(index.toString(), isTestnet)
 
     const spot = getCoreSpotDeployment(index, isTestnet, logger)
+
+    if (txData.weiDiff == null) {
+        throw new Error(
+            'weiDiff is not set in txData. Run core-spot-deployment create first to calculate the correct value.'
+        )
+    }
+
     spot.coreSpot.evmContract = {
         address: tokenAddress,
-        evm_extra_wei_decimals: txData.weiDiff ?? 0,
+        evm_extra_wei_decimals: txData.weiDiff,
     }
     spot.coreSpot.fullName = tokenFullName
     spot.txData.txHash = txData.txHash


### PR DESCRIPTION

## Motivation

`request-evm-contract` reads `txData.weiDiff` from the local deployment JSON and submits it as `evmExtraWeiDecimals` **without any validation**. If the deployment file is stale, manually edited, or generated by an older CLI version, the wrong value gets submitted. Once `finalize-evm-contract` is called, this value is **permanently locked on-chain**.

This has already caused real-world damage: token index **1825** on Hyperliquid testnet was permanently locked with `evm_extra_wei_decimals=0` instead of the correct value `11` (`ERC20 decimals(18) - weiDecimals(7)`). The token had to be abandoned and redeployed.

Additionally, `writeUpdatedCoreSpotDeployment` silently falls back to `0` when `weiDiff` is `null`/`undefined`, masking configuration errors.

## Changes

### 1. On-chain cross-validation in `requestEvmContract` (`link-evm-core.ts`)

Before submitting, the CLI now:
- Fetches `decimals()` from the ERC20 contract on-chain
- Computes the expected value: `onChainDecimals - coreSpot.weiDecimals`
- If the stored `txData.weiDiff` does not match, warns the user with full details and prompts to use the on-chain derived value
- If accepted, persists the corrected value to the deployment JSON so `finalize-evm-contract` also uses it

### 2. Display `evmExtraWeiDecimals` in confirmation prompt (`link-evm-core.ts`)

The confirmation prompt now shows the exact `evmExtraWeiDecimals` value being submitted and warns that it becomes irreversible after finalization:

```
Connect HyperCore-EVM {index} to {address} with evmExtraWeiDecimals={value}. This value is IRREVERSIBLE after finalization. Continue?
```

### 3. Remove silent fallback to 0 (`parser.ts`)

`writeUpdatedCoreSpotDeployment` previously used `txData.weiDiff ?? 0`, silently writing `evm_extra_wei_decimals: 0` when `weiDiff` was missing. This is now replaced with an explicit error:

```
Error: weiDiff is not set in txData. Run core-spot-deployment create first to calculate the correct value.
```

## Files Changed

| File | Change |
|------|--------|
| `packages/hyperliquid-composer/src/commands/link-evm-core.ts` | On-chain validation, updated prompt, persist corrected value |
| `packages/hyperliquid-composer/src/io/parser.ts` | Replace `?? 0` fallback with explicit null-check error |
